### PR TITLE
client再接続後にデータを受信できなくなるバグの修正

### DIFF
--- a/src/client/client_ws.cc
+++ b/src/client/client_ws.cc
@@ -7,42 +7,38 @@ namespace WebCFace {
 
 void Client::messageThreadMain(std::shared_ptr<ClientData> data,
                                std::string host, int port) {
-    using namespace cinatra;
-    auto client = std::make_shared<coro_http_client>();
-    // on_ws_closeが完了する前にclientが消えているとセグフォするので、
-    // client_keep内にclientのshared_ptrをキープしておく
-    auto client_keep =
-        std::make_shared<std::shared_ptr<coro_http_client>>(client);
-    std::weak_ptr<ClientData> data_w = data;
-    auto connected_this = std::make_shared<std::atomic<bool>>(true);
+    while (!data->closing.load()) {
+        using namespace cinatra;
+        // 通信エラーで閉じる場合はdeleteするが、
+        // 自分で閉じる場合は裏で受信スレッドがまだうごいているのでdeleteするとセグフォする
+        auto client = new coro_http_client();
+        std::weak_ptr<ClientData> data_w = data;
+        auto connected_this = std::make_shared<std::atomic<bool>>(true);
 
-    client->on_ws_msg([data_w, connected_this, client_keep](resp_data rdata) {
-        auto data = data_w.lock();
-        if (rdata.net_err) {
+        client->on_ws_msg([data_w, connected_this](resp_data rdata) {
+            auto data = data_w.lock();
+            if (rdata.net_err) {
+                if (data) {
+                    data->logger_internal->error("recv error {}",
+                                                 rdata.net_err.message());
+                }
+                connected_this->store(false);
+            } else {
+                if (data) {
+                    data->logger_internal->trace("message received");
+                    data->recv_queue.push(std::string(rdata.resp_body));
+                    data->logger_internal->trace("message recv done");
+                }
+            }
+        });
+        client->on_ws_close([data_w, connected_this](auto &&) {
+            auto data = data_w.lock();
             if (data) {
-                data->logger_internal->error("recv error {}",
-                                             rdata.net_err.message());
+                data->logger_internal->debug("connection closed");
             }
             connected_this->store(false);
-            // client_keep->reset();
-        } else {
-            if (data) {
-                data->logger_internal->trace("message received");
-                data->recv_queue.push(std::string(rdata.resp_body));
-                data->logger_internal->trace("message recv done");
-            }
-        }
-    });
-    client->on_ws_close([data_w, connected_this, client_keep](auto &&) {
-        auto data = data_w.lock();
-        if (data) {
-            data->logger_internal->debug("connection closed");
-        }
-        connected_this->store(false);
-        // client_keep->reset();
-    });
+        });
 
-    while (!data->closing.load()) {
 
         connected_this->store(true);
         data->connected_.store(false);
@@ -50,7 +46,6 @@ void Client::messageThreadMain(std::shared_ptr<ClientData> data,
         data->logger_internal->trace("start connecting");
         bool ok = async_simple::coro::syncAwait(client->async_ws_connect(
             "ws://" + host + ":" + std::to_string(port)));
-        data->logger_internal->trace("finished connecting, status={}", ok);
         if (ok) {
             data->sync_init.store(false);
             data->connected_.store(true);
@@ -61,7 +56,6 @@ void Client::messageThreadMain(std::shared_ptr<ClientData> data,
                 auto msg =
                     data->message_queue.pop(std::chrono::milliseconds(10));
                 if (msg) {
-                    // this->send(*msg);
                     data->logger_internal->trace("sending message");
                     auto rdata = async_simple::coro::syncAwait(
                         client->async_send_ws(*msg, true, opcode::binary));
@@ -75,6 +69,12 @@ void Client::messageThreadMain(std::shared_ptr<ClientData> data,
 
             async_simple::coro::syncAwait(client->async_send_ws_close());
             data->logger_internal->trace("closing");
+
+            if (!connected_this->load()) {
+                delete client;
+            }
+        } else {
+            delete client;
         }
 
         std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/src/example/main.cc
+++ b/src/example/main.cc
@@ -12,7 +12,7 @@ double hello2(int a, double b, bool c, const std::string &d) {
     return a + b;
 }
 int main() {
-    WebCFace::logger_internal_level = spdlog::level::trace;
+    WebCFace::logger_internal_level = spdlog::level::debug;
 
     WebCFace::Client c("example_main");
     c.value("test") = 0;

--- a/src/example/main.cc
+++ b/src/example/main.cc
@@ -12,7 +12,7 @@ double hello2(int a, double b, bool c, const std::string &d) {
     return a + b;
 }
 int main() {
-    WebCFace::logger_internal_level = spdlog::level::debug;
+    WebCFace::logger_internal_level = spdlog::level::trace;
 
     WebCFace::Client c("example_main");
     c.value("test") = 0;

--- a/src/server/s_client_data.cc
+++ b/src/server/s_client_data.cc
@@ -1,5 +1,6 @@
 #include "s_client_data.h"
 #include "store.h"
+#include "websock.h"
 #include "../message/message.h"
 #include <webcface/common/def.h>
 #include <cinatra.hpp>
@@ -80,10 +81,16 @@ void ClientData::onRecv(const std::string &message) {
             this->last_ping_duration =
                 std::chrono::duration_cast<std::chrono::milliseconds>(
                     std::chrono::system_clock::now() - this->last_send_ping);
+            logger->debug("ping {} ms", this->last_ping_duration->count());
             break;
         }
         case MessageKind::ping_status_req: {
             this->ping_status_req = true;
+            logger->debug("ping_status_req");
+            if (ping_status != nullptr) {
+                this->pack(Message::PingStatus{{}, ping_status});
+                logger->trace("send ping_status");
+            }
             break;
         }
         case MessageKind::sync_init: {

--- a/src/server/websock.cc
+++ b/src/server/websock.cc
@@ -20,20 +20,22 @@ void pingThreadMain() {
         if (server_stop) {
             return;
         }
-        auto ping_status =
+        auto new_ping_status =
             std::make_shared<std::unordered_map<unsigned int, int>>();
         store.forEach([&](auto &cd) {
             if (cd.last_ping_duration) {
-                ping_status->emplace(cd.member_id,
-                                     cd.last_ping_duration->count());
+                new_ping_status->emplace(cd.member_id,
+                                         cd.last_ping_duration->count());
             }
         });
+        ping_status = new_ping_status;
         auto msg = Message::packSingle(Message::PingStatus{{}, ping_status});
         store.forEach([&](auto &cd) {
             cd.logger->trace("ping");
             cd.sendPing();
             if (cd.ping_status_req) {
                 cd.send(msg);
+                cd.logger->trace("send ping_status");
             }
         });
     }

--- a/src/server/websock.h
+++ b/src/server/websock.h
@@ -2,12 +2,16 @@
 #include <spdlog/common.h>
 #include <mutex>
 #include <condition_variable>
+#include <memory>
+#include <unordered_map>
 
 namespace WebCFace {
 namespace Server {
 inline bool server_stop;
 inline std::condition_variable server_ping_wait;
 inline std::mutex server_mtx;
+inline std::shared_ptr<std::unordered_map<unsigned int, int>> ping_status;
+
 void serverStop();
 void serverRun(int port, const spdlog::sink_ptr &sink,
                spdlog::level::level_enum level);


### PR DESCRIPTION
* server側でping関連のdebug,traceメッセージ追加
* ping_status_req時にping_statusを送信するようにした
* fix #13 
