### PR TITLE
server側で受信した文字列のutf-8チェックをする

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,19 @@ FetchContent_Declare(cli11
 )
 FetchContent_MakeAvailable(cli11)
 
+message(STATUS "Fetching utfcpp Source...")
+FetchContent_Declare(utfcpp
+    GIT_REPOSITORY https://github.com/nemtrif/utfcpp.git
+    GIT_TAG v4.0.5
+)
+if(NOT utfcpp_POPULATED)
+    FetchContent_Populate(utfcpp)
+    add_library(utfcpp INTERFACE)
+    target_include_directories(utfcpp INTERFACE
+        ${utfcpp_SOURCE_DIR}/source
+    )
+endif()
+
 if(WEBCFACE_USE_OPENCV)
     find_package(OpenCV REQUIRED)
 endif()
@@ -442,6 +455,7 @@ add_library(${PROJECT_NAME}-server-impl STATIC ${SVR_SRC})
 target_link_libraries(${PROJECT_NAME}-server-impl PUBLIC
     ${PROJECT_NAME}-message
     Crow
+    utfcpp
 )
 if(WIN32)
     target_link_libraries(${PROJECT_NAME}-server-impl PRIVATE
@@ -639,6 +653,10 @@ if(WEBCFACE_INSTALL)
             DESTINATION share/webcface/3rd_party/msgpack-c
         )
     endif()
