### PR TITLE
clients_by_idにnullptrを入れないようにした

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,9 @@ if(NOT asio_POPULATED)
         ${asio_SOURCE_DIR}/asio/include
     )
     target_compile_definitions(asio INTERFACE ASIO_STANDALONE)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        target_compile_options(asio INTERFACE -Wno-deprecated-declarations)
+    endif()
 endif()
 if(MINGW)
     set(ASIO asio ws2_32 wsock32)
@@ -294,11 +297,16 @@ endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wall -Wextra -Wpedantic -Werror)
     add_compile_options(-Wno-psabi) # refer to PR#9
-    add_compile_options(-Wno-deprecated-enum-enum-conversion) # inside opencv
+    add_compile_options( # inside opencv
+        $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-enum-enum-conversion>
+    )
 endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-    add_compile_options(-Wno-c11-extensions -Wno-deprecated-enum-enum-conversion) # inside opencv
+    add_compile_options( # inside opencv
+        -Wno-c11-extensions
+        $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-enum-enum-conversion>
+    )
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")

--- a/src/server/store.cc
+++ b/src/server/store.cc
@@ -22,7 +22,7 @@ void Store::removeClient(const ClientData::wsConnPtr &con) {
         it->second->onClose();
         // 名前があるクライアントのデータはclients_by_idに残す
         if (it->second->name.empty()) {
-            clients_by_id[it->second->member_id] = nullptr;
+            clients_by_id.erase(it->second->member_id);
         }
         clients.erase(con);
     }

--- a/src/server/store.h
+++ b/src/server/store.h
@@ -20,7 +20,6 @@ inline struct Store {
      * 切断されてもデータは残り、valueやlogなどあとで参照できる
      * * 名前があるクライアントは同じ名前で再接続されたときに上書きする。
      * * (ver1.2.2から) 名前がないクライアントは切断時に削除
-     * (idを被らせないためnullptrで埋める)
      *
      */
     std::unordered_map<unsigned int, ClientDataPtr> clients_by_id;


### PR DESCRIPTION
fix #159

あとついでになんかwarningのオプションが修正されている
