### PR TITLE
Viewのメッセージのmapのキーをstringにした

### DIFF
--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -221,7 +221,7 @@ void Client::onRecv(const std::string &message) {
             }
             (*v_prev)->resize(r.length);
             for (const auto &d : *r.data_diff) {
-                (**v_prev)[d.first] = d.second;
+                (**v_prev)[std::stoi(d.first)] = d.second;
             }
             data->view_change_event.dispatch(FieldBase{member, field},
                                              Field{data, member, field});

--- a/src/message/message.h
+++ b/src/message/message.h
@@ -228,7 +228,7 @@ struct View : public MessageBase<MessageKind::view> {
                            MSGPACK_NVP("c", text_color),
                            MSGPACK_NVP("b", bg_color));
     };
-    std::shared_ptr<std::unordered_map<int, ViewComponent>> data_diff;
+    std::shared_ptr<std::unordered_map<std::string, ViewComponent>> data_diff;
     std::size_t length;
     View() = default;
     View(const std::string &field,
@@ -236,14 +236,15 @@ struct View : public MessageBase<MessageKind::view> {
              std::unordered_map<int, Common::ViewComponentBase>> &data_diff,
          std::size_t length)
         : field(field),
-          data_diff(std::make_shared<std::unordered_map<int, ViewComponent>>()),
+          data_diff(std::make_shared<
+                    std::unordered_map<std::string, ViewComponent>>()),
           length(length) {
         for (const auto &vc : *data_diff) {
-            this->data_diff->emplace(vc.first, vc.second);
+            this->data_diff->emplace(std::to_string(vc.first), vc.second);
         }
     }
     View(const std::string &field,
-         const std::shared_ptr<std::unordered_map<int, ViewComponent>>
+         const std::shared_ptr<std::unordered_map<std::string, ViewComponent>>
              &data_diff,
          std::size_t length)
         : field(field), data_diff(data_diff), length(length) {}
@@ -375,12 +376,13 @@ template <>
 struct Res<View> : public MessageBase<MessageKind::view + MessageKind::res> {
     unsigned int req_id;
     std::string sub_field;
-    std::shared_ptr<std::unordered_map<int, View::ViewComponent>> data_diff;
+    std::shared_ptr<std::unordered_map<std::string, View::ViewComponent>>
+        data_diff;
     std::size_t length;
     Res() = default;
     Res(unsigned int req_id, const std::string &sub_field,
-        const std::shared_ptr<std::unordered_map<int, View::ViewComponent>>
-            &data_diff,
+        const std::shared_ptr<
+            std::unordered_map<std::string, View::ViewComponent>> &data_diff,
         std::size_t length)
         : req_id(req_id), sub_field(sub_field), data_diff(data_diff),
           length(length) {}

--- a/src/server/s_client_data.cc
+++ b/src/server/s_client_data.cc
@@ -312,7 +312,7 @@ void ClientData::onRecv(const std::string &message) {
             }
             this->view[v.field].resize(v.length);
             for (const auto &d : *v.data_diff) {
-                this->view[v.field][d.first] = d.second;
+                this->view[v.field][std::stoi(d.first)] = d.second;
             }
             // このvalueをsubscribeしてるところに送り返す
             store.forEach([&](auto &cd) {
@@ -441,9 +441,10 @@ void ClientData::onRecv(const std::string &message) {
                     if (it.first == s.field ||
                         it.first.starts_with(s.field + ".")) {
                         auto diff = std::make_shared<std::unordered_map<
-                            int, WebCFace::Message::View::ViewComponent>>();
+                            std::string,
+                            WebCFace::Message::View::ViewComponent>>();
                         for (std::size_t i = 0; i < it.second.size(); i++) {
-                            diff->emplace(i, it.second[i]);
+                            diff->emplace(std::to_string(i), it.second[i]);
                         }
                         std::string sub_field;
                         if (it.first == s.field) {

--- a/src/test/client_test.cc
+++ b/src/test/client_test.cc
@@ -256,15 +256,15 @@ TEST_F(ClientTest, viewSend) {
             EXPECT_EQ(obj.field, "a");
             EXPECT_EQ(obj.length, 3);
             EXPECT_EQ(obj.data_diff->size(), 3);
-            EXPECT_EQ((*obj.data_diff)[0].type, ViewComponentType::text);
-            EXPECT_EQ((*obj.data_diff)[0].text, "a");
-            EXPECT_EQ((*obj.data_diff)[0].text_color, ViewColor::yellow);
-            EXPECT_EQ((*obj.data_diff)[0].bg_color, ViewColor::green);
-            EXPECT_EQ((*obj.data_diff)[1].type, ViewComponentType::new_line);
-            EXPECT_EQ((*obj.data_diff)[2].type, ViewComponentType::button);
-            EXPECT_EQ((*obj.data_diff)[2].text, "a");
-            EXPECT_EQ((*obj.data_diff)[2].on_click_member, "x");
-            EXPECT_EQ((*obj.data_diff)[2].on_click_field, "y");
+            EXPECT_EQ((*obj.data_diff)["0"].type, ViewComponentType::text);
+            EXPECT_EQ((*obj.data_diff)["0"].text, "a");
+            EXPECT_EQ((*obj.data_diff)["0"].text_color, ViewColor::yellow);
+            EXPECT_EQ((*obj.data_diff)["0"].bg_color, ViewColor::green);
+            EXPECT_EQ((*obj.data_diff)["1"].type, ViewComponentType::new_line);
+            EXPECT_EQ((*obj.data_diff)["2"].type, ViewComponentType::button);
+            EXPECT_EQ((*obj.data_diff)["2"].text, "a");
+            EXPECT_EQ((*obj.data_diff)["2"].on_click_member, "x");
+            EXPECT_EQ((*obj.data_diff)["2"].on_click_field, "y");
         },
         [&] { ADD_FAILURE() << "View recv error"; });
     dummy_s->recvClear();
@@ -308,14 +308,14 @@ TEST_F(ClientTest, viewReq) {
         [&] { ADD_FAILURE() << "View Req recv error"; });
 
     auto v =
-        std::make_shared<std::unordered_map<int, Message::View::ViewComponent>>(
-            std::unordered_map<int, Message::View::ViewComponent>{
-                {0, ViewComponents::text("a")
+        std::make_shared<std::unordered_map<std::string, Message::View::ViewComponent>>(
+            std::unordered_map<std::string, Message::View::ViewComponent>{
+                {"0", ViewComponents::text("a")
                         .textColor(ViewColor::yellow)
                         .bgColor(ViewColor::green)
                         .lockTmp(data_, "")},
-                {1, ViewComponents::newLine().lockTmp(data_, "")},
-                {2, ViewComponents::button("a", Func{Field{data_, "x", "y"}})
+                {"1", ViewComponents::newLine().lockTmp(data_, "")},
+                {"2", ViewComponents::button("a", Func{Field{data_, "x", "y"}})
                         .lockTmp(data_, "")},
             });
     dummy_s->send(Message::Res<Message::View>{1, "", v, 3});
@@ -337,9 +337,9 @@ TEST_F(ClientTest, viewReq) {
 
     // 差分だけ送る
     auto v2 =
-        std::make_shared<std::unordered_map<int, Message::View::ViewComponent>>(
-            std::unordered_map<int, Message::View::ViewComponent>{
-                {0, ViewComponents::text("b")
+        std::make_shared<std::unordered_map<std::string, Message::View::ViewComponent>>(
+            std::unordered_map<std::string, Message::View::ViewComponent>{
+                {"0", ViewComponents::text("b")
                         .textColor(ViewColor::red)
                         .bgColor(ViewColor::green)
                         .lockTmp(data_, "")},

--- a/src/test/client_test.cc
+++ b/src/test/client_test.cc
@@ -287,10 +287,10 @@ TEST_F(ClientTest, viewSend) {
             EXPECT_EQ(obj.field, "a");
             EXPECT_EQ(obj.length, 3);
             EXPECT_EQ(obj.data_diff->size(), 1);
-            EXPECT_EQ((*obj.data_diff)[0].type, ViewComponentType::text);
-            EXPECT_EQ((*obj.data_diff)[0].text, "b");
-            EXPECT_EQ((*obj.data_diff)[0].text_color, ViewColor::red);
-            EXPECT_EQ((*obj.data_diff)[0].bg_color, ViewColor::green);
+            EXPECT_EQ((*obj.data_diff)["0"].type, ViewComponentType::text);
+            EXPECT_EQ((*obj.data_diff)["0"].text, "b");
+            EXPECT_EQ((*obj.data_diff)["0"].text_color, ViewColor::red);
+            EXPECT_EQ((*obj.data_diff)["0"].bg_color, ViewColor::green);
         },
         [&] { ADD_FAILURE() << "View recv error"; });
 }

--- a/src/test/server_test.cc
+++ b/src/test/server_test.cc
@@ -112,7 +112,7 @@ TEST_F(ServerTest, entry) {
     dummy_c1->send(Message::View{
         "a",
         std::make_shared<
-            std::unordered_map<int, Message::View::ViewComponent>>(),
+            std::unordered_map<std::string, Message::View::ViewComponent>>(),
         0});
     dummy_c1->send(Message::FuncInfo{
         0, "a", ValType::none_,
@@ -176,7 +176,7 @@ TEST_F(ServerTest, entry) {
     dummy_c1->send(Message::View{
         "b",
         std::make_shared<
-            std::unordered_map<int, Message::View::ViewComponent>>(),
+            std::unordered_map<std::string, Message::View::ViewComponent>>(),
         0});
     wait();
     dummy_c2->recv<Message::Entry<Message::View>>(
@@ -281,13 +281,15 @@ TEST_F(ServerTest, view) {
     dummy_c1->send(Message::Sync{});
     dummy_c1->send(Message::View{
         "a",
-        std::make_shared<std::unordered_map<int, Message::View::ViewComponent>>(
-            std::unordered_map<int, Message::View::ViewComponent>{
-                {0, ViewComponents::text("a").lockTmp(data_, "")},
-                {1, ViewComponents::newLine().lockTmp(data_, "")},
-                {2, ViewComponents::button(
-                        "f", Func{Field{std::weak_ptr<ClientData>(), "p", "q"}})
-                        .lockTmp(data_, "")}}),
+        std::make_shared<
+            std::unordered_map<std::string, Message::View::ViewComponent>>(
+            std::unordered_map<std::string, Message::View::ViewComponent>{
+                {"0", ViewComponents::text("a").lockTmp(data_, "")},
+                {"1", ViewComponents::newLine().lockTmp(data_, "")},
+                {"2",
+                 ViewComponents::button(
+                     "f", Func{Field{std::weak_ptr<ClientData>(), "p", "q"}})
+                     .lockTmp(data_, "")}}),
         3});
     wait();
     dummy_c2->send(Message::SyncInit{{}, "", 0, "", "", ""});
@@ -311,9 +313,10 @@ TEST_F(ServerTest, view) {
     dummy_c1->send(Message::Sync{});
     dummy_c1->send(Message::View{
         "a",
-        std::make_shared<std::unordered_map<int, Message::View::ViewComponent>>(
-            std::unordered_map<int, Message::View::ViewComponent>{
-                {0, ViewComponents::text("b").lockTmp(data_, "")},
+        std::make_shared<
+            std::unordered_map<std::string, Message::View::ViewComponent>>(
+            std::unordered_map<std::string, Message::View::ViewComponent>{
+                {"0", ViewComponents::text("b").lockTmp(data_, "")},
             }),
         3});
     wait();

--- a/src/test/server_test.cc
+++ b/src/test/server_test.cc
@@ -303,7 +303,7 @@ TEST_F(ServerTest, view) {
             EXPECT_EQ(obj.req_id, 1);
             EXPECT_EQ(obj.sub_field, "");
             EXPECT_EQ(obj.data_diff->size(), 3);
-            EXPECT_EQ(obj.data_diff->at(0).type, ViewComponentType::text);
+            EXPECT_EQ(obj.data_diff->at("0").type, ViewComponentType::text);
             EXPECT_EQ(obj.length, 3);
         },
         [&] { ADD_FAILURE() << "View Res recv failed"; });
@@ -327,7 +327,7 @@ TEST_F(ServerTest, view) {
             EXPECT_EQ(obj.req_id, 1);
             EXPECT_EQ(obj.sub_field, "");
             EXPECT_EQ(obj.data_diff->size(), 1);
-            EXPECT_EQ(obj.data_diff->at(0).type, ViewComponentType::text);
+            EXPECT_EQ(obj.data_diff->at("0").type, ViewComponentType::text);
             EXPECT_EQ(obj.length, 3);
         },
         [&] { ADD_FAILURE() << "View Res recv failed"; });


### PR DESCRIPTION
* client-jsとの通信のため、viewのdiffの送信形式を`std::unordered_map<int, ViewComponent>`から`std::unordered_map<std::string, ViewComponent>`に変更
* messageのunpack時のエラー表示を詳しくした
* unpack時にエラーがある場合エラー以外の部分のメッセージは通常通り処理するようにした
