### PR TITLE
クライアント切断時にcallresponseを返すようにした

### DIFF
--- a/src/server/s_client_data.cc
+++ b/src/server/s_client_data.cc
@@ -8,8 +8,38 @@
 
 namespace webcface::Server {
 void ClientData::onClose() {
-    // 作ったものの何もすることがなかった
+    con = nullptr;
     logger->info("connection closed");
+    for (const auto &pm : pending_calls) {
+        store.findAndDo(pm.first, [&](auto cd) {
+            for (const auto &pi : pm.second) {
+                switch (pi.second) {
+                case 2:
+                    cd->send(Message::packSingle(
+                        Message::CallResponse{{}, pi.first, pm.first, false}));
+                    cd->logger->debug("pending call aborted, sending "
+                                      "call_response (caller_id {})",
+                                      pi.first);
+                    break;
+                case 1:
+                    cd->send(Message::packSingle(Message::CallResult{
+                        {},
+                        pi.first,
+                        pm.first,
+                        true,
+                        "member(\"" + this->name + "\") Disconnected"}));
+                    cd->logger->debug("pending call aborted, sending "
+                                      "call_result (caller_id {})",
+                                      pi.first);
+                    break;
+                case 0:
+                    break;
+                default:
+                    throw std::runtime_error("invalid pending_call");
+                }
+            }
+        });
+    }
 }
 void ClientData::send() {
     if (connected() && send_len > 0) {
@@ -23,7 +53,6 @@ void ClientData::send(const std::string &msg) {
         serverSend(con, msg);
     }
 }
-bool ClientData::connected() const { return con != nullptr; }
 void ClientData::onConnect() { logger->info("connected"); }
 
 bool ClientData::hasReq(const std::string &member) {
@@ -109,10 +138,10 @@ void ClientData::onRecv(const std::string &message) {
                     "sync_init name={}, member_id={} (before {})", this->name,
                     this->member_id, member_id_before);
                 // 全クライアントに新しいMemberを通知
-                store.forEach([&](auto &cd) {
-                    if (cd.member_id != this->member_id) {
-                        cd.pack(v);
-                        cd.logger->trace("send sync_init {} ({})", this->name,
+                store.forEach([&](auto cd) {
+                    if (cd->member_id != this->member_id) {
+                        cd->pack(v);
+                        cd->logger->trace("send sync_init {} ({})", this->name,
                                          this->member_id);
                     }
                 });
@@ -120,37 +149,37 @@ void ClientData::onRecv(const std::string &message) {
             this->pack(webcface::Message::SvrVersion{
                 {}, WEBCFACE_SERVER_NAME, WEBCFACE_VERSION});
             // 逆に新しいMemberに他の全Memberのentryを通知
-            store.forEachWithName([&](auto &cd) {
-                if (cd.member_id != this->member_id) {
-                    this->pack(cd.init_data);
-                    logger->trace("send sync_init {} ({})", cd.name,
-                                  cd.member_id);
+            store.forEachWithName([&](auto cd) {
+                if (cd->member_id != this->member_id) {
+                    this->pack(cd->init_data);
+                    logger->trace("send sync_init {} ({})", cd->name,
+                                  cd->member_id);
 
-                    for (const auto &f : cd.value) {
+                    for (const auto &f : cd->value) {
                         this->pack(
                             webcface::Message::Entry<webcface::Message::Value>{
-                                {}, cd.member_id, f.first});
+                                {}, cd->member_id, f.first});
                         logger->trace("send value_entry {} of member {}",
-                                      f.first, cd.member_id);
+                                      f.first, cd->member_id);
                     }
-                    for (const auto &f : cd.text) {
+                    for (const auto &f : cd->text) {
                         this->pack(
                             webcface::Message::Entry<webcface::Message::Text>{
-                                {}, cd.member_id, f.first});
+                                {}, cd->member_id, f.first});
                         logger->trace("send text_entry {} of member {}",
-                                      f.first, cd.member_id);
+                                      f.first, cd->member_id);
                     }
-                    for (const auto &f : cd.view) {
+                    for (const auto &f : cd->view) {
                         this->pack(
                             webcface::Message::Entry<webcface::Message::View>{
-                                {}, cd.member_id, f.first});
+                                {}, cd->member_id, f.first});
                         logger->trace("send view_entry {} of member {}",
-                                      f.first, cd.member_id);
+                                      f.first, cd->member_id);
                     }
-                    for (const auto &f : cd.func) {
+                    for (const auto &f : cd->func) {
                         this->pack(*f.second);
                         logger->trace("send func_info {} of member {}",
-                                      f.second->field, cd.member_id);
+                                      f.second->field, cd->member_id);
                     }
                 }
             });
@@ -161,10 +190,10 @@ void ClientData::onRecv(const std::string &message) {
             v.member_id = this->member_id;
             logger->debug("sync");
             // 1つ以上リクエストしているクライアントにはsyncの情報を流す
-            store.forEach([&](auto &cd) {
-                if (cd.hasReq(this->name)) {
-                    cd.pack(v);
-                    cd.logger->trace("send sync {}", this->member_id);
+            store.forEach([&](auto cd) {
+                if (cd->hasReq(this->name)) {
+                    cd->pack(v);
+                    cd->logger->trace("send sync {}", this->member_id);
                 }
             });
             break;
@@ -176,17 +205,18 @@ void ClientData::onRecv(const std::string &message) {
                 "call caller_id={}, target_id={}, field={}, with {} args",
                 v.caller_id, v.target_member_id, v.field, v.args.size());
             // そのままターゲットのクライアントに送る
-            store.findAndDo(
+            store.findConnectedAndDo(
                 v.target_member_id,
-                [&](auto &cd) {
-                    cd.pack(v);
-                    cd.logger->trace("send call caller_id={}, target_id={}, "
+                [&](auto cd) {
+                    cd->pack(v);
+                    cd->pending_calls[this->member_id][v.caller_id] = 2;
+                    cd->logger->trace("send call caller_id={}, target_id={}, "
                                      "field={}, with {} args",
                                      v.caller_id, v.target_member_id, v.field,
                                      v.args.size());
                 },
                 [&]() {
-                    // 関数存在しないときの処理
+                    // 関数存在しないor切断されているときの処理
                     this->pack(webcface::Message::CallResponse{
                         {}, v.caller_id, v.caller_member_id, false});
                     logger->debug("call target not found");
@@ -197,10 +227,11 @@ void ClientData::onRecv(const std::string &message) {
             auto v = std::any_cast<webcface::Message::CallResponse>(obj);
             logger->debug("call_response to (member_id {}, caller_id {}), {}",
                           v.caller_member_id, v.caller_id, v.started);
+            this->pending_calls[v.caller_member_id][v.caller_id] = 1;
             // そのままcallerに送る
-            store.findAndDo(v.caller_member_id, [&](auto &cd) {
-                cd.pack(v);
-                cd.logger->trace(
+            store.findAndDo(v.caller_member_id, [&](auto cd) {
+                cd->pack(v);
+                cd->logger->trace(
                     "send call_response to (member_id {}, caller_id {}), {}",
                     v.caller_member_id, v.caller_id, v.started);
             });
@@ -211,10 +242,11 @@ void ClientData::onRecv(const std::string &message) {
             logger->debug("call_result to (member_id {}, caller_id {}), {}",
                           v.caller_member_id, v.caller_id,
                           static_cast<std::string>(v.result));
+            this->pending_calls[v.caller_member_id][v.caller_id] = 0;
             // そのままcallerに送る
-            store.findAndDo(v.caller_member_id, [&](auto &cd) {
-                cd.pack(v);
-                cd.logger->trace(
+            store.findAndDo(v.caller_member_id, [&](auto cd) {
+                cd->pack(v);
+                cd->logger->trace(
                     "send call_result to (member_id {}, caller_id {}), {}",
                     v.caller_member_id, v.caller_id,
                     static_cast<std::string>(v.result));
@@ -230,25 +262,25 @@ void ClientData::onRecv(const std::string &message) {
                               v.data->size());
             }
             if (!this->value.count(v.field)) {
-                store.forEach([&](auto &cd) {
-                    if (cd.name != this->name) {
-                        cd.pack(
+                store.forEach([&](auto cd) {
+                    if (cd->name != this->name) {
+                        cd->pack(
                             webcface::Message::Entry<webcface::Message::Value>{
                                 {}, this->member_id, v.field});
-                        cd.logger->trace("send value_entry {} of member {}",
+                        cd->logger->trace("send value_entry {} of member {}",
                                          v.field, this->member_id);
                     }
                 });
             }
             this->value[v.field] = v.data;
             // このvalueをsubscribeしてるところに送り返す
-            store.forEach([&](auto &cd) {
+            store.forEach([&](auto cd) {
                 auto [req_id, sub_field] =
-                    findReqField(cd.value_req, this->name, v.field);
+                    findReqField(cd->value_req, this->name, v.field);
                 if (req_id > 0) {
-                    cd.pack(webcface::Message::Res<webcface::Message::Value>(
+                    cd->pack(webcface::Message::Res<webcface::Message::Value>(
                         req_id, sub_field, v.data));
-                    cd.logger->trace("send value_res req_id={} + '{}'", req_id,
+                    cd->logger->trace("send value_res req_id={} + '{}'", req_id,
                                      sub_field);
                 }
             });
@@ -258,25 +290,25 @@ void ClientData::onRecv(const std::string &message) {
             auto v = std::any_cast<webcface::Message::Text>(obj);
             logger->debug("text {} = {}", v.field, *v.data);
             if (!this->text.count(v.field)) {
-                store.forEach([&](auto &cd) {
-                    if (cd.name != this->name) {
-                        cd.pack(
+                store.forEach([&](auto cd) {
+                    if (cd->name != this->name) {
+                        cd->pack(
                             webcface::Message::Entry<webcface::Message::Text>{
                                 {}, this->member_id, v.field});
-                        cd.logger->trace("send text_entry {} of member {}",
+                        cd->logger->trace("send text_entry {} of member {}",
                                          v.field, this->member_id);
                     }
                 });
             }
             this->text[v.field] = v.data;
             // このvalueをsubscribeしてるところに送り返す
-            store.forEach([&](auto &cd) {
+            store.forEach([&](auto cd) {
                 auto [req_id, sub_field] =
-                    findReqField(cd.text_req, this->name, v.field);
+                    findReqField(cd->text_req, this->name, v.field);
                 if (req_id > 0) {
-                    cd.pack(webcface::Message::Res<webcface::Message::Text>(
+                    cd->pack(webcface::Message::Res<webcface::Message::Text>(
                         req_id, sub_field, v.data));
-                    cd.logger->trace("send text_res {}, req_id={} + '{}'",
+                    cd->logger->trace("send text_res {}, req_id={} + '{}'",
                                      *v.data, req_id, sub_field);
                 }
             });
@@ -287,12 +319,12 @@ void ClientData::onRecv(const std::string &message) {
             logger->debug("view {} diff={}, length={}", v.field,
                           v.data_diff->size(), v.length);
             if (!this->view.count(v.field)) {
-                store.forEach([&](auto &cd) {
-                    if (cd.name != this->name) {
-                        cd.pack(
+                store.forEach([&](auto cd) {
+                    if (cd->name != this->name) {
+                        cd->pack(
                             webcface::Message::Entry<webcface::Message::View>{
                                 {}, this->member_id, v.field});
-                        cd.logger->trace("send view_entry {} of member {}",
+                        cd->logger->trace("send view_entry {} of member {}",
                                          v.field, this->member_id);
                     }
                 });
@@ -302,13 +334,13 @@ void ClientData::onRecv(const std::string &message) {
                 this->view[v.field][std::stoi(d.first)] = d.second;
             }
             // このvalueをsubscribeしてるところに送り返す
-            store.forEach([&](auto &cd) {
+            store.forEach([&](auto cd) {
                 auto [req_id, sub_field] =
-                    findReqField(cd.view_req, this->name, v.field);
+                    findReqField(cd->view_req, this->name, v.field);
                 if (req_id > 0) {
-                    cd.pack(webcface::Message::Res<webcface::Message::View>(
+                    cd->pack(webcface::Message::Res<webcface::Message::View>(
                         req_id, sub_field, v.data_diff, v.length));
-                    cd.logger->trace("send view_res req_id={} + '{}'", req_id,
+                    cd->logger->trace("send view_res req_id={} + '{}'", req_id,
                                      sub_field);
                 }
             });
@@ -330,10 +362,10 @@ void ClientData::onRecv(const std::string &message) {
                 this->log->pop_front();
             }
             // このlogをsubscribeしてるところに送り返す
-            store.forEach([&](auto &cd) {
-                if (cd.log_req.count(this->name)) {
-                    cd.pack(v);
-                    cd.logger->trace("send log {} lines", v.log->size());
+            store.forEach([&](auto cd) {
+                if (cd->log_req.count(this->name)) {
+                    cd->pack(v);
+                    cd->logger->trace("send log {} lines", v.log->size());
                 }
             });
             break;
@@ -343,10 +375,10 @@ void ClientData::onRecv(const std::string &message) {
             v.member_id = this->member_id;
             logger->debug("func_info {}", v.field);
             if (!this->func.count(v.field)) {
-                store.forEach([&](auto &cd) {
-                    if (cd.member_id != this->member_id) {
-                        cd.pack(v);
-                        cd.logger->trace("send func_info {} of member {}",
+                store.forEach([&](auto cd) {
+                    if (cd->member_id != this->member_id) {
+                        cd->pack(v);
+                        cd->logger->trace("send func_info {} of member {}",
                                          v.field, this->member_id);
                     }
                 });
@@ -361,13 +393,13 @@ void ClientData::onRecv(const std::string &message) {
             logger->debug("request value ({}): {} from {}", s.req_id, s.field,
                           s.member);
             // 指定した値を返す
-            store.findAndDo(s.member, [&](auto &cd) {
+            store.findAndDo(s.member, [&](auto cd) {
                 if (!this->hasReq(s.member)) {
-                    this->pack(webcface::Message::Sync{cd.member_id,
-                                                       cd.last_sync_time});
+                    this->pack(webcface::Message::Sync{cd->member_id,
+                                                       cd->last_sync_time});
                     logger->trace("send sync {}", this->member_id);
                 }
-                for (const auto &it : cd.value) {
+                for (const auto &it : cd->value) {
                     if (it.first == s.field ||
                         it.first.starts_with(s.field + ".")) {
                         std::string sub_field;
@@ -394,13 +426,13 @@ void ClientData::onRecv(const std::string &message) {
             logger->debug("request text ({}): {} from {}", s.req_id, s.field,
                           s.member);
             // 指定した値を返す
-            store.findAndDo(s.member, [&](auto &cd) {
+            store.findAndDo(s.member, [&](auto cd) {
                 if (!this->hasReq(s.member)) {
-                    this->pack(webcface::Message::Sync{cd.member_id,
-                                                       cd.last_sync_time});
+                    this->pack(webcface::Message::Sync{cd->member_id,
+                                                       cd->last_sync_time});
                     logger->trace("send sync {}", this->member_id);
                 }
-                for (const auto &it : cd.text) {
+                for (const auto &it : cd->text) {
                     if (it.first == s.field ||
                         it.first.starts_with(s.field + ".")) {
                         std::string sub_field;
@@ -427,13 +459,13 @@ void ClientData::onRecv(const std::string &message) {
             logger->debug("request view ({}): {} from {}", s.req_id, s.field,
                           s.member);
             // 指定した値を返す
-            store.findAndDo(s.member, [&](auto &cd) {
+            store.findAndDo(s.member, [&](auto cd) {
                 if (!this->hasReq(s.member)) {
-                    this->pack(webcface::Message::Sync{cd.member_id,
-                                                       cd.last_sync_time});
+                    this->pack(webcface::Message::Sync{cd->member_id,
+                                                       cd->last_sync_time});
                     logger->trace("send sync {}", this->member_id);
                 }
-                for (const auto &it : cd.view) {
+                for (const auto &it : cd->view) {
                     if (it.first == s.field ||
                         it.first.starts_with(s.field + ".")) {
                         auto diff = std::make_shared<std::unordered_map<
@@ -464,9 +496,9 @@ void ClientData::onRecv(const std::string &message) {
             logger->debug("request log from {}", s.member);
             log_req.insert(s.member);
             // 指定した値を返す
-            store.findAndDo(s.member, [&](auto &cd) {
-                this->pack(webcface::Message::Log{cd.member_id, cd.log});
-                logger->trace("send log {} lines", cd.log->size());
+            store.findAndDo(s.member, [&](auto cd) {
+                this->pack(webcface::Message::Log{cd->member_id, cd->log});
+                logger->trace("send log {} lines", cd->log->size());
             });
             break;
         }

--- a/src/server/s_client_data.cc
+++ b/src/server/s_client_data.cc
@@ -53,7 +53,7 @@ void ClientData::send(const std::string &msg) {
         serverSend(con, msg);
     }
 }
-void ClientData::onConnect() { logger->info("connected"); }
+void ClientData::onConnect() { logger->debug("websocket connected"); }
 
 bool ClientData::hasReq(const std::string &member) {
     return std::any_of(this->value_req[member].begin(),
@@ -137,6 +137,7 @@ void ClientData::onRecv(const std::string &message) {
                 this->logger->debug(
                     "sync_init name={}, member_id={} (before {})", this->name,
                     this->member_id, member_id_before);
+                this->logger->info("successfully connected and initialized.");
                 // 全クライアントに新しいMemberを通知
                 store.forEach([&](auto cd) {
                     if (cd->member_id != this->member_id) {

--- a/src/server/s_client_data.h
+++ b/src/server/s_client_data.h
@@ -15,12 +15,19 @@ struct ClientData {
     std::shared_ptr<spdlog::logger> logger;
     spdlog::level::level_enum logger_level;
 
+    /*!
+     * \brief ws接続のポインタ、切断後(onClose後)nullptrになる
+     */
     wsConnPtr con;
     std::string remote_addr;
-    bool connected() const;
+    bool connected() const { return con != nullptr; }
 
-    //! 初回のsync()が終わったか
-    //! falseならentryの通知などはしない
+    /*!
+     * \brief 初回のsync() が終わったか
+     * 
+     * falseならentryの通知などはしない
+     * 
+     */
     bool sync_init = false;
 
     std::string name;
@@ -41,7 +48,17 @@ struct ClientData {
     bool hasReq(const std::string &member);
     //! ログ全履歴
     std::shared_ptr<std::deque<Message::Log::LogLine>> log;
-
+    /*!
+     * \brief まだ完了していない自分へのcall呼び出しのリスト
+     *
+     * [caller_member_id][caller_id]
+     * 
+     * 呼び出し開始で2, response返したら1, result返したら0
+     * 
+     * 切断時にそれぞれにresponseを返す必要がある。
+     *
+     */
+    std::unordered_map<unsigned int, std::unordered_map<unsigned int, int>> pending_calls;
 
     inline static unsigned int last_member_id = 0;
 

--- a/src/server/s_client_data.h
+++ b/src/server/s_client_data.h
@@ -24,9 +24,9 @@ struct ClientData {
 
     /*!
      * \brief 初回のsync() が終わったか
-     * 
+     *
      * falseならentryの通知などはしない
-     * 
+     *
      */
     bool sync_init = false;
 
@@ -52,13 +52,14 @@ struct ClientData {
      * \brief まだ完了していない自分へのcall呼び出しのリスト
      *
      * [caller_member_id][caller_id]
-     * 
+     *
      * 呼び出し開始で2, response返したら1, result返したら0
-     * 
+     *
      * 切断時にそれぞれにresponseを返す必要がある。
      *
      */
-    std::unordered_map<unsigned int, std::unordered_map<unsigned int, int>> pending_calls;
+    std::unordered_map<unsigned int, std::unordered_map<std::size_t, int>>
+        pending_calls;
 
     inline static unsigned int last_member_id = 0;
 

--- a/src/server/store.cc
+++ b/src/server/store.cc
@@ -81,14 +81,14 @@ void Store::findConnectedAndDo(unsigned int id,
     }
 }
 void Store::forEach(const std::function<void(ClientDataPtr)> &func) {
-    for (const auto cd : clients) {
+    for (const auto &cd : clients) {
         if (cd.second->sync_init) {
             func(cd.second);
         }
     }
 }
 void Store::forEachWithName(const std::function<void(ClientDataPtr)> &func) {
-    for (const auto cd : clients_by_id) {
+    for (const auto &cd : clients_by_id) {
         if (cd.second->sync_init) {
             func(cd.second);
         }

--- a/src/server/store.cc
+++ b/src/server/store.cc
@@ -20,11 +20,14 @@ void Store::removeClient(const ClientData::wsConnPtr &con) {
     auto it = clients.find(con);
     if (it != clients.end()) {
         it->second->onClose();
+        // 名前があるクライアントのデータはclients_by_idに残す
+        if (it->second->name.empty()) {
+            clients_by_id[it->second->member_id] = nullptr;
+        }
         clients.erase(con);
-        // clients_by_idは残す
     }
 }
-std::shared_ptr<ClientData> Store::getClient(const ClientData::wsConnPtr &con) {
+ClientDataPtr Store::getClient(const ClientData::wsConnPtr &con) {
     auto it = clients.find(con);
     if (it != clients.end()) {
         return it->second;
@@ -40,13 +43,13 @@ void Store::clientSendAll() {
 }
 
 void Store::findAndDo(const std::string &name,
-                      const std::function<void(ClientData &)> &func,
+                      const std::function<void(ClientDataPtr)> &func,
                       const std::function<void()> &func_else) {
     auto cd =
         std::find_if(clients_by_id.begin(), clients_by_id.end(),
                      [&](const auto &cd) { return cd.second->name == name; });
-    if (cd != clients_by_id.end()) {
-        func(*cd->second);
+    if (cd != clients_by_id.end() && cd->second->sync_init) {
+        func(cd->second);
     } else {
         if (func_else != nullptr) {
             func_else();
@@ -54,28 +57,40 @@ void Store::findAndDo(const std::string &name,
     }
 }
 void Store::findAndDo(unsigned int id,
-                      const std::function<void(ClientData &)> &func,
+                      const std::function<void(ClientDataPtr)> &func,
                       const std::function<void()> &func_else) {
     auto cd = clients_by_id.find(id);
-    if (cd != clients_by_id.end()) {
-        func(*cd->second);
+    if (cd != clients_by_id.end() && cd->second->sync_init) {
+        func(cd->second);
     } else {
         if (func_else != nullptr) {
             func_else();
         }
     }
 }
-void Store::forEach(const std::function<void(ClientData &)> &func) {
-    for (const auto cd : clients) {
-        if (cd.second->sync_init) {
-            func(*cd.second);
+void Store::findConnectedAndDo(unsigned int id,
+                      const std::function<void(ClientDataPtr)> &func,
+                      const std::function<void()> &func_else) {
+    auto cd = clients_by_id.find(id);
+    if (cd != clients_by_id.end() && cd->second->sync_init && cd->second->connected()) {
+        func(cd->second);
+    } else {
+        if (func_else != nullptr) {
+            func_else();
         }
     }
 }
-void Store::forEachWithName(const std::function<void(ClientData &)> &func) {
+void Store::forEach(const std::function<void(ClientDataPtr)> &func) {
+    for (const auto cd : clients) {
+        if (cd.second->sync_init) {
+            func(cd.second);
+        }
+    }
+}
+void Store::forEachWithName(const std::function<void(ClientDataPtr)> &func) {
     for (const auto cd : clients_by_id) {
         if (cd.second->sync_init) {
-            func(*cd.second);
+            func(cd.second);
         }
     }
 }

--- a/src/server/websock.cc
+++ b/src/server/websock.cc
@@ -34,20 +34,20 @@ void pingThreadMain() {
         }
         auto new_ping_status =
             std::make_shared<std::unordered_map<unsigned int, int>>();
-        store.forEach([&](auto &cd) {
-            if (cd.last_ping_duration) {
-                new_ping_status->emplace(cd.member_id,
-                                         cd.last_ping_duration->count());
+        store.forEach([&](auto cd) {
+            if (cd->last_ping_duration) {
+                new_ping_status->emplace(cd->member_id,
+                                         cd->last_ping_duration->count());
             }
         });
         ping_status = new_ping_status;
         auto msg = Message::packSingle(Message::PingStatus{{}, ping_status});
-        store.forEach([&](auto &cd) {
-            cd.logger->trace("ping");
-            cd.sendPing();
-            if (cd.ping_status_req) {
-                cd.send(msg);
-                cd.logger->trace("send ping_status");
+        store.forEach([&](auto cd) {
+            cd->logger->trace("ping");
+            cd->sendPing();
+            if (cd->ping_status_req) {
+                cd->send(msg);
+                cd->logger->trace("send ping_status");
             }
         });
     }


### PR DESCRIPTION
fix #133 
* s_ClientData::pending_calls, Store::findConnectedAndDoを追加
* 切断時にs_ClientData::conにnullptrをセット
* 切断時に名前のないクライアントはStore::clients_by_idから削除
* ついでにstore.forEachなどの関数が参照ではなくshared_ptrを返すようにした。
* std::shared_ptr<ClientData> → ClientDataPtr のエイリアスを追加
* ついでに接続時のログ表示を修正 (接続したmemberの名前がinfoで確認できるようにした)