+    install(FILES
+        ${utfcpp_SOURCE_DIR}/LICENSE
+        DESTINATION share/webcface/3rd_party/utfcpp
+    )
 
     # https://decovar.dev/blog/2021/09/23/cmake-cpack-package-deb-apt/
     set(CPACK_VERBATIM_VARIABLES yes)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ MinGW用バイナリは今のところ配布していません(ソースから�
 	* [![CMake Test (MacOS Clang)](https://github.com/na-trium-144/webcface/actions/workflows/cmake-test-macos-clang.yml/badge.svg?branch=main)](https://github.com/na-trium-144/webcface/actions/workflows/cmake-test-macos-clang.yml)
 	* [![CMake Test (Windows MSVC)](https://github.com/na-trium-144/webcface/actions/workflows/cmake-test-windows-msvc.yml/badge.svg?branch=main)](https://github.com/na-trium-144/webcface/actions/workflows/cmake-test-windows-msvc.yml)
 	* [![CMake Test (Windows MinGW64 GCC)](https://github.com/na-trium-144/webcface/actions/workflows/cmake-test-windows-gcc.yml/badge.svg?branch=main)](https://github.com/na-trium-144/webcface/actions/workflows/cmake-test-windows-gcc.yml)
-* webcfaceは外部ライブラリとして [crow](https://github.com/CrowCpp/Crow), [asio](https://github.com/chriskohlhoff/asio), [libcurl](https://github.com/curl/curl), [eventpp](https://github.com/wqking/eventpp), [msgpack-cxx](https://github.com/msgpack/msgpack-c), [spdlog](https://github.com/gabime/spdlog), [cli11](https://github.com/CLIUtils/CLI11.git), [opencv](https://opencv.org/) を使用します。
+* webcfaceは外部ライブラリとして [crow](https://github.com/CrowCpp/Crow), [asio](https://github.com/chriskohlhoff/asio), [libcurl](https://github.com/curl/curl), [eventpp](https://github.com/wqking/eventpp), [msgpack-cxx](https://github.com/msgpack/msgpack-c), [spdlog](https://github.com/gabime/spdlog), [cli11](https://github.com/CLIUtils/CLI11.git), [UTF8-CPP](https://github.com/nemtrif/utfcpp), [opencv](https://opencv.org/) を使用します。
 	* cmake時に自動的にFetchContentでソースコード取得しビルドしますが、eventpp, msgpack, spdlog に関してはシステムにインストールされていてfind_packageで見つけることができればそれを使用します
 	* opencvはソースからビルドしません。別途インストールする必要があります。
 		* またはcmake時のオプションでopencvを使わないようにすることもできます (画像の変換機能が無効になります)
@@ -239,6 +239,7 @@ WebCFace本体とtoolsが使用しているサードパーティーのライブ�
 * msgpack-c (Boost Software License) : https://github.com/msgpack/msgpack-c
 * spdlog (MIT) : https://github.com/gabime/spdlog
 * CLI11 (BSD 3-Clause) : https://github.com/CLIUtils/CLI11
+* UTF8-CPP (BSD 1.0) : https://github.com/nemtrif/utfcpp
 * OpenCV (Apache 2.0) : https://opencv.org/license/
 * tiny-process-library (MIT) : https://gitlab.com/eidheim/tiny-process-library (toolsで使用)
 * toml++ (MIT) : https://github.com/marzer/tomlplusplus (toolsで使用)

--- a/src/server/s_client_data.cc
+++ b/src/server/s_client_data.cc
@@ -251,7 +251,7 @@ void ClientData::onRecv(const std::string &message) {
             auto v = std::any_cast<WEBCFACE_NS::Message::Call>(obj);
             v.caller_member_id = this->member_id;
             for (auto &a : v.args) {
-                a = utf8::replace_invalid(a);
+                a = utf8::replace_invalid(static_cast<std::string>(a));
             }
             logger->debug(
                 "call caller_id={}, target_id={}, field={}, with {} args",
@@ -291,7 +291,8 @@ void ClientData::onRecv(const std::string &message) {
         }
         case MessageKind::call_result: {
             auto v = std::any_cast<WEBCFACE_NS::Message::CallResult>(obj);
-            v.result = utf8::replace_invalid(v.result);
+            v.result =
+                utf8::replace_invalid(static_cast<std::string>(v.result));
             logger->debug("call_result to (member_id {}, caller_id {}), {}",
                           v.caller_member_id, v.caller_id,
                           static_cast<std::string>(v.result));
@@ -527,14 +528,16 @@ void ClientData::onRecv(const std::string &message) {
             for (auto &a : *v.args) {
                 std::vector<Common::ValAdaptor> replaced_opt;
                 for (auto &o : a.option()) {
-                    replaced_opt.push_back(utf8::replace_invalid(o));
+                    replaced_opt.push_back(
+                        utf8::replace_invalid(static_cast<std::string>(o)));
                 }
-                a = Common::Arg(utf8::replace_invalid(a.name()), a.type(),
-                                a.init()
-                                    ? std::make_optional<Common::ValAdaptor>(
-                                          utf8::replace_invalid(*a.init()))
-                                    : std::nullopt,
-                                a.min(), a.max(), replaced_opt);
+                a = Common::Arg(
+                    utf8::replace_invalid(a.name()), a.type(),
+                    a.init() ? std::make_optional<Common::ValAdaptor>(
+                                   utf8::replace_invalid(
+                                       static_cast<std::string>(*a.init())))
+                             : std::nullopt,
+                    a.min(), a.max(), replaced_opt);
             }
             logger->debug("func_info {}", v.field);
             if (!this->func.count(v.field)) {

--- a/src/server/s_client_data.cc
+++ b/src/server/s_client_data.cc
@@ -5,6 +5,7 @@
 #include <webcface/common/def.h>
 #include <algorithm>
 #include <iterator>
+#include <utf8.h>
 
 #if WEBCFACE_USE_OPENCV
 #include <opencv2/core.hpp>
@@ -249,6 +250,9 @@ void ClientData::onRecv(const std::string &message) {
         case MessageKind::call: {
             auto v = std::any_cast<WEBCFACE_NS::Message::Call>(obj);
             v.caller_member_id = this->member_id;
+            for (auto &a : v.args) {
+                a = utf8::replace_invalid(a);
+            }
             logger->debug(
                 "call caller_id={}, target_id={}, field={}, with {} args",
                 v.caller_id, v.target_member_id, v.field, v.args.size());
@@ -287,6 +291,7 @@ void ClientData::onRecv(const std::string &message) {
         }
         case MessageKind::call_result: {
             auto v = std::any_cast<WEBCFACE_NS::Message::CallResult>(obj);
+            v.result = utf8::replace_invalid(v.result);
             logger->debug("call_result to (member_id {}, caller_id {}), {}",
                           v.caller_member_id, v.caller_id,
                           static_cast<std::string>(v.result));
@@ -337,6 +342,7 @@ void ClientData::onRecv(const std::string &message) {
         }
         case MessageKind::text: {
             auto v = std::any_cast<WEBCFACE_NS::Message::Text>(obj);
+            *v.data = utf8::replace_invalid(*v.data);
             logger->debug("text {} = {}", v.field, *v.data);
             if (!this->text.count(v.field)) {
                 store.forEach([&](auto cd) {
@@ -410,7 +416,8 @@ void ClientData::onRecv(const std::string &message) {
                 });
             }
             this->view[v.field].resize(v.length);
-            for (const auto &d : *v.data_diff) {
+            for (auto &d : *v.data_diff) {
+                d.second.text = utf8::replace_invalid(d.second.text);
                 this->view[v.field][std::stoi(d.first)] = d.second;
             }
             // このvalueをsubscribeしてるところに送り返す
@@ -451,11 +458,11 @@ void ClientData::onRecv(const std::string &message) {
                 auto [req_id, sub_field] =
                     findReqField(cd->canvas3d_req, this->name, v.field);
                 if (req_id > 0) {
-                    cd->pack(
-                        WEBCFACE_NS::Message::Res<WEBCFACE_NS::Message::Canvas3D>(
-                            req_id, sub_field, v.data_diff, v.length));
-                    cd->logger->trace("send canvas3d_res req_id={} + '{}'", req_id,
-                                      sub_field);
+                    cd->pack(WEBCFACE_NS::Message::Res<
+                             WEBCFACE_NS::Message::Canvas3D>(
+                        req_id, sub_field, v.data_diff, v.length));
+                    cd->logger->trace("send canvas3d_res req_id={} + '{}'",
+                                      req_id, sub_field);
                 }
             });
             break;
@@ -496,8 +503,10 @@ void ClientData::onRecv(const std::string &message) {
                              "log will be romoved.",
                              store.keep_log);
             }
-            std::copy(v.log->begin(), v.log->end(),
-                      std::back_inserter(*this->log));
+            for (auto &ll : *v.log) {
+                ll.message = utf8::replace_invalid(ll.message);
+                this->log->push_back(ll);
+            }
             while (store.keep_log >= 0 &&
                    this->log->size() >
                        static_cast<unsigned int>(store.keep_log)) {
@@ -515,6 +524,18 @@ void ClientData::onRecv(const std::string &message) {
         case MessageKind::func_info: {
             auto v = std::any_cast<WEBCFACE_NS::Message::FuncInfo>(obj);
             v.member_id = this->member_id;
+            for (auto &a : *v.args) {
+                std::vector<Common::ValAdaptor> replaced_opt;
+                for (auto &o : a.option()) {
+                    replaced_opt.push_back(utf8::replace_invalid(o));
+                }
+                a = Common::Arg(utf8::replace_invalid(a.name()), a.type(),
+                                a.init()
+                                    ? std::make_optional<Common::ValAdaptor>(
+                                          utf8::replace_invalid(*a.init()))
+                                    : std::nullopt,
+                                a.min(), a.max(), replaced_opt);
+            }
             logger->debug("func_info {}", v.field);
             if (!this->func.count(v.field)) {
                 store.forEach([&](auto cd) {
@@ -663,11 +684,11 @@ void ClientData::onRecv(const std::string &message) {
             view_req[s.member][s.field] = s.req_id;
             break;
         }
-    case MessageKind::req + MessageKind::canvas3d: {
+        case MessageKind::req + MessageKind::canvas3d: {
             auto s = std::any_cast<
                 WEBCFACE_NS::Message::Req<WEBCFACE_NS::Message::Canvas3D>>(obj);
-            logger->debug("request canvas3d ({}): {} from {}", s.req_id, s.field,
-                          s.member);
+            logger->debug("request canvas3d ({}): {} from {}", s.req_id,
+                          s.field, s.member);
             // 指定した値を返す
             store.findAndDo(s.member, [&](auto cd) {
                 if (!this->hasReq(s.member)) {
@@ -679,8 +700,8 @@ void ClientData::onRecv(const std::string &message) {
                     if (it.first == s.field ||
                         it.first.starts_with(s.field + ".")) {
                         auto diff = std::make_shared<std::unordered_map<
-                            std::string,
-                            WEBCFACE_NS::Message::Canvas3D::Canvas3DComponent>>();
+                            std::string, WEBCFACE_NS::Message::Canvas3D::
+                                             Canvas3DComponent>>();
                         for (std::size_t i = 0; i < it.second.size(); i++) {
                             diff->emplace(std::to_string(i), it.second[i]);
                         }


### PR DESCRIPTION
* サーバー側でtext, log, view, funcinfo, call, callresult内の文字列に対してutf-8でデコードできないデータを置き換えるようにした
* member名、field名はチェックしない(置き換えてもどうせアクセスできないことに変わりはないから)
