### PR TITLE
サーバーが保持するログの行数を制限

### DIFF
--- a/docs/01_client.md
+++ b/docs/01_client.md
@@ -54,6 +54,7 @@ Client::close() で切断します。
 
 ## ログ出力
 
+![ver1.1.7から](https://img.shields.io/badge/ver1.1.7~-00599c?logo=C%2B%2B)
 `WEBCFACE_VERBOSE` 環境変数が存在する場合、WebCFaceの通信に関するログ(接続、切断、メッセージのエラー)が出力されます。
 また `WEBCFACE_TRACE` 環境変数が存在すると内部で使用しているlibcurlの出力も表示します。
 

--- a/docs/40_log.md
+++ b/docs/40_log.md
@@ -93,7 +93,8 @@ std::nullopt<std::vector<WebCFace::LogLine>> log = log_a.tryGet();
 ```
 Log::get() はstd::nulloptの代わりに空のリストを返す点以外は同じです。
 
-(ver1.1.9から) サーバーは各クライアントのログを1000行まで保持しています。
+![ver1.1.9から](https://img.shields.io/badge/ver1.1.9~-00599c?logo=C%2B%2B)
+サーバーは各クライアントのログを1000行まで保持しています。
 logの受信リクエストを送った時点から1000行より前のログは取得できません。
 serverの起動時のオプションでこの行数は変更できます。(`webcface-server -h`を参照)
 

--- a/docs/40_log.md
+++ b/docs/40_log.md
@@ -93,6 +93,10 @@ std::nullopt<std::vector<WebCFace::LogLine>> log = log_a.tryGet();
 ```
 Log::get() はstd::nulloptの代わりに空のリストを返す点以外は同じです。
 
+(ver1.1.9から) サーバーは各クライアントのログを1000行まで保持しています。
+logの受信リクエストを送った時点から1000行より前のログは取得できません。
+serverの起動時のオプションでこの行数は変更できます。(`webcface-server -h`を参照)
+
 ## 受信イベント
 
 Log::appendListener() で受信したデータが変化したときにコールバックを呼び出すことができます

--- a/docs/90_message.md
+++ b/docs/90_message.md
@@ -225,7 +225,8 @@ data = {
 * lは変更されていない分も含めたviewの全要素数です
 * dのindexはstring型で、要素のindexを10進数で文字列にしたものです
 	* 例えば `[text("aaa"), text("bbb"), text("ccc")]` が `[text("aaa"), text("ccc"), text("bbb")]` に変更された場合のメッセージは `{"d": {"1": {"t": 0, "x": "ccc"}, "2": {"t": 0, "x": "bbb"}}}`
-* C++ ver1.1で変更: dのindexをnumber型からstring型に変更
+* ![ver1.1から](https://img.shields.io/badge/ver1.1~-00599c?logo=C%2B%2B) 
+dのindexをnumber型からstring型に変更
 
 ### view entry (kind = 23)
 * value entryと同様

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -126,11 +126,10 @@ void Client::sync() {
             log_s = std::make_shared<std::vector<std::shared_ptr<LogLine>>>();
             data->log_store.setRecv(member_, *log_s);
         }
-        auto log_send = std::make_shared<std::vector<Message::Log::LogLine>>();
+        auto log_send = std::make_shared<std::deque<Message::Log::LogLine>>();
         if (is_first) {
-            log_send->resize((*log_s)->size());
             for (std::size_t i = 0; i < (*log_s)->size(); i++) {
-                (*log_send)[i] = *(**log_s)[i];
+                log_send->push_back(*(**log_s)[i]);
             }
         }
         while (auto log = data->logger_sink->pop()) {

--- a/src/message/message.h
+++ b/src/message/message.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <deque>
 #include <any>
 #include <cstdint>
 #include <spdlog/logger.h>
@@ -198,7 +199,8 @@ struct View : public MessageBase<MessageKind::view> {
         Common::ViewComponentType type = Common::ViewComponentType::text;
         std::string text;
         std::optional<std::string> on_click_member, on_click_field;
-        Common::ViewColor text_color = Common::ViewColor::inherit, bg_color = Common::ViewColor::inherit;
+        Common::ViewColor text_color = Common::ViewColor::inherit,
+                          bg_color = Common::ViewColor::inherit;
         ViewComponent() = default;
         ViewComponent(const Common::ViewComponentBase &vc)
             : type(vc.type_), text(vc.text_), text_color(vc.text_color_),
@@ -259,7 +261,8 @@ struct Log : public MessageBase<MessageKind::log> {
         std::uint64_t time = 0;
         std::string message;
         LogLine() = default;
-        LogLine(const Common::LogLine &l)            : level(l.level),
+        LogLine(const Common::LogLine &l)
+            : level(l.level),
               time(std::chrono::duration_cast<std::chrono::milliseconds>(
                        l.time.time_since_epoch())
                        .count()),
@@ -273,7 +276,7 @@ struct Log : public MessageBase<MessageKind::log> {
         MSGPACK_DEFINE_MAP(MSGPACK_NVP("v", level), MSGPACK_NVP("t", time),
                            MSGPACK_NVP("m", message));
     };
-    std::shared_ptr<std::vector<LogLine>> log;
+    std::shared_ptr<std::deque<LogLine>> log;
     MSGPACK_DEFINE_MAP(MSGPACK_NVP("m", member_id), MSGPACK_NVP("l", log));
 };
 //! Logのリクエストはメンバ名のみ

--- a/src/server/s_client_data.cc
+++ b/src/server/s_client_data.cc
@@ -318,8 +318,17 @@ void ClientData::onRecv(const std::string &message) {
             auto v = std::any_cast<WebCFace::Message::Log>(obj);
             v.member_id = this->member_id;
             logger->debug("log {} lines", v.log->size());
+            if (store.keep_log >= 0 && this->log->size() < store.keep_log &&
+                this->log->size() + v.log->size() >= store.keep_log) {
+                logger->info("number of log lines reached {}, so the oldest "
+                             "log will be romoved.",
+                             store.keep_log);
+            }
             std::copy(v.log->begin(), v.log->end(),
                       std::back_inserter(*this->log));
+            while (store.keep_log >= 0 && this->log->size() > store.keep_log) {
+                this->log->pop_front();
+            }
             // このlogをsubscribeしてるところに送り返す
             store.forEach([&](auto &cd) {
                 if (cd.log_req.count(this->name)) {

--- a/src/server/s_client_data.h
+++ b/src/server/s_client_data.h
@@ -40,7 +40,7 @@ struct ClientData {
     std::set<std::string> log_req;
     bool hasReq(const std::string &member);
     //! ログ全履歴
-    std::shared_ptr<std::vector<Message::Log::LogLine>> log;
+    std::shared_ptr<std::deque<Message::Log::LogLine>> log;
 
 
     inline static unsigned int last_member_id = 0;
@@ -52,7 +52,7 @@ struct ClientData {
                         const spdlog::sink_ptr &sink,
                         spdlog::level::level_enum level)
         : con(con), remote_addr(remote_addr), sink(sink), logger_level(level),
-          log(std::make_shared<std::vector<Message::Log::LogLine>>()) {
+          log(std::make_shared<std::deque<Message::Log::LogLine>>()) {
         this->member_id = ++last_member_id;
         logger = std::make_shared<spdlog::logger>(
             std::to_string(member_id) + "_(unknown client)", this->sink);

--- a/src/server/store.h
+++ b/src/server/store.h
@@ -12,14 +12,15 @@ inline struct Store {
         clients;
     std::unordered_map<unsigned int, std::shared_ptr<ClientData>> clients_by_id;
 
+    int keep_log = 1000; // server_mainで上書きされる
+
     Store() : clients(), clients_by_id() {}
 
     //! テスト用
     void clear();
 
     void newClient(const ClientData::wsConnPtr &con,
-                   const std::string &remote_addr,
-                   const spdlog::sink_ptr &sink,
+                   const std::string &remote_addr, const spdlog::sink_ptr &sink,
                    spdlog::level::level_enum level);
     void removeClient(const ClientData::wsConnPtr &con);
     std::shared_ptr<ClientData> getClient(const ClientData::wsConnPtr &con);

--- a/src/server_main.cc
+++ b/src/server_main.cc
@@ -1,4 +1,5 @@
 #include "../server/websock.h"
+#include "../server/store.h"
 #include <webcface/common/def.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <CLI/CLI.hpp>
@@ -9,10 +10,17 @@ int main(int argc, char **argv) {
 
     int port = WEBCFACE_DEFAULT_PORT;
     int verbosity = 0;
+    int keep_log = 1000;
     app.add_option("-p,--port", port,
                    "Server port (default: " WEBCFACE_DEFAULT_PORT_S ")");
     app.add_flag("-v,--verbose", verbosity,
                  "Show all received messages (-vv to show sent messages too)");
+    app.add_option("-l,--keep-log", keep_log,
+                   ("Number of lines of received log to keep (default: " +
+                    std::to_string(keep_log) +
+                    ") \n"
+                    "(keep all log by setting -1)")
+                       .c_str());
 
     CLI11_PARSE(app, argc, argv);
 
@@ -25,7 +33,6 @@ int main(int argc, char **argv) {
         stderr_sink->set_level(spdlog::level::info);
     }
 
-    // Set HTTP listener address and port
-    // todo: 引数で変えられるようにする
+    WebCFace::Server::store.keep_log = keep_log;
     WebCFace::Server::serverRun(port, stderr_sink, spdlog::level::trace);
 }

--- a/src/test/client_test.cc
+++ b/src/test/client_test.cc
@@ -416,8 +416,8 @@ TEST_F(ClientTest, logReq) {
     dummy_s->send(
         Message::Log{{},
                      10,
-                     std::make_shared<std::vector<Message::Log::LogLine>>(
-                         std::vector<Message::Log::LogLine>{
+                     std::make_shared<std::deque<Message::Log::LogLine>>(
+                         std::deque<Message::Log::LogLine>{
                              LogLine{0, std::chrono::system_clock::now(), "a"},
                              LogLine{1, std::chrono::system_clock::now(), "b"},
                          })});
@@ -431,8 +431,8 @@ TEST_F(ClientTest, logReq) {
     dummy_s->send(
         Message::Log{{},
                      10,
-                     std::make_shared<std::vector<Message::Log::LogLine>>(
-                         std::vector<Message::Log::LogLine>{
+                     std::make_shared<std::deque<Message::Log::LogLine>>(
+                         std::deque<Message::Log::LogLine>{
                              LogLine{2, std::chrono::system_clock::now(), "c"},
                          })});
     wait();

--- a/src/test/server_test.cc
+++ b/src/test/server_test.cc
@@ -351,8 +351,8 @@ TEST_F(ServerTest, log) {
     dummy_c1->send(
         Message::Log{{},
                      0,
-                     std::make_shared<std::vector<Message::Log::LogLine>>(
-                         std::vector<Message::Log::LogLine>{
+                     std::make_shared<std::deque<Message::Log::LogLine>>(
+                         std::deque<Message::Log::LogLine>{
                              LogLine{0, std::chrono::system_clock::now(), "0"},
                              LogLine{1, std::chrono::system_clock::now(), "1"},
                          })});
@@ -375,8 +375,8 @@ TEST_F(ServerTest, log) {
     dummy_c1->send(
         Message::Log{{},
                      0,
-                     std::make_shared<std::vector<Message::Log::LogLine>>(
-                         std::vector<Message::Log::LogLine>{
+                     std::make_shared<std::deque<Message::Log::LogLine>>(
+                         std::deque<Message::Log::LogLine>{
                              LogLine{2, std::chrono::system_clock::now(), "2"},
                          })});
     wait();


### PR DESCRIPTION
サーバーが保持するログの行数を1000行までにし、オプションで変更可能にした
