### PR TITLE
remove doxygen cleanup

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -16,8 +16,6 @@ jobs:
     - uses: ssciwr/doxygen-install@v1
       with:
         version: "1.9.8"
-    - name: Delete doxygen download
-      run: rm -r doxygen-*
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y libopencv-dev libspdlog-dev
     - name: Configure CMake


### PR DESCRIPTION
ssciwr/doxygen-install がダウンロードしたdoxygenのファイルを削除するよう仕様変更されていた。