### PR TITLE
clientのインタフェース改良

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,7 +328,7 @@ endif()
 
 ###############################################################################
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-deprecated-declarations)
     add_compile_options(-Wno-psabi) # refer to PR#9
     add_compile_options( # inside opencv
         $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-enum-enum-conversion>
@@ -339,7 +339,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     )
 endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-deprecated-declarations)
     add_compile_options( # inside opencv
         -Wno-c11-extensions
         $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-enum-enum-conversion>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,7 +328,8 @@ endif()
 
 ###############################################################################
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-deprecated-declarations)
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+    add_compile_options(-Wno-error=deprecated-declarations)
     add_compile_options(-Wno-psabi) # refer to PR#9
     add_compile_options( # inside opencv
         $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-enum-enum-conversion>
@@ -339,7 +340,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     )
 endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-deprecated-declarations)
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+    add_compile_options(-Wno-error=deprecated-declarations)
     add_compile_options( # inside opencv
         -Wno-c11-extensions
         $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-enum-enum-conversion>

--- a/docs/02_member.md
+++ b/docs/02_member.md
@@ -38,7 +38,7 @@ Memberクラスから実際にそれぞれのデータにアクセスする方�
 このクライアント自身もMemberの1つですが、Client自体がMemberを継承したクラスになっているので、直接Clientのオブジェクト(wcli)に対して操作すればよいです。
 
 \note
-`member()` の引数に自身の名前を入れると、Clientオブジェクトに直接アクセスする場合と同様です。  
+`member()` の引数に自身の名前を入れると、Clientオブジェクトに直接アクセスする場合と同様そのクライアント自身を指します。  
 <span class="since-c">1.7</span> 引数に空文字列を入れても同様です。
 
 ## members
@@ -90,16 +90,20 @@ Client::onMemberEntry() で新しいメンバーが接続されたときのイ�
     wcli.onMemberEntry().appendListener([](webcface::Member m){/* ... */});
     ```
     C++では EventTarget クラスのオブジェクトを返します。
-    内部ではイベントの管理に [eventpp](https://github.com/wqking/eventpp) ライブラリを使用しており、EventTargetは eventpp::EventDispatcher のラッパーとなっています。
+    内部ではイベントの管理に [eventpp](https://github.com/wqking/eventpp) ライブラリを使用しており、EventTargetは eventpp::CallbackList のラッパーとなっています。
 
     `appendListener()`, `prependListener()` でコールバックを追加できます。
     また`insertListener()`でこれまでに追加されたコールバックのリストの途中にコールバックを挿入したり、
     `removeListener()` でコールバックを削除したりできます。
+
+    <span class="since-c">1.11</span>
+    `wcli.onMemberEntry().callbackList()` で[eventpp::CallbaskList](https://github.com/wqking/eventpp/blob/master/doc/callbacklist.md)のインスタンスが得られ、
+    CounterRemover, ConditionalRemover などeventppに用意されているさまざまなユーティリティ機能を使用できます。
     より詳細な使い方はeventppのドキュメントを参照してください。
 
-    \note eventppのEventDispatcherやCallbackListクラスにそのままアクセスできるようにはしていないため、
-    eventppのユーティリティ機能はwebcfaceのイベントに対しては使用できなくなっています
-    (todo?)
+    \note
+    ver1.10以前は eventpp::EventDispatcher を使用していたため、
+    関数名はCallbackListではなくEventDispatcherのものに従っている
 
 - <b class="tab-title">JavaScript</b>
     ```ts
@@ -147,6 +151,10 @@ Member::pingStatus() でそのクライアントの通信速度を取得でき�
         std::cout << m.name() << ": " << m.pingStatus() << " ms" << std::endl;
     });
     ```
+
+    <span class="since-c">1.11</span>
+    onMemberEntry() と同様、 callbackList() でCallbackListにアクセスできます。
+
 - <b class="tab-title">JavaScript</b>
     ```ts
     import { Member } from "webcface";

--- a/docs/02_member.md
+++ b/docs/02_member.md
@@ -100,12 +100,16 @@ Client::onMemberEntry() で新しいメンバーが接続されたときのイ�
     appendListener, prependListener ではコールバックの引数が不要な場合は引数のない関数も渡すことができます。
 
     <span class="since-c">1.11</span>
-    `wcli.onMemberEntry().callbackList()` で[eventpp::CallbaskList](https://github.com/wqking/eventpp/blob/master/doc/callbacklist.md)のインスタンスが得られ、
+    `wcli.onMemberEntry().callbackList()` で[eventpp::CallbackList](https://github.com/wqking/eventpp/blob/master/doc/callbacklist.md)のインスタンスが得られ、
     CounterRemover, ConditionalRemover などeventppに用意されているさまざまなユーティリティ機能を使用できます。
     より詳細な使い方はeventppのドキュメントを参照してください。
     (この場合コールバックの引数は省略できません)
     ```cpp
     wcli.onMemberEntry().callbackList().append([](webcface::Member m){/* ... */});
+    
+    // CounterRemoverを使って1回呼び出されたらコールバックを削除する:
+    eventpp::counterRemover(wcli.onMemberEntry().callbackList())
+        .append([](webcface::Member m){/* ... */}, 1);
     ```
 
     \note

--- a/docs/02_member.md
+++ b/docs/02_member.md
@@ -96,14 +96,21 @@ Client::onMemberEntry() で新しいメンバーが接続されたときのイ�
     また`insertListener()`でこれまでに追加されたコールバックのリストの途中にコールバックを挿入したり、
     `removeListener()` でコールバックを削除したりできます。
 
+    <span class="since-c">1.7</span>
+    appendListener, prependListener ではコールバックの引数が不要な場合は引数のない関数も渡すことができます。
+
     <span class="since-c">1.11</span>
     `wcli.onMemberEntry().callbackList()` で[eventpp::CallbaskList](https://github.com/wqking/eventpp/blob/master/doc/callbacklist.md)のインスタンスが得られ、
     CounterRemover, ConditionalRemover などeventppに用意されているさまざまなユーティリティ機能を使用できます。
     より詳細な使い方はeventppのドキュメントを参照してください。
+    (この場合コールバックの引数は省略できません)
+    ```cpp
+    wcli.onMemberEntry().callbackList().append([](webcface::Member m){/* ... */});
+    ```
 
     \note
     ver1.10以前は eventpp::EventDispatcher を使用していたため、
-    関数名はCallbackListではなくEventDispatcherのものに従っている
+    EventTargetでの関数名(appendListenerなど)はCallbackListではなくEventDispatcherのものに従っている
 
 - <b class="tab-title">JavaScript</b>
     ```ts
@@ -151,6 +158,9 @@ Member::pingStatus() でそのクライアントの通信速度を取得でき�
         std::cout << m.name() << ": " << m.pingStatus() << " ms" << std::endl;
     });
     ```
+    
+    <span class="since-c">1.7</span>
+    appendListener, prependListener ではコールバックの引数が不要な場合は引数のない関数も渡すことができます。
 
     <span class="since-c">1.11</span>
     onMemberEntry() と同様、 callbackList() でCallbackListにアクセスできます。

--- a/docs/10_value.md
+++ b/docs/10_value.md
@@ -142,6 +142,7 @@ Valueに限らず他のデータ型 ([View](./13_view.md), [Canvas2D](./14_canva
     pos["y"].value() = 2;       // = "pos.y"
     pos.value("z") = 3;         // = "pos.z"
     ```
+    FieldとValue(とTextなどその他の型)は相互にキャストすることもできます。
 
     \note <span class="since-c">1.11</span>
     child() (または`[]`)の引数が数値(または`"1"`のような文字列でも同じ)の場合、

--- a/docs/10_value.md
+++ b/docs/10_value.md
@@ -424,6 +424,15 @@ Member::valueEntries() に変更
         // ...
     }
     ```
+
+    <span class="since-c">1.11</span>
+    Field::valueEntries() でそのfield以下のvalueのみが得られます
+    (Textなど他の型についても同様)
+    ```cpp
+    std::vector<webcface::Value> values = wcli.member("foo").field("pos").valueEntries();
+    // pos.x, pos.y などのvalueが得られる
+    ```
+
 - <b class="tab-title">JavaScript</b>
     ```js
     for(const v of wcli.member("foo").values()){

--- a/docs/10_value.md
+++ b/docs/10_value.md
@@ -44,6 +44,18 @@ Client::value からValueオブジェクトを作り、 Value::set() でデー�
     wcli.value("hoge") = 5;
     ```
 
+    <span class="since-c">1.11</span>
+    valueに直接`[]`(または`child()`)で要素アクセスが可能です。
+    また、resize()で配列を初期化しpush_back()で追加する使い方もできます。
+    ```cpp
+    wcli.value("fuga").resize(5);
+    for(int i = 0; i < 5; i++){
+        wcli.value("fuga").push_back(i);
+    }
+    wcli.value("fuga")[3] = 100; // 上書き
+    // wcli.value("fuga").child(3) = 100; としても同じ
+    ```
+
 - <b class="tab-title">C</b>
     double型の単一の値は
     ```c
@@ -115,9 +127,29 @@ Valueに限らず他のデータ型 ([View](./13_view.md), [Canvas2D](./14_canva
     Value::child() でも同じ結果になります。
     ```cpp
     webcface::Value pos = wcli.value("pos");
-    pos.child("x") = 1;
-    pos.child("y") = 2;
-    pos.child("z") = 3;
+    pos.child("x") = 1; // = "pos.x"
+    pos.child("y") = 2; // = "pos.y"
+    pos.child("z") = 3; // = "pos.z"
+    ```
+
+    <span class="since-c">1.11</span>
+    Member::child() で webcface::Field 型としてオブジェクトが得られ、そこからvalue()でValue型に変換することもできます。
+    (この場合はValue以外の型に変換することもでき汎用性が高いです)
+    また、`[]`を使ってもchild()と同じ結果になります。
+    ```cpp
+    webcface::Field pos = wcli.child("pos");
+    pos.child("x").value() = 1; // = "pos.x"
+    pos["y"].value() = 2;       // = "pos.y"
+    pos.value("z") = 3;         // = "pos.z"
+    ```
+
+    \note <span class="since-c">1.11</span>
+    child() (または`[]`)の引数が数値(または`"1"`のような文字列でも同じ)の場合、
+    グループ化ではなく配列としての値代入が優先されます。
+    (これはValue型のみの特別な処理です。)
+    ただし以下のような場合は通常の文字列と同様に処理します。
+    ```cpp
+    wcli.value("data")[0]["a"] = 1; // value("data.0.a") = 1
     ```
 
 - <b class="tab-title">C</b>
@@ -169,37 +201,6 @@ Pythonの辞書型への対応は未実装
 
 <div class="tabbed">
 
-- <b class="tab-title">C++</b>
-    webcface::Value::Dict オブジェクトを使うと複数の値をまとめて送ることができます。
-    これは構造体などのデータを送るときに使えます
-    ```cpp
-    struct A {
-        double x, y;
-        operator webcface::Value::Dict() const {
-            return {
-                {"x", x},
-                {"y", y},
-                {"vec", {1, 2, 3}}, // vectorも入れられます
-                {"a", {             // 入れ子にもできます
-                    {"a", 1},
-                    {"b", 1},
-                }}
-            }
-        }
-    };
-
-    A a_instance;
-    wcli.value("a").set(a_instance); // Dictにキャストされる
-
-    /* 結果は以下のようになる
-      value("a.x") -> a_instance.x
-      value("a.y") -> a_instance.y
-      value("a.vec") -> {1, 2, 3}
-      value("a.a.a") -> 1
-      value("a.a.b") -> 1
-    */
-    ```
-
 - <b class="tab-title">JavaScript</b>
     オブジェクトを渡すことができます。
     ```ts
@@ -223,6 +224,40 @@ Pythonの辞書型への対応は未実装
 
 </div>
 
+<details><summary>(deprecated) C++でwebcface::Value::Dictを使った値のセット</summary>
+
+webcface::Value::Dict オブジェクトを使うと複数の値をまとめて送ることができます。
+これは構造体などのデータを送るときに使えます
+```cpp
+struct A {
+    double x, y;
+    operator webcface::Value::Dict() const {
+        return {
+            {"x", x},
+            {"y", y},
+            {"vec", {1, 2, 3}}, // vectorも入れられます
+            {"a", {             // 入れ子にもできます
+                {"a", 1},
+                {"b", 1},
+            }}
+        }
+    }
+};
+
+A a_instance;
+wcli.value("a").set(a_instance); // Dictにキャストされる
+
+/* 結果は以下のようになる
+  value("a.x") -> a_instance.x
+  value("a.y") -> a_instance.y
+  value("a.vec") -> {1, 2, 3}
+  value("a.a.a") -> 1
+  value("a.a.b") -> 1
+*/
+```
+
+</details>
+
 ## 受信
 
 Member::value() でValueクラスのオブジェクトが得られ、
@@ -236,18 +271,36 @@ Value::tryGet(), Value::tryGetVec() などで値のリクエストをすると�
     ```cpp
     std::optional<double> hoge = wcli.member("foo").value("hoge").tryGet();
     std::optional<std::vector<double>> hoge = wcli.member("foo").value("hoge").tryGetVec();
-    std::optional<webcface::Value::Dict> hoge = wcli.member("foo").value("hoge").tryGetRecurse();
     ```
-    初回の呼び出しではまだ受信していないため、
-    tryGet(), tryGetVec(), tryGetRecurse() はstd::nulloptを返します。  
-    get(), getVec(), getRecurse() はstd::nulloptの代わりにデフォルト値を返します。  
-    また、doubleやstd::vector<double>, Value::Dict などの型にキャストすることでも同様に値が得られます。
+    値を受信していない場合 tryGet(), tryGetVec() はstd::nulloptを返します。  
+    get(), getVec() はstd::nulloptの代わりにデフォルト値を返します。  
+    また、doubleやstd::vector<double> などの型にキャストすることでも同様に値が得られます。
 
     <span class="since-c">1.8</span>
     std::ostreamにValueを直接渡して表示することもできます。
     まだ受信していない場合nullと表示されます。
     ```cpp
     std::cout << "hoge = " << wcli.member("foo").value("hoge") << std::endl;
+    ```
+
+    グループ化したデータは送信時と同様child()を使って要素を参照できます。
+    ```cpp
+    webcface::Value pos = wcli.member("foo").value("pos");
+    double x = pos.child("x").get(); // = "pos.x"
+    double y = pos.child("y").get(); // = "pos.y"
+    double z = pos.child("z").get(); // = "pos.z"
+    ```
+    ```cpp
+    webcface::Field pos = wcli.member("foo").child("pos");
+    double x = pos.child("x").value().get(); // = "pos.x"
+    double y = pos["y"].value().get();       // = "pos.y"
+    double z = pos.value("z").get();         // = "pos.z"
+    ```
+
+    <span class="since-c">1.11</span>
+    送信時と同様、配列データはchild()または`[]`を使ってもアクセスできます。
+    ```cpp
+    double hoge = wcli.member("foo").value("hoge")[3].get();
     ```
 
     \warning
@@ -269,7 +322,7 @@ Value::tryGet(), Value::tryGetVec() などで値のリクエストをすると�
     ```
     sizeに受信した値の個数、valueに受信した値が入ります。
 
-    初回の呼び出しでは`WCF_NOT_FOUND`を返し、別スレッドでリクエストが送信されます。
+    値を受信していない場合`WCF_NOT_FOUND`を返し、別スレッドでリクエストが送信されます。
     
     <span class="since-c">1.7</span>
     1つの値のみを受信する場合はwcfValueGetも使えます。
@@ -285,25 +338,25 @@ Value::tryGet(), Value::tryGetVec() などで値のリクエストをすると�
     const hoge: double | null = wcli.member("foo").value("hoge").tryGet();
     const hoge: double[] | null = wcli.member("foo").value("hoge").tryGetVec();
     ```
-    初回の呼び出しではまだ受信していないため、
-    tryGet(), tryGetVec() はnullを返します。  
+    値を受信していない場合 tryGet(), tryGetVec() はnullを返します。  
     get(), getVec() はnullの代わりにデフォルト値を返します。
 - <b class="tab-title">Python</b>
     ```python
     hoge = wcli.member("foo").value("hoge").try_get()
     hoge = wcli.member("foo").value("hoge").try_get_vec()
     ```
-    初回の呼び出しではまだ受信していないため、
-    try_get(), try_get_vec() はNoneを返します。  
+    値を受信していない場合 try_get(), try_get_vec() はNoneを返します。  
     get(), getVec() はNoneの代わりにデフォルト値を返します。
 
 </div>
 
-~~その後Client::sync()したときに実際にリクエストが送信され、~~  
+### リクエスト
+get()などの初回の呼び出しではまだ値を受信していないためnullなどを返しますが、  
+~~Client::sync()したときに実際にリクエストが送信され、~~  
 <span class="since-c">1.2</span>
 <span class="since-js">1.1</span>
 <span class="since-py"></span>
-自動的に別スレッドでリクエストが送信され、それ以降は値が得られるようになります。
+自動的に別スレッドでリクエストが送信され、サーバーから値が返ってきたら値が得られるようになります。
 そのため、次の例のように繰り返し取得して使ってください。
 
 <div class="tabbed">
@@ -356,8 +409,6 @@ Value::request()で明示的にリクエストを送信することもできま�
 Member::syncTime() に変更
 (Textなど他のデータの送信時刻と共通です)
 
-\todo JavaScriptでもMember.syncTimeに統一する
-
 ### Entry
 
 ~~Member::values() で~~ そのMemberが送信しているvalueのリストが得られます  
@@ -394,7 +445,7 @@ Member::onValueEntry() で新しくデータが追加されたときのコール
 Member名がわかっていれば初回の Client::sync() 前に、
 そうでなければ Client::onMemberEntry() イベントのコールバックの中で各種イベントを設定すればよいです。
 
-イベントの詳細な使い方は [Member](./02_member.md) のページを参照してください。
+イベントの詳細な使い方はonMemberEntryと同様です([Member](./02_member.md) のページを参照してください)。
 
 <div class="tabbed">
 
@@ -423,7 +474,7 @@ Member名がわかっていれば初回の Client::sync() 前に、
 
 また、データが変化したどうかに関わらずそのMemberがsync()したときにコールバックを呼び出したい場合は Member::onSync() が使えます。
 
-イベントの詳細な使い方は [Member](./02_member.md) のページを参照してください。
+イベントの詳細な使い方はonMemberEntryと同様です([Member](./02_member.md) のページを参照してください)。
 
 <div class="tabbed">
 

--- a/docs/13_view.md
+++ b/docs/13_view.md
@@ -136,6 +136,20 @@ Viewに追加する各種要素をViewComponentといいます。
     各要素はそれぞれの関数から webcface::ViewComponent または webcface::TemporalComponent のオブジェクトとして得られます。
     `button(...).textColor(...)` などのようにメソッドチェーンすることで各要素にオプションを設定できます。
 
+    <span class="since-c">1.11</span>
+    引数にViewを取る関数オブジェクトをViewに渡すと、その場でその関数が呼び出されます。
+    複数のViewComponentを出力する処理をまとめて使いまわしたい場合に便利です。
+    ```cpp
+    auto showNameAndValue(const std::string &name, int value) {
+        return [=](webcface::View &view) {
+            view << name << " = " << value;
+        };
+    }
+
+    webcface::View v = wcli.view("a");
+    v << showNameAndValue("foo", 123) << std::endl; // v << "foo = 123";
+    v.sync();
+    ```
 
 - <b class="tab-title">JavaScript</b>
     JavaScriptでは [`viewComponents`](https://na-trium-144.github.io/webcface-js/variables/viewComponents.html) オブジェクト内にそれぞれの要素を表す関数があります
@@ -425,6 +439,11 @@ viewに入力欄を表示します。
     この場合はv.sync()の時に前周期のinput_valの内容が復元されるという挙動になります。
     (したがってv.sync()より前では値が未初期化になります)
 
+    InputRefの値は`get()`で webcface::ValAdaptor 型として取得できます。
+    また std::string, double, bool などの型にキャストすることでも値を得られます。  
+    <span class="since-c">1.11</span>
+    `asStringRef()`, `asString()`, `as<double>()`, `asBool()` でも型変換ができます。
+
     \note
     内部の実装では入力値を受け取りInputRefに値をセットする関数をonChangeにセットしています。
     また、InputRefの値は[Text](./11_text.md)の1つとしてviewを表示しているクライアントに送信されます。
@@ -437,6 +456,8 @@ viewに入力欄を表示します。
         std::cout << "input changed: " << val << std::endl;
     });
     ```
+
+    \note bindとonChangeを両方設定することはできません。
 
     その他各種inputに指定できるオプションには以下のものがあります。
     ([Func](./30_func.md)のArgオプションと同様です。)

--- a/docs/30_func.md
+++ b/docs/30_func.md
@@ -317,6 +317,8 @@ Func::run() で関数を実行できます。引数を渡すこともでき、�
 
 実行した関数が例外を投げた場合、また引数の個数が一致しない場合などはrun()が例外を投げます。
 
+対象のクライアントと通信できない場合、また指定した関数が存在しない場合は webcface::FuncNotFoundError を投げます。
+
 \note 引数の型が違う場合、関数登録時に指定した型に自動的に変換されてから呼び出されます。
 (ver1.5.3〜1.9.0のserverではすべて文字列型に置き換えられてしまうバグあり、ver1.9.1で修正)  
 変換は受信側のライブラリで行われ、基本的にその言語仕様に従って変換します  
@@ -382,13 +384,26 @@ AsyncFuncResultからは started と result が取得できます。
 
     <span class="since-c">1.11</span>
     `onStarted()`, `onResult()` で値が返ってきたときに実行されるイベントが取得でき、コールバックを設定することができます。
-    ([eventpp::CallbackList 型](https://github.com/wqking/eventpp/blob/master/doc/callbacklist.md)で返ります)
+    ([eventpp::CallbackList 型](https://github.com/wqking/eventpp/blob/master/doc/callbacklist.md)の参照で返ります)  
     ```cpp
     AsyncFuncResult res = wcli.member("foo").func("hoge").runAsync(1, "aa");
+    res.onStarted().append([](bool started){
+        std::cout << "func hoge() " << started ? "started" : "not started" << std::endl;
+    });
     res.onResult().append([](std::shared_future<webcface::ValAdaptor> result){
-        double ans = result.get();
+        try{
+            double ans = result.get();
+        }catch(const std::exception &e){
+            std::cout << e.what() << std::endl;
+        }
     });
     ```
+    \warning
+    onStartedではコールバックの引数は`bool`,
+    onResultではコールバックの引数は`std::shared_future<webcface::ValAdaptor>`です。
+    関数の呼び出しに失敗した場合や呼び出した関数の結果がエラーだった場合resultのshared_futureは例外を投げるので、
+    上の例のように必ずtry〜catchを使用してください。
+    (例外がcatchされなかった場合terminateしてしまいます)
 
     詳細は webcface::AsyncFuncResult を参照してください。
 

--- a/docs/30_func.md
+++ b/docs/30_func.md
@@ -380,6 +380,16 @@ AsyncFuncResultからは started と result が取得できます。
     ```
     startedとresultはstd::shared_futureです。取得できるまで待機するならget(), ブロックせず完了したか確認したければwait_for()などが使えます。例外はresult.get()が投げます。
 
+    <span class="since-c">1.11</span>
+    `onStarted()`, `onResult()` で値が返ってきたときに実行されるイベントが取得でき、コールバックを設定することができます。
+    ([eventpp::CallbackList 型](https://github.com/wqking/eventpp/blob/master/doc/callbacklist.md)で返ります)
+    ```cpp
+    AsyncFuncResult res = wcli.member("foo").func("hoge").runAsync(1, "aa");
+    res.onResult().append([](std::shared_future<webcface::ValAdaptor> result){
+        double ans = result.get();
+    });
+    ```
+
     詳細は webcface::AsyncFuncResult を参照してください。
 
 - <b class="tab-title">C</b>

--- a/src/client/canvas2d.cc
+++ b/src/client/canvas2d.cc
@@ -12,9 +12,11 @@ Canvas2D::Canvas2D()
     : Field(), EventTarget<Canvas2D>(),
       sb(std::make_shared<Internal::Canvas2DDataBuf>()) {}
 Canvas2D::Canvas2D(const Field &base)
-    : Field(base),
-      EventTarget<Canvas2D>(&this->dataLock()->canvas2d_change_event, *this),
-      sb(std::make_shared<Internal::Canvas2DDataBuf>(base)) {}
+    : Field(base), EventTarget<Canvas2D>(),
+      sb(std::make_shared<Internal::Canvas2DDataBuf>(base)) {
+    std::lock_guard lock(this->dataLock()->event_m);
+    this->cl = &this->dataLock()->canvas2d_change_event[*this];
+}
 Canvas2D &Canvas2D::init(double width, double height) {
     sb->init(width, height);
     return *this;

--- a/src/client/canvas3d.cc
+++ b/src/client/canvas3d.cc
@@ -12,9 +12,11 @@ Canvas3D::Canvas3D()
     : Field(), EventTarget<Canvas3D>(),
       sb(std::make_shared<Internal::DataSetBuffer<Canvas3DComponent>>()) {}
 Canvas3D::Canvas3D(const Field &base)
-    : Field(base), EventTarget<Canvas3D>(
-                       &this->dataLock()->canvas3d_change_event, *this),
-      sb(std::make_shared<Internal::DataSetBuffer<Canvas3DComponent>>(base)) {}
+    : Field(base), EventTarget<Canvas3D>(),
+      sb(std::make_shared<Internal::DataSetBuffer<Canvas3DComponent>>(base)) {
+    std::lock_guard lock(this->dataLock()->event_m);
+    this->cl = &this->dataLock()->canvas3d_change_event[*this];
+}
 Canvas3D &Canvas3D::init() {
     sb->init();
     return *this;
@@ -33,7 +35,7 @@ Canvas3D &Canvas3D::operator<<(Canvas3DComponent &&cc) {
 }
 
 template <>
-void Internal::DataSetBuffer<Canvas3DComponent>::onSync(){
+void Internal::DataSetBuffer<Canvas3DComponent>::onSync() {
     auto cb = std::make_shared<std::vector<Canvas3DComponentBase>>();
     cb->reserve(components_.size());
     for (std::size_t i = 0; i < components_.size(); i++) {

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -646,7 +646,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
                 webcface::Message::Entry<webcface::Message::Value>>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->value_store.setEntry(member, r.field);
-            CallbackList *cl;
+            CallbackList *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->value_entry_event.count(member)) {
@@ -663,7 +663,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
                 webcface::Message::Entry<webcface::Message::Text>>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->text_store.setEntry(member, r.field);
-            CallbackList *cl;
+            CallbackList *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->text_entry_event.count(member)) {
@@ -680,7 +680,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
                 webcface::Message::Entry<webcface::Message::View>>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->view_store.setEntry(member, r.field);
-            CallbackList *cl;
+            CallbackList *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->view_entry_event.count(member)) {
@@ -697,7 +697,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
                 webcface::Message::Entry<webcface::Message::Canvas3D>>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->canvas3d_store.setEntry(member, r.field);
-            CallbackList *cl;
+            CallbackList *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->canvas3d_entry_event.count(member)) {
@@ -714,7 +714,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
                 webcface::Message::Entry<webcface::Message::Canvas2D>>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->canvas2d_store.setEntry(member, r.field);
-            CallbackList *cl;
+            CallbackList *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->canvas2d_entry_event.count(member)) {
@@ -731,7 +731,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
                 webcface::Message::Entry<webcface::Message::RobotModel>>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->robot_model_store.setEntry(member, r.field);
-            CallbackList *cl;
+            CallbackList *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->robot_model_entry_event.count(member)) {
@@ -748,7 +748,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
                 webcface::Message::Entry<webcface::Message::Image>>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->image_store.setEntry(member, r.field);
-            CallbackList *cl;
+            CallbackList *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->image_entry_event.count(member)) {
@@ -766,7 +766,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
             this->func_store.setEntry(member, r.field);
             this->func_store.setRecv(member, r.field,
                                      std::make_shared<FuncInfo>(r));
-            CallbackList *cl;
+            CallbackList *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->func_entry_event.count(member)) {
@@ -810,7 +810,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
         }
     }
     for (const auto &m : sync_members) {
-        CallbackList *cl;
+        CallbackList *cl = nullptr;
         {
             std::lock_guard lock(event_m);
             if (this->sync_event.count(m)) {

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -88,9 +88,9 @@ std::vector<Member> Client::members() {
     }
     return ret;
 }
-EventTarget<Member, int> Client::onMemberEntry() {
+EventTarget<Member> Client::onMemberEntry() {
     std::lock_guard lock(data->event_m);
-    return EventTarget<Member, int>{&data->member_entry_event};
+    return EventTarget<Member>{&data->member_entry_event};
 }
 void Client::setDefaultRunCond(FuncWrapperType wrapper) {
     data->default_func_wrapper = wrapper;
@@ -331,7 +331,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
             auto r = std::any_cast<webcface::Message::PingStatus>(obj);
             this->ping_status = r.status;
             for (const auto &member_name : value_store.getMembers()) {
-                CallbackList *cl = nullptr;
+                eventpp::CallbackList<void(Member)> *cl = nullptr;
                 {
                     std::lock_guard lock(event_m);
                     if (this->ping_event.count(member_name)) {
@@ -360,7 +360,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
             this->value_store.setRecv(
                 member, field,
                 std::static_pointer_cast<VectorOpt<double>>(r.data));
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(Value)> *cl = nullptr;
             FieldBaseComparable key{member, field};
             {
                 std::lock_guard lock(event_m);
@@ -380,7 +380,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
             auto [member, field] =
                 this->text_store.getReq(r.req_id, r.sub_field);
             this->text_store.setRecv(member, field, r.data);
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(Text)> *cl = nullptr;
             FieldBaseComparable key{member, field};
             {
                 std::lock_guard lock(event_m);
@@ -399,7 +399,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
             auto [member, field] =
                 this->robot_model_store.getReq(r.req_id, r.sub_field);
             this->robot_model_store.setRecv(member, field, r.commonLinks());
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(RobotModel)> *cl = nullptr;
             FieldBaseComparable key{member, field};
             {
                 std::lock_guard lock(event_m);
@@ -429,7 +429,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
             for (const auto &d : *r.data_diff) {
                 (**v_prev)[std::stoi(d.first)] = d.second;
             }
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(View)> *cl = nullptr;
             FieldBaseComparable key{member, field};
             {
                 std::lock_guard lock(event_m);
@@ -458,7 +458,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
             for (const auto &d : *r.data_diff) {
                 (**v_prev)[std::stoi(d.first)] = d.second;
             }
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(Canvas3D)> *cl = nullptr;
             FieldBaseComparable key{member, field};
             {
                 std::lock_guard lock(event_m);
@@ -488,7 +488,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
             for (const auto &d : *r.data_diff) {
                 (*v_prev)->components[std::stoi(d.first)] = d.second;
             }
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(Canvas2D)> *cl = nullptr;
             FieldBaseComparable key{member, field};
             {
                 std::lock_guard lock(event_m);
@@ -508,7 +508,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
             auto [member, field] =
                 this->image_store.getReq(r.req_id, r.sub_field);
             this->image_store.setRecv(member, field, r);
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(Image)> *cl = nullptr;
             FieldBaseComparable key{member, field};
             {
                 std::lock_guard lock(event_m);
@@ -533,7 +533,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
             for (const auto &lm : *r.log) {
                 (*log_s)->push_back(lm);
             }
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(Log)> *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->log_append_event.count(member)) {
@@ -646,7 +646,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
                 webcface::Message::Entry<webcface::Message::Value>>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->value_store.setEntry(member, r.field);
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(Value)> *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->value_entry_event.count(member)) {
@@ -663,7 +663,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
                 webcface::Message::Entry<webcface::Message::Text>>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->text_store.setEntry(member, r.field);
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(Text)> *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->text_entry_event.count(member)) {
@@ -680,7 +680,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
                 webcface::Message::Entry<webcface::Message::View>>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->view_store.setEntry(member, r.field);
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(View)> *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->view_entry_event.count(member)) {
@@ -697,7 +697,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
                 webcface::Message::Entry<webcface::Message::Canvas3D>>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->canvas3d_store.setEntry(member, r.field);
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(Canvas3D)> *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->canvas3d_entry_event.count(member)) {
@@ -714,7 +714,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
                 webcface::Message::Entry<webcface::Message::Canvas2D>>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->canvas2d_store.setEntry(member, r.field);
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(Canvas2D)> *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->canvas2d_entry_event.count(member)) {
@@ -731,7 +731,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
                 webcface::Message::Entry<webcface::Message::RobotModel>>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->robot_model_store.setEntry(member, r.field);
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(RobotModel)> *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->robot_model_entry_event.count(member)) {
@@ -748,7 +748,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
                 webcface::Message::Entry<webcface::Message::Image>>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->image_store.setEntry(member, r.field);
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(Image)> *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->image_entry_event.count(member)) {
@@ -766,7 +766,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
             this->func_store.setEntry(member, r.field);
             this->func_store.setRecv(member, r.field,
                                      std::make_shared<FuncInfo>(r));
-            CallbackList *cl = nullptr;
+            eventpp::CallbackList<void(Func)> *cl = nullptr;
             {
                 std::lock_guard lock(event_m);
                 if (this->func_entry_event.count(member)) {
@@ -810,7 +810,7 @@ void Internal::ClientData::onRecv(const std::string &message) {
         }
     }
     for (const auto &m : sync_members) {
-        CallbackList *cl = nullptr;
+        eventpp::CallbackList<void(Member)> *cl = nullptr;
         {
             std::lock_guard lock(event_m);
             if (this->sync_event.count(m)) {

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <atomic>
 #include <unordered_map>
+#include <map>
 #include <cstdlib>
 #include <eventpp/eventdispatcher.h>
 #include <spdlog/logger.h>
@@ -164,14 +165,15 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
         return 0;
     }
 
-    eventpp::EventDispatcher<FieldBaseComparable, void(Field)>
-        value_change_event, text_change_event, view_change_event,
-        image_change_event, robot_model_change_event, canvas3d_change_event,
-        canvas2d_change_event;
-    eventpp::EventDispatcher<std::string, void(Field)> log_append_event;
-    eventpp::EventDispatcher<int, void(Field)> member_entry_event;
-    eventpp::EventDispatcher<std::string, void(Field)> sync_event,
-        value_entry_event, text_entry_event, func_entry_event, view_entry_event,
+    std::mutex event_m;
+    using CallbackList = eventpp::CallbackList<void(Field)>;
+    std::map<FieldBaseComparable, CallbackList> value_change_event,
+        text_change_event, view_change_event, image_change_event,
+        robot_model_change_event, canvas3d_change_event, canvas2d_change_event;
+    std::unordered_map<std::string, CallbackList> log_append_event;
+    CallbackList member_entry_event;
+    std::unordered_map<std::string, CallbackList> sync_event, value_entry_event,
+        text_entry_event, func_entry_event, view_entry_event,
         robot_model_entry_event, image_entry_event, canvas3d_entry_event,
         canvas2d_entry_event, ping_event;
 

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -166,16 +166,41 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
     }
 
     std::mutex event_m;
-    using CallbackList = eventpp::CallbackList<void(Field)>;
-    std::map<FieldBaseComparable, CallbackList> value_change_event,
-        text_change_event, view_change_event, image_change_event,
-        robot_model_change_event, canvas3d_change_event, canvas2d_change_event;
-    std::unordered_map<std::string, CallbackList> log_append_event;
-    CallbackList member_entry_event;
-    std::unordered_map<std::string, CallbackList> sync_event, value_entry_event,
-        text_entry_event, func_entry_event, view_entry_event,
-        robot_model_entry_event, image_entry_event, canvas3d_entry_event,
-        canvas2d_entry_event, ping_event;
+    std::map<FieldBaseComparable, eventpp::CallbackList<void(Value)>>
+        value_change_event;
+    std::map<FieldBaseComparable, eventpp::CallbackList<void(Text)>>
+        text_change_event;
+    std::map<FieldBaseComparable, eventpp::CallbackList<void(Image)>>
+        image_change_event;
+    std::map<FieldBaseComparable, eventpp::CallbackList<void(RobotModel)>>
+        robot_model_change_event;
+    std::map<FieldBaseComparable, eventpp::CallbackList<void(View)>>
+        view_change_event;
+    std::map<FieldBaseComparable, eventpp::CallbackList<void(Canvas3D)>>
+        canvas3d_change_event;
+    std::map<FieldBaseComparable, eventpp::CallbackList<void(Canvas2D)>>
+        canvas2d_change_event;
+    std::unordered_map<std::string, eventpp::CallbackList<void(Log)>>
+        log_append_event;
+    eventpp::CallbackList<void(Member)> member_entry_event;
+    std::unordered_map<std::string, eventpp::CallbackList<void(Member)>>
+        sync_event, ping_event;
+    std::unordered_map<std::string, eventpp::CallbackList<void(Value)>>
+        value_entry_event;
+    std::unordered_map<std::string, eventpp::CallbackList<void(Text)>>
+        text_entry_event;
+    std::unordered_map<std::string, eventpp::CallbackList<void(Func)>>
+        func_entry_event;
+    std::unordered_map<std::string, eventpp::CallbackList<void(View)>>
+        view_entry_event;
+    std::unordered_map<std::string, eventpp::CallbackList<void(Image)>>
+        image_entry_event;
+    std::unordered_map<std::string, eventpp::CallbackList<void(RobotModel)>>
+        robot_model_entry_event;
+    std::unordered_map<std::string, eventpp::CallbackList<void(Canvas3D)>>
+        canvas3d_entry_event;
+    std::unordered_map<std::string, eventpp::CallbackList<void(Canvas2D)>>
+        canvas2d_entry_event;
 
     /*!
      * \brief sync()のタイミングで実行を同期する関数のcondition_variable

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <atomic>
 #include <unordered_map>
+#include <unordered_set>
 #include <map>
 #include <cstdlib>
 #include <eventpp/eventdispatcher.h>
@@ -125,6 +126,8 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
      */
     WEBCFACE_DLL void onRecv(const std::string &message);
 
+    std::mutex entry_m;
+    std::unordered_set<std::string> member_entry;
     SyncDataStore2<ValueData> value_store;
     SyncDataStore2<TextData> text_store;
     SyncDataStore2<FuncData> func_store;

--- a/src/client/data_store2.cc
+++ b/src/client/data_store2.cc
@@ -38,35 +38,26 @@ void SyncDataStore2<T, ReqT>::setRecv(const std::string &from,
 }
 
 template <typename T, typename ReqT>
-std::vector<std::string> SyncDataStore2<T, ReqT>::getMembers() {
-    std::lock_guard lock(mtx);
-    std::vector<std::string> k;
-    for (const auto &r : entry) {
-        k.push_back(r.first);
-    }
-    return k;
-}
-template <typename T, typename ReqT>
-std::vector<std::string>
+std::unordered_set<std::string>
 SyncDataStore2<T, ReqT>::getEntry(const std::string &name) {
     std::lock_guard lock(mtx);
     auto e = entry.find(name);
     if (e != entry.end()) {
         return e->second;
     } else {
-        return std::vector<std::string>{};
+        return std::unordered_set<std::string>{};
     }
 }
 template <typename T, typename ReqT>
-void SyncDataStore2<T, ReqT>::setEntry(const std::string &from) {
+void SyncDataStore2<T, ReqT>::clearEntry(const std::string &from) {
     std::lock_guard lock(mtx);
-    entry.emplace(std::make_pair(from, std::vector<std::string>{}));
+    entry[from].clear();
 }
 template <typename T, typename ReqT>
 void SyncDataStore2<T, ReqT>::setEntry(const std::string &from,
                                        const std::string &e) {
     std::lock_guard lock(mtx);
-    entry[from].push_back(e);
+    entry[from].emplace(e);
 }
 
 template <typename T, typename ReqT>

--- a/src/client/data_store2.cc
+++ b/src/client/data_store2.cc
@@ -212,7 +212,7 @@ SyncDataStore2<T, ReqT>::transferSend(bool is_first) {
         return data_send_prev = recv_self;
     } else {
         data_send_prev = send_changed;
-        return std::move(send_changed);
+        return send_changed;
     }
 }
 template <typename T, typename ReqT>

--- a/src/client/data_store2.h
+++ b/src/client/data_store2.h
@@ -41,6 +41,9 @@ class SyncDataStore2 {
      *
      * data_recv[member名][データ名] = 値
      *
+     * ver1.11〜 setSend時には上書きされず、transferSendで上書きされる
+     * それまでの間はgetRecvはdata_recvではなくdata_sendを優先的に読むようにする
+     *
      */
     std::unordered_map<std::string, std::unordered_map<std::string, T>>
         data_recv;

--- a/src/client/data_store2.h
+++ b/src/client/data_store2.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <mutex>
 #include <unordered_map>
+#include <unordered_set>
 #include <string>
 #include <optional>
 #include <functional>
@@ -53,7 +54,7 @@ class SyncDataStore2 {
      * entry[member名] = {データ名のリスト}
      *
      */
-    std::unordered_map<std::string, std::vector<std::string>> entry;
+    std::unordered_map<std::string, std::unordered_set<std::string>> entry;
     /*!
      * \brief データ受信リクエスト
      *
@@ -175,11 +176,11 @@ class SyncDataStore2 {
     }
 
     /*!
-     * \brief entryにmember名のみ追加
+     * \brief memberのentryをクリア
      *
-     *  ambiguousなので引数にFieldBaseは使わない (そもそも必要ない)
+     * ambiguousなので引数にFieldBaseは使わない (そもそも必要ない)
      */
-    void setEntry(const std::string &from);
+    void clearEntry(const std::string &from);
     /*!
      * \brief 受信したentryを追加
      *
@@ -190,15 +191,10 @@ class SyncDataStore2 {
      * \brief entryを取得
      *
      */
-    std::vector<std::string> getEntry(const std::string &from);
-    std::vector<std::string> getEntry(const FieldBase &base) {
+    std::unordered_set<std::string> getEntry(const std::string &from);
+    std::unordered_set<std::string> getEntry(const FieldBase &base) {
         return getEntry(base.member_);
     }
-    /*!
-     * \brief member名のりすとを取得(entryから)
-     *
-     */
-    std::vector<std::string> getMembers();
 
     /*!
      * \brief req_idに対応するmember名とフィールド名を返す

--- a/src/client/field.cc
+++ b/src/client/field.cc
@@ -55,10 +55,10 @@ Canvas2D Field::canvas2D(std::string_view field) const { return child(field); }
 std::vector<Value> Field::valueEntries() const {
     auto keys = dataLock()->value_store.getEntry(*this);
     std::vector<Value> ret;
-    for (std::size_t i = 0; i < keys.size(); i++) {
+    for (const auto &f : keys) {
         if (this->field_.empty() ||
-            keys[i].starts_with(this->field_ + field_separator)) {
-            ret.push_back(value(keys[i]));
+            f.starts_with(this->field_ + field_separator)) {
+            ret.push_back(value(f));
         }
     }
     return ret;
@@ -66,10 +66,10 @@ std::vector<Value> Field::valueEntries() const {
 std::vector<Text> Field::textEntries() const {
     auto keys = dataLock()->text_store.getEntry(*this);
     std::vector<Text> ret;
-    for (std::size_t i = 0; i < keys.size(); i++) {
+    for (const auto &f : keys) {
         if (this->field_.empty() ||
-            keys[i].starts_with(this->field_ + field_separator)) {
-            ret.push_back(text(keys[i]));
+            f.starts_with(this->field_ + field_separator)) {
+            ret.push_back(text(f));
         }
     }
     return ret;
@@ -77,10 +77,10 @@ std::vector<Text> Field::textEntries() const {
 std::vector<RobotModel> Field::robotModelEntries() const {
     auto keys = dataLock()->robot_model_store.getEntry(*this);
     std::vector<RobotModel> ret;
-    for (std::size_t i = 0; i < keys.size(); i++) {
+    for (const auto &f : keys) {
         if (this->field_.empty() ||
-            keys[i].starts_with(this->field_ + field_separator)) {
-            ret.push_back(robotModel(keys[i]));
+            f.starts_with(this->field_ + field_separator)) {
+            ret.push_back(robotModel(f));
         }
     }
     return ret;
@@ -88,10 +88,10 @@ std::vector<RobotModel> Field::robotModelEntries() const {
 std::vector<Func> Field::funcEntries() const {
     auto keys = dataLock()->func_store.getEntry(*this);
     std::vector<Func> ret;
-    for (std::size_t i = 0; i < keys.size(); i++) {
+    for (const auto &f : keys) {
         if (this->field_.empty() ||
-            keys[i].starts_with(this->field_ + field_separator)) {
-            ret.push_back(func(keys[i]));
+            f.starts_with(this->field_ + field_separator)) {
+            ret.push_back(func(f));
         }
     }
     return ret;
@@ -99,10 +99,10 @@ std::vector<Func> Field::funcEntries() const {
 std::vector<View> Field::viewEntries() const {
     auto keys = dataLock()->view_store.getEntry(*this);
     std::vector<View> ret;
-    for (std::size_t i = 0; i < keys.size(); i++) {
+    for (const auto &f : keys) {
         if (this->field_.empty() ||
-            keys[i].starts_with(this->field_ + field_separator)) {
-            ret.push_back(view(keys[i]));
+            f.starts_with(this->field_ + field_separator)) {
+            ret.push_back(view(f));
         }
     }
     return ret;
@@ -110,10 +110,10 @@ std::vector<View> Field::viewEntries() const {
 std::vector<Canvas3D> Field::canvas3DEntries() const {
     auto keys = dataLock()->canvas3d_store.getEntry(*this);
     std::vector<Canvas3D> ret;
-    for (std::size_t i = 0; i < keys.size(); i++) {
+    for (const auto &f : keys) {
         if (this->field_.empty() ||
-            keys[i].starts_with(this->field_ + field_separator)) {
-            ret.push_back(canvas3D(keys[i]));
+            f.starts_with(this->field_ + field_separator)) {
+            ret.push_back(canvas3D(f));
         }
     }
     return ret;
@@ -121,10 +121,10 @@ std::vector<Canvas3D> Field::canvas3DEntries() const {
 std::vector<Canvas2D> Field::canvas2DEntries() const {
     auto keys = dataLock()->canvas2d_store.getEntry(*this);
     std::vector<Canvas2D> ret;
-    for (std::size_t i = 0; i < keys.size(); i++) {
+    for (const auto &f : keys) {
         if (this->field_.empty() ||
-            keys[i].starts_with(this->field_ + field_separator)) {
-            ret.push_back(canvas2D(keys[i]));
+            f.starts_with(this->field_ + field_separator)) {
+            ret.push_back(canvas2D(f));
         }
     }
     return ret;
@@ -132,10 +132,10 @@ std::vector<Canvas2D> Field::canvas2DEntries() const {
 std::vector<Image> Field::imageEntries() const {
     auto keys = dataLock()->image_store.getEntry(*this);
     std::vector<Image> ret;
-    for (std::size_t i = 0; i < keys.size(); i++) {
+    for (const auto &f : keys) {
         if (this->field_.empty() ||
-            keys[i].starts_with(this->field_ + field_separator)) {
-            ret.push_back(image(keys[i]));
+            f.starts_with(this->field_ + field_separator)) {
+            ret.push_back(image(f));
         }
     }
     return ret;

--- a/src/client/field.cc
+++ b/src/client/field.cc
@@ -1,11 +1,28 @@
 #include <webcface/field.h>
 #include <webcface/member.h>
+#include <webcface/value.h>
+#include <webcface/text.h>
+#include <webcface/robot_model.h>
+#include <webcface/image.h>
+#include <webcface/view.h>
+#include <webcface/func.h>
+#include <webcface/canvas2d.h>
+#include <webcface/canvas3d.h>
 #include "client_internal.h"
 #include <stdexcept>
 #include <webcface/common/def.h>
 
 WEBCFACE_NS_BEGIN
 Member Field::member() const { return *this; }
+
+Value Field::value(std::string_view field) const { return child(field); }
+Text Field::text(std::string_view field) const { return child(field); }
+RobotModel Field::robotModel(std::string_view field) const { return child(field); }
+Image Field::image(std::string_view field) const { return child(field); }
+Func Field::func(std::string_view field) const { return child(field); }
+View Field::view(std::string_view field) const { return child(field); }
+Canvas3D Field::canvas3D(std::string_view field) const { return child(field); }
+Canvas2D Field::canvas2D(std::string_view field) const { return child(field); }
 
 bool Field::expired() const { return data_w.expired(); }
 

--- a/src/client/field.cc
+++ b/src/client/field.cc
@@ -54,65 +54,89 @@ Canvas2D Field::canvas2D(std::string_view field) const { return child(field); }
 
 std::vector<Value> Field::valueEntries() const {
     auto keys = dataLock()->value_store.getEntry(*this);
-    std::vector<Value> ret(keys.size());
+    std::vector<Value> ret;
     for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = value(keys[i]);
+        if (this->field_.empty() ||
+            keys[i].starts_with(this->field_ + field_separator)) {
+            ret.push_back(value(keys[i]));
+        }
     }
     return ret;
 }
 std::vector<Text> Field::textEntries() const {
     auto keys = dataLock()->text_store.getEntry(*this);
-    std::vector<Text> ret(keys.size());
+    std::vector<Text> ret;
     for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = text(keys[i]);
+        if (this->field_.empty() ||
+            keys[i].starts_with(this->field_ + field_separator)) {
+            ret.push_back(text(keys[i]));
+        }
     }
     return ret;
 }
 std::vector<RobotModel> Field::robotModelEntries() const {
     auto keys = dataLock()->robot_model_store.getEntry(*this);
-    std::vector<RobotModel> ret(keys.size());
+    std::vector<RobotModel> ret;
     for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = robotModel(keys[i]);
+        if (this->field_.empty() ||
+            keys[i].starts_with(this->field_ + field_separator)) {
+            ret.push_back(robotModel(keys[i]));
+        }
     }
     return ret;
 }
 std::vector<Func> Field::funcEntries() const {
     auto keys = dataLock()->func_store.getEntry(*this);
-    std::vector<Func> ret(keys.size());
+    std::vector<Func> ret;
     for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = func(keys[i]);
+        if (this->field_.empty() ||
+            keys[i].starts_with(this->field_ + field_separator)) {
+            ret.push_back(func(keys[i]));
+        }
     }
     return ret;
 }
 std::vector<View> Field::viewEntries() const {
     auto keys = dataLock()->view_store.getEntry(*this);
-    std::vector<View> ret(keys.size());
+    std::vector<View> ret;
     for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = view(keys[i]);
+        if (this->field_.empty() ||
+            keys[i].starts_with(this->field_ + field_separator)) {
+            ret.push_back(view(keys[i]));
+        }
     }
     return ret;
 }
 std::vector<Canvas3D> Field::canvas3DEntries() const {
     auto keys = dataLock()->canvas3d_store.getEntry(*this);
-    std::vector<Canvas3D> ret(keys.size());
+    std::vector<Canvas3D> ret;
     for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = canvas3D(keys[i]);
+        if (this->field_.empty() ||
+            keys[i].starts_with(this->field_ + field_separator)) {
+            ret.push_back(canvas3D(keys[i]));
+        }
     }
     return ret;
 }
 std::vector<Canvas2D> Field::canvas2DEntries() const {
     auto keys = dataLock()->canvas2d_store.getEntry(*this);
-    std::vector<Canvas2D> ret(keys.size());
+    std::vector<Canvas2D> ret;
     for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = canvas2D(keys[i]);
+        if (this->field_.empty() ||
+            keys[i].starts_with(this->field_ + field_separator)) {
+            ret.push_back(canvas2D(keys[i]));
+        }
     }
     return ret;
 }
 std::vector<Image> Field::imageEntries() const {
     auto keys = dataLock()->image_store.getEntry(*this);
-    std::vector<Image> ret(keys.size());
+    std::vector<Image> ret;
     for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = image(keys[i]);
+        if (this->field_.empty() ||
+            keys[i].starts_with(this->field_ + field_separator)) {
+            ret.push_back(image(keys[i]));
+        }
     }
     return ret;
 }

--- a/src/client/field.cc
+++ b/src/client/field.cc
@@ -17,12 +17,79 @@ Member Field::member() const { return *this; }
 
 Value Field::value(std::string_view field) const { return child(field); }
 Text Field::text(std::string_view field) const { return child(field); }
-RobotModel Field::robotModel(std::string_view field) const { return child(field); }
+RobotModel Field::robotModel(std::string_view field) const {
+    return child(field);
+}
 Image Field::image(std::string_view field) const { return child(field); }
 Func Field::func(std::string_view field) const { return child(field); }
 View Field::view(std::string_view field) const { return child(field); }
 Canvas3D Field::canvas3D(std::string_view field) const { return child(field); }
 Canvas2D Field::canvas2D(std::string_view field) const { return child(field); }
+
+std::vector<Value> Field::valueEntries() const {
+    auto keys = dataLock()->value_store.getEntry(*this);
+    std::vector<Value> ret(keys.size());
+    for (std::size_t i = 0; i < keys.size(); i++) {
+        ret[i] = value(keys[i]);
+    }
+    return ret;
+}
+std::vector<Text> Field::textEntries() const {
+    auto keys = dataLock()->text_store.getEntry(*this);
+    std::vector<Text> ret(keys.size());
+    for (std::size_t i = 0; i < keys.size(); i++) {
+        ret[i] = text(keys[i]);
+    }
+    return ret;
+}
+std::vector<RobotModel> Field::robotModelEntries() const {
+    auto keys = dataLock()->robot_model_store.getEntry(*this);
+    std::vector<RobotModel> ret(keys.size());
+    for (std::size_t i = 0; i < keys.size(); i++) {
+        ret[i] = robotModel(keys[i]);
+    }
+    return ret;
+}
+std::vector<Func> Field::funcEntries() const {
+    auto keys = dataLock()->func_store.getEntry(*this);
+    std::vector<Func> ret(keys.size());
+    for (std::size_t i = 0; i < keys.size(); i++) {
+        ret[i] = func(keys[i]);
+    }
+    return ret;
+}
+std::vector<View> Field::viewEntries() const {
+    auto keys = dataLock()->view_store.getEntry(*this);
+    std::vector<View> ret(keys.size());
+    for (std::size_t i = 0; i < keys.size(); i++) {
+        ret[i] = view(keys[i]);
+    }
+    return ret;
+}
+std::vector<Canvas3D> Field::canvas3DEntries() const {
+    auto keys = dataLock()->canvas3d_store.getEntry(*this);
+    std::vector<Canvas3D> ret(keys.size());
+    for (std::size_t i = 0; i < keys.size(); i++) {
+        ret[i] = canvas3D(keys[i]);
+    }
+    return ret;
+}
+std::vector<Canvas2D> Field::canvas2DEntries() const {
+    auto keys = dataLock()->canvas2d_store.getEntry(*this);
+    std::vector<Canvas2D> ret(keys.size());
+    for (std::size_t i = 0; i < keys.size(); i++) {
+        ret[i] = canvas2D(keys[i]);
+    }
+    return ret;
+}
+std::vector<Image> Field::imageEntries() const {
+    auto keys = dataLock()->image_store.getEntry(*this);
+    std::vector<Image> ret(keys.size());
+    for (std::size_t i = 0; i < keys.size(); i++) {
+        ret[i] = image(keys[i]);
+    }
+    return ret;
+}
 
 bool Field::expired() const { return data_w.expired(); }
 

--- a/src/client/field.cc
+++ b/src/client/field.cc
@@ -14,6 +14,32 @@
 
 WEBCFACE_NS_BEGIN
 Member Field::member() const { return *this; }
+std::string_view Field::lastName() const {
+    auto i = this->field_.rfind(field_separator);
+    if (i != std::string::npos && i != 0 &&
+        !(i == 1 && this->field_[0] == field_separator)) {
+        return std::string_view(this->field_).substr(i + 1);
+    } else {
+        return this->field_;
+    }
+}
+Field Field::parent() const {
+    int l = this->field_.size() - lastName().size() - 1;
+    if (l < 0) {
+        l = 0;
+    }
+    return Field{*this, this->field_.substr(0, l)};
+}
+Field Field::child(std::string_view field) const {
+    if (this->field_.empty()) {
+        return Field{*this, field};
+    } else if (field.empty()) {
+        return *this;
+    } else {
+        return Field{*this,
+                     this->field_ + field_separator + std::string(field)};
+    }
+}
 
 Value Field::value(std::string_view field) const { return child(field); }
 Text Field::text(std::string_view field) const { return child(field); }

--- a/src/client/func_internal.h
+++ b/src/client/func_internal.h
@@ -30,10 +30,13 @@ class FuncResultStore {
         std::lock_guard lock(mtx);
         std::size_t caller_id = next_caller_id++;
         result_setter.emplace(caller_id, AsyncFuncResultSetter{base});
-        return AsyncFuncResult{
-            base, caller_id,
-            result_setter.at(caller_id).started.get_future().share(),
-            result_setter.at(caller_id).result.get_future().share()};
+        auto &setter = result_setter.at(caller_id);
+        return AsyncFuncResult{base,
+                               caller_id,
+                               setter.started_f,
+                               setter.result_f,
+                               setter.started_event,
+                               setter.result_event};
     }
     /*!
      * \brief promiseを取得
@@ -51,7 +54,7 @@ class FuncResultStore {
     /*!
      * \brief resultを設定し終わったpromiseを削除
      *
-     * 
+     *
      */
     void removeResultSetter(std::size_t caller_id) {
         std::lock_guard lock(mtx);

--- a/src/client/image.cc
+++ b/src/client/image.cc
@@ -7,9 +7,10 @@ WEBCFACE_NS_BEGIN
 
 template class WEBCFACE_DLL EventTarget<Image>;
 
-Image::Image(const Field &base)
-    : Field(base), EventTarget<Image>(&this->dataLock()->image_change_event,
-                                      *this) {}
+Image::Image(const Field &base) : Field(base), EventTarget<Image>() {
+    std::lock_guard lock(this->dataLock()->event_m);
+    this->cl = &this->dataLock()->image_change_event[*this];
+}
 
 Image &Image::request(std::optional<int> rows, std::optional<int> cols,
                       Common::ImageCompressMode cmp_mode, int quality,

--- a/src/client/log.cc
+++ b/src/client/log.cc
@@ -6,10 +6,10 @@ WEBCFACE_NS_BEGIN
 
 template class WEBCFACE_DLL EventTarget<Log, std::string>;
 
-Log::Log(const Field &base)
-    : Field(base), EventTarget<Log, std::string>(
-                       &this->dataLock()->log_append_event, this->member_) {}
-
+Log::Log(const Field &base) : Field(base), EventTarget<Log, std::string>() {
+    std::lock_guard lock(this->dataLock()->event_m);
+    this->cl = &this->dataLock()->log_append_event[this->member_];
+}
 
 void Log::request() const {
     auto data = dataLock();

--- a/src/client/log.cc
+++ b/src/client/log.cc
@@ -4,9 +4,9 @@
 
 WEBCFACE_NS_BEGIN
 
-template class WEBCFACE_DLL EventTarget<Log, std::string>;
+template class WEBCFACE_DLL EventTarget<Log>;
 
-Log::Log(const Field &base) : Field(base), EventTarget<Log, std::string>() {
+Log::Log(const Field &base) : Field(base), EventTarget<Log>() {
     std::lock_guard lock(this->dataLock()->event_m);
     this->cl = &this->dataLock()->log_append_event[this->member_];
 }

--- a/src/client/member.cc
+++ b/src/client/member.cc
@@ -16,39 +16,48 @@ WEBCFACE_NS_BEGIN
 Log Member::log() const { return Log{*this}; }
 
 EventTarget<Value, std::string> Member::onValueEntry() const {
-    return EventTarget<Value, std::string>{&dataLock()->value_entry_event,
-                                           member_};
+    std::lock_guard lock(dataLock()->event_m);
+    return EventTarget<Value, std::string>{
+        &dataLock()->value_entry_event[member_]};
 }
 EventTarget<Text, std::string> Member::onTextEntry() const {
-    return EventTarget<Text, std::string>{&dataLock()->text_entry_event,
-                                          member_};
+    std::lock_guard lock(dataLock()->event_m);
+    return EventTarget<Text, std::string>{
+        &dataLock()->text_entry_event[member_]};
 }
 EventTarget<RobotModel, std::string> Member::onRobotModelEntry() const {
+    std::lock_guard lock(dataLock()->event_m);
     return EventTarget<RobotModel, std::string>{
-        &dataLock()->robot_model_entry_event, member_};
+        &dataLock()->robot_model_entry_event[member_]};
 }
 EventTarget<Func, std::string> Member::onFuncEntry() const {
-    return EventTarget<Func, std::string>{&dataLock()->func_entry_event,
-                                          member_};
+    std::lock_guard lock(dataLock()->event_m);
+    return EventTarget<Func, std::string>{
+        &dataLock()->func_entry_event[member_]};
 }
 EventTarget<View, std::string> Member::onViewEntry() const {
-    return EventTarget<View, std::string>{&dataLock()->view_entry_event,
-                                          member_};
+    std::lock_guard lock(dataLock()->event_m);
+    return EventTarget<View, std::string>{
+        &dataLock()->view_entry_event[member_]};
 }
 EventTarget<Canvas3D, std::string> Member::onCanvas3DEntry() const {
-    return EventTarget<Canvas3D, std::string>{&dataLock()->canvas3d_entry_event,
-                                              member_};
+    std::lock_guard lock(dataLock()->event_m);
+    return EventTarget<Canvas3D, std::string>{
+        &dataLock()->canvas3d_entry_event[member_]};
 }
 EventTarget<Canvas2D, std::string> Member::onCanvas2DEntry() const {
-    return EventTarget<Canvas2D, std::string>{&dataLock()->canvas2d_entry_event,
-                                              member_};
+    std::lock_guard lock(dataLock()->event_m);
+    return EventTarget<Canvas2D, std::string>{
+        &dataLock()->canvas2d_entry_event[member_]};
 }
 EventTarget<Image, std::string> Member::onImageEntry() const {
-    return EventTarget<Image, std::string>{&dataLock()->image_entry_event,
-                                           member_};
+    std::lock_guard lock(dataLock()->event_m);
+    return EventTarget<Image, std::string>{
+        &dataLock()->image_entry_event[member_]};
 }
 EventTarget<Member, std::string> Member::onSync() const {
-    return EventTarget<Member, std::string>{&dataLock()->sync_event, member_};
+    std::lock_guard lock(dataLock()->event_m);
+    return EventTarget<Member, std::string>{&dataLock()->sync_event[member_]};
 }
 
 std::vector<Value> Member::values() const { return valueEntries(); }
@@ -108,6 +117,7 @@ std::optional<int> Member::pingStatus() const {
 EventTarget<Member, std::string> Member::onPing() const {
     // ほんとはonAppendに追加したかったけど面倒なのでここでリクエストをtrueにしちゃう
     dataLock()->pingStatusReq();
-    return EventTarget<Member, std::string>{&dataLock()->ping_event, member_};
+    std::lock_guard lock(dataLock()->event_m);
+    return EventTarget<Member, std::string>{&dataLock()->ping_event[member_]};
 }
 WEBCFACE_NS_END

--- a/src/client/member.cc
+++ b/src/client/member.cc
@@ -15,49 +15,49 @@ WEBCFACE_NS_BEGIN
 
 Log Member::log() const { return Log{*this}; }
 
-EventTarget<Value, std::string> Member::onValueEntry() const {
+EventTarget<Value> Member::onValueEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<Value, std::string>{
+    return EventTarget<Value>{
         &dataLock()->value_entry_event[member_]};
 }
-EventTarget<Text, std::string> Member::onTextEntry() const {
+EventTarget<Text> Member::onTextEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<Text, std::string>{
+    return EventTarget<Text>{
         &dataLock()->text_entry_event[member_]};
 }
-EventTarget<RobotModel, std::string> Member::onRobotModelEntry() const {
+EventTarget<RobotModel> Member::onRobotModelEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<RobotModel, std::string>{
+    return EventTarget<RobotModel>{
         &dataLock()->robot_model_entry_event[member_]};
 }
-EventTarget<Func, std::string> Member::onFuncEntry() const {
+EventTarget<Func> Member::onFuncEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<Func, std::string>{
+    return EventTarget<Func>{
         &dataLock()->func_entry_event[member_]};
 }
-EventTarget<View, std::string> Member::onViewEntry() const {
+EventTarget<View> Member::onViewEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<View, std::string>{
+    return EventTarget<View>{
         &dataLock()->view_entry_event[member_]};
 }
-EventTarget<Canvas3D, std::string> Member::onCanvas3DEntry() const {
+EventTarget<Canvas3D> Member::onCanvas3DEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<Canvas3D, std::string>{
+    return EventTarget<Canvas3D>{
         &dataLock()->canvas3d_entry_event[member_]};
 }
-EventTarget<Canvas2D, std::string> Member::onCanvas2DEntry() const {
+EventTarget<Canvas2D> Member::onCanvas2DEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<Canvas2D, std::string>{
+    return EventTarget<Canvas2D>{
         &dataLock()->canvas2d_entry_event[member_]};
 }
-EventTarget<Image, std::string> Member::onImageEntry() const {
+EventTarget<Image> Member::onImageEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<Image, std::string>{
+    return EventTarget<Image>{
         &dataLock()->image_entry_event[member_]};
 }
-EventTarget<Member, std::string> Member::onSync() const {
+EventTarget<Member> Member::onSync() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<Member, std::string>{&dataLock()->sync_event[member_]};
+    return EventTarget<Member>{&dataLock()->sync_event[member_]};
 }
 
 std::vector<Value> Member::values() const { return valueEntries(); }
@@ -114,10 +114,10 @@ std::optional<int> Member::pingStatus() const {
         return std::nullopt;
     }
 }
-EventTarget<Member, std::string> Member::onPing() const {
+EventTarget<Member> Member::onPing() const {
     // ほんとはonAppendに追加したかったけど面倒なのでここでリクエストをtrueにしちゃう
     dataLock()->pingStatusReq();
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<Member, std::string>{&dataLock()->ping_event[member_]};
+    return EventTarget<Member>{&dataLock()->ping_event[member_]};
 }
 WEBCFACE_NS_END

--- a/src/client/member.cc
+++ b/src/client/member.cc
@@ -13,24 +13,6 @@
 
 WEBCFACE_NS_BEGIN
 
-Value Member::value(const std::string &field) const {
-    return Value{*this, field};
-}
-Text Member::text(const std::string &field) const { return Text{*this, field}; }
-RobotModel Member::robotModel(const std::string &field) const {
-    return RobotModel{*this, field};
-}
-Image Member::image(const std::string &field) const {
-    return Image{*this, field};
-}
-Func Member::func(const std::string &field) const { return Func{*this, field}; }
-View Member::view(const std::string &field) const { return View{*this, field}; }
-Canvas3D Member::canvas3D(const std::string &field) const {
-    return Canvas3D{*this, field};
-}
-Canvas2D Member::canvas2D(const std::string &field) const {
-    return Canvas2D{*this, field};
-}
 Log Member::log() const { return Log{*this}; }
 
 EventTarget<Value, std::string> Member::onValueEntry() const {
@@ -67,71 +49,6 @@ EventTarget<Image, std::string> Member::onImageEntry() const {
 }
 EventTarget<Member, std::string> Member::onSync() const {
     return EventTarget<Member, std::string>{&dataLock()->sync_event, member_};
-}
-
-std::vector<Value> Member::valueEntries() const {
-    auto keys = dataLock()->value_store.getEntry(*this);
-    std::vector<Value> ret(keys.size());
-    for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = value(keys[i]);
-    }
-    return ret;
-}
-std::vector<Text> Member::textEntries() const {
-    auto keys = dataLock()->text_store.getEntry(*this);
-    std::vector<Text> ret(keys.size());
-    for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = text(keys[i]);
-    }
-    return ret;
-}
-std::vector<RobotModel> Member::robotModelEntries() const {
-    auto keys = dataLock()->robot_model_store.getEntry(*this);
-    std::vector<RobotModel> ret(keys.size());
-    for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = robotModel(keys[i]);
-    }
-    return ret;
-}
-std::vector<Func> Member::funcEntries() const {
-    auto keys = dataLock()->func_store.getEntry(*this);
-    std::vector<Func> ret(keys.size());
-    for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = func(keys[i]);
-    }
-    return ret;
-}
-std::vector<View> Member::viewEntries() const {
-    auto keys = dataLock()->view_store.getEntry(*this);
-    std::vector<View> ret(keys.size());
-    for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = view(keys[i]);
-    }
-    return ret;
-}
-std::vector<Canvas3D> Member::canvas3DEntries() const {
-    auto keys = dataLock()->canvas3d_store.getEntry(*this);
-    std::vector<Canvas3D> ret(keys.size());
-    for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = canvas3D(keys[i]);
-    }
-    return ret;
-}
-std::vector<Canvas2D> Member::canvas2DEntries() const {
-    auto keys = dataLock()->canvas2d_store.getEntry(*this);
-    std::vector<Canvas2D> ret(keys.size());
-    for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = canvas2D(keys[i]);
-    }
-    return ret;
-}
-std::vector<Image> Member::imageEntries() const {
-    auto keys = dataLock()->image_store.getEntry(*this);
-    std::vector<Image> ret(keys.size());
-    for (std::size_t i = 0; i < keys.size(); i++) {
-        ret[i] = image(keys[i]);
-    }
-    return ret;
 }
 
 std::vector<Value> Member::values() const { return valueEntries(); }

--- a/src/client/member.cc
+++ b/src/client/member.cc
@@ -17,13 +17,11 @@ Log Member::log() const { return Log{*this}; }
 
 EventTarget<Value> Member::onValueEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<Value>{
-        &dataLock()->value_entry_event[member_]};
+    return EventTarget<Value>{&dataLock()->value_entry_event[member_]};
 }
 EventTarget<Text> Member::onTextEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<Text>{
-        &dataLock()->text_entry_event[member_]};
+    return EventTarget<Text>{&dataLock()->text_entry_event[member_]};
 }
 EventTarget<RobotModel> Member::onRobotModelEntry() const {
     std::lock_guard lock(dataLock()->event_m);
@@ -32,28 +30,23 @@ EventTarget<RobotModel> Member::onRobotModelEntry() const {
 }
 EventTarget<Func> Member::onFuncEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<Func>{
-        &dataLock()->func_entry_event[member_]};
+    return EventTarget<Func>{&dataLock()->func_entry_event[member_]};
 }
 EventTarget<View> Member::onViewEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<View>{
-        &dataLock()->view_entry_event[member_]};
+    return EventTarget<View>{&dataLock()->view_entry_event[member_]};
 }
 EventTarget<Canvas3D> Member::onCanvas3DEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<Canvas3D>{
-        &dataLock()->canvas3d_entry_event[member_]};
+    return EventTarget<Canvas3D>{&dataLock()->canvas3d_entry_event[member_]};
 }
 EventTarget<Canvas2D> Member::onCanvas2DEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<Canvas2D>{
-        &dataLock()->canvas2d_entry_event[member_]};
+    return EventTarget<Canvas2D>{&dataLock()->canvas2d_entry_event[member_]};
 }
 EventTarget<Image> Member::onImageEntry() const {
     std::lock_guard lock(dataLock()->event_m);
-    return EventTarget<Image>{
-        &dataLock()->image_entry_event[member_]};
+    return EventTarget<Image>{&dataLock()->image_entry_event[member_]};
 }
 EventTarget<Member> Member::onSync() const {
     std::lock_guard lock(dataLock()->event_m);

--- a/src/client/robot_model.cc
+++ b/src/client/robot_model.cc
@@ -14,11 +14,12 @@ RobotModel::RobotModel()
       sb(std::make_shared<Internal::DataSetBuffer<RobotLink>>()) {}
 
 RobotModel::RobotModel(const Field &base)
-    : Field(base), EventTarget<RobotModel>(
-                       &this->dataLock()->robot_model_change_event, *this),
+    : Field(base), EventTarget<RobotModel>(),
       Canvas3DComponent(Canvas3DComponentType::robot_model, this->dataLock()),
       sb(std::make_shared<Internal::DataSetBuffer<RobotLink>>(base)) {
     this->Canvas3DComponent::robotModel(*this);
+    std::lock_guard lock(this->dataLock()->event_m);
+    this->cl = &this->dataLock()->robot_model_change_event[*this];
 }
 
 RobotModel &RobotModel::init() {

--- a/src/client/text.cc
+++ b/src/client/text.cc
@@ -7,9 +7,10 @@ WEBCFACE_NS_BEGIN
 
 template class WEBCFACE_DLL EventTarget<Text>;
 
-Text::Text(const Field &base)
-    : Field(base), EventTarget<Text>(&this->dataLock()->text_change_event,
-                                     *this) {}
+Text::Text(const Field &base) : Field(base), EventTarget<Text>() {
+    std::lock_guard lock(this->dataLock()->event_m);
+    this->cl = &this->dataLock()->text_change_event[*this];
+}
 
 void Text::request() const {
     auto data = dataLock();

--- a/src/client/value.cc
+++ b/src/client/value.cc
@@ -9,9 +9,10 @@ WEBCFACE_NS_BEGIN
 
 template class WEBCFACE_DLL EventTarget<Value>;
 
-Value::Value(const Field &base)
-    : Field(base), EventTarget<Value>(&this->dataLock()->value_change_event,
-                                      *this) {}
+Value::Value(const Field &base) : Field(base), EventTarget<Value>() {
+    std::lock_guard lock(this->dataLock()->event_m);
+    this->cl = &this->dataLock()->value_change_event[*this];
+}
 
 void Value::request() const {
     auto data = dataLock();

--- a/src/client/value.cc
+++ b/src/client/value.cc
@@ -2,6 +2,8 @@
 #include <webcface/value.h>
 #include <webcface/member.h>
 #include "../message/message.h"
+#include <algorithm>
+#include <cctype>
 
 WEBCFACE_NS_BEGIN
 
@@ -32,9 +34,45 @@ Value &Value::set(const Value::Dict &v) {
     return *this;
 }
 Value &Value::set(const VectorOpt<double> &v) {
+    auto last_name = this->lastName();
+    auto parent = this->parent();
+    if (std::all_of(last_name.cbegin(), last_name.cend(),
+                    [](unsigned char c) { return std::isdigit(c); }) &&
+        v.size() == 1) {
+        std::size_t index = std::stoi(std::string(last_name));
+        auto pv = parent.tryGetVec();
+        if (pv && index < pv->size() + 10) { // てきとう
+            while (pv->size() <= index) {
+                pv->push_back(0);
+            }
+            pv->at(index) = v;
+            parent.set(*pv);
+            return *this;
+        }
+    }
     setCheck()->value_store.setSend(*this,
                                     std::make_shared<VectorOpt<double>>(v));
     this->triggerEvent(*this);
+    return *this;
+}
+Value &Value::resize(std::size_t size) {
+    auto pv = this->tryGetVec();
+    if (pv) {
+        pv->resize(size);
+    } else {
+        pv.emplace(size);
+    }
+    this->set(*pv);
+    return *this;
+}
+Value &Value::push_back(double v) {
+    auto pv = this->tryGetVec();
+    if (pv) {
+        pv->push_back(v);
+    } else {
+        pv.emplace({v});
+    }
+    this->set(*pv);
     return *this;
 }
 
@@ -45,9 +83,17 @@ std::optional<double> Value::tryGet() const {
     request();
     if (v) {
         return **v;
-    } else {
-        return std::nullopt;
     }
+    auto last_name = lastName();
+    if (std::all_of(last_name.cbegin(), last_name.cend(),
+                    [](unsigned char c) { return std::isdigit(c); })) {
+        std::size_t index = std::stoi(std::string(last_name));
+        auto pv = parent().tryGetVec();
+        if (pv && index < pv->size()) {
+            return pv->at(index);
+        }
+    }
+    return std::nullopt;
 }
 std::optional<std::vector<double>> Value::tryGetVec() const {
     auto v = dataLock()->value_store.getRecv(*this);

--- a/src/client/view.cc
+++ b/src/client/view.cc
@@ -14,10 +14,11 @@ View::View()
     this->std::ostream::init(sb.get());
 }
 View::View(const Field &base)
-    : Field(base),
-      EventTarget<View>(&this->dataLock()->view_change_event, *this),
-      std::ostream(nullptr), sb(std::make_shared<Internal::ViewBuf>(base)) {
+    : Field(base), EventTarget<View>(), std::ostream(nullptr),
+      sb(std::make_shared<Internal::ViewBuf>(base)) {
     this->std::ostream::init(sb.get());
+    std::lock_guard lock(this->dataLock()->event_m);
+    this->cl = &this->dataLock()->view_change_event[*this];
 }
 View::~View() { this->rdbuf(nullptr); }
 

--- a/src/example/recv.cc
+++ b/src/example/recv.cc
@@ -37,27 +37,26 @@ int main() {
         });
     });
     c.start();
+    auto func_m = c.member("example_func");
     while (true) {
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         // example_mainのtestの値を取得する
         std::cout << "example_main.test = "
-                  << c.member("example_main").value("test") << std::endl;
+                  << c.member("example_value").value("test") << std::endl;
 
         // example_mainのfunc1を実行する
-        c.member("example_main").func("func1").runAsync();
+        func_m.func("func1").runAsync();
         // example_mainのfunc2を実行し結果を取得
-        auto result =
-            c.member("example_main").func("func2").runAsync(9, 7.1, false, "");
-        try {
-            std::cout << "func2(9, 7.1, false, \"\") = "
-                      << static_cast<std::string>(result.result.get())
-                      << std::endl;
-        } catch (...) {
-        }
+        auto result = func_m.func("func2").runAsync(9, 7.1, false, "");
+        result.onResult().append(
+            [](std::shared_future<webcface::ValAdaptor> result) {
+                std::cout << "func2(9, 7.1, false, \"\") = "
+                          << result.get().asStringRef() << std::endl;
+            });
 
-        c.member("example_main").func("func_bool").runAsync(true);
-        c.member("example_main").func("func_int").runAsync(1);
-        c.member("example_main").func("func_double").runAsync(1.0);
-        c.member("example_main").func("func_str").runAsync("1");
+        func_m.func("func_bool").runAsync(true);
+        func_m.func("func_int").runAsync(1);
+        func_m.func("func_double").runAsync(1.0);
+        func_m.func("func_str").runAsync("1");
     }
 }

--- a/src/example/value.cc
+++ b/src/example/value.cc
@@ -4,29 +4,22 @@
 #include <thread>
 #include <chrono>
 
-struct A {
-    int x = 1, y = 2;
-    A() = default;
-    // Dict → A に変換
-    A(const webcface::Value::Dict &d) : x(d["x"]), y(d["y"]) {}
-    // A → Dictに変換
-    operator webcface::Value::Dict() const {
-        return {{"x", x}, {"y", y}, {"nest", {{"a", 3}, {"b", 4}}}};
-    }
-};
 int main() {
     webcface::Client wcli("example_value");
 
     // wcli.value("test").set(0);
     wcli.value("test") = 0;
 
-    // structをDictに変換するとまとめて送信することができる
-    wcli.value("dict") = A();
-
     webcface::Field field = wcli.child("sub_field");
-    field.value("a") = 1; // wcli.value("sub_field.a")
+    field.value("a") = 1;         // wcli.value("sub_field.a")
     field.child("b").value() = 2; // wcli.value("sub_field.b")
-    field["c"].value() = 3; // wcli.value("sub_field.c")
+    field["c"].value() = 3;       // wcli.value("sub_field.c")
+
+    // wcli.value("vec") = {1, 2, 3};
+    webcface::Value vec = wcli.value("vec");
+    for (int i = 0; i < 3; i++) {
+        vec.push_back(i);
+    }
 
     // 文字列送信
     wcli.text("str") = "hello";

--- a/src/example/value.cc
+++ b/src/example/value.cc
@@ -23,6 +23,11 @@ int main() {
     // structをDictに変換するとまとめて送信することができる
     wcli.value("dict") = A();
 
+    webcface::Field field = wcli.field("sub_field");
+    field.value("a") = 1; // wcli.value("sub_field.a")
+    field.child("b").value() = 2; // wcli.value("sub_field.b")
+    field["c"].value() = 3; // wcli.value("sub_field.c")
+
     // 文字列送信
     wcli.text("str") = "hello";
 

--- a/src/example/value.cc
+++ b/src/example/value.cc
@@ -23,7 +23,7 @@ int main() {
     // structをDictに変換するとまとめて送信することができる
     wcli.value("dict") = A();
 
-    webcface::Field field = wcli.field("sub_field");
+    webcface::Field field = wcli.child("sub_field");
     field.value("a") = 1; // wcli.value("sub_field.a")
     field.child("b").value() = 2; // wcli.value("sub_field.b")
     field["c"].value() = 3; // wcli.value("sub_field.c")

--- a/src/include/webcface/canvas2d.h
+++ b/src/include/webcface/canvas2d.h
@@ -39,19 +39,43 @@ class WEBCFACE_DLL Canvas2D : protected Field, public EventTarget<Canvas2D> {
         init(width, height);
     }
 
-    using Field::member;
-    using Field::name;
     friend Internal::DataSetBuffer<Canvas2DComponent>;
 
+    using Field::lastName;
+    using Field::member;
+    using Field::name;
     /*!
-     * \brief 子フィールドを返す
-     *
-     * \return「(thisのフィールド名).(子フィールド名)」をフィールド名とするCanvas3D
+     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
      */
-    Canvas2D child(const std::string &field) const {
-        return Canvas2D{*this, this->field_ + "." + field};
+    Canvas2D child(std::string_view field) const {
+        return this->Field::child(field);
     }
+    /*!
+     * \since ver1.11
+     */
+    Canvas2D child(int index) const { return this->Field::child(index); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
+    Canvas2D operator[](std::string_view field) const { return child(field); }
+    /*!
+     * operator[](long, const char *)と解釈されるのを防ぐための定義
+     * \since ver1.11
+     */
+    Canvas2D operator[](const char *field) const { return child(field); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
+    Canvas2D operator[](int index) const { return child(index); }
+    /*!
+     * \brief nameの最後のピリオドの前までを新しい名前とするField
+     * \since ver1.11
+     */
+    Canvas2D parent() const { return this->Field::parent(); }
+
     /*!
      * \brief Canvasの内容をリクエストする
      * \since ver1.7
@@ -230,8 +254,8 @@ class WEBCFACE_DLL Canvas2D : protected Field, public EventTarget<Canvas2D> {
      *
      */
     template <typename T>
-        requires std::same_as<T, Canvas2D>
-    bool operator==(const T &other) const {
+        requires std::same_as<T, Canvas2D> bool
+    operator==(const T &other) const {
         return static_cast<Field>(*this) == static_cast<Field>(other);
     }
     /*!
@@ -240,8 +264,8 @@ class WEBCFACE_DLL Canvas2D : protected Field, public EventTarget<Canvas2D> {
      *
      */
     template <typename T>
-        requires std::same_as<T, Canvas2D>
-    bool operator!=(const T &other) const {
+        requires std::same_as<T, Canvas2D> bool
+    operator!=(const T &other) const {
         return !(*this == other);
     }
 };

--- a/src/include/webcface/canvas3d.h
+++ b/src/include/webcface/canvas3d.h
@@ -39,19 +39,42 @@ class WEBCFACE_DLL Canvas3D : protected Field, public EventTarget<Canvas3D> {
     Canvas3D(const Field &base, const std::string &field)
         : Canvas3D(Field{base, field}) {}
 
+    friend Internal::DataSetBuffer<Canvas3DComponent>;
+    using Field::lastName;
     using Field::member;
     using Field::name;
-    friend Internal::DataSetBuffer<Canvas3DComponent>;
-
     /*!
-     * \brief 子フィールドを返す
-     *
-     * \return「(thisのフィールド名).(子フィールド名)」をフィールド名とするCanvas3D
+     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
      */
-    Canvas3D child(const std::string &field) const {
-        return Canvas3D{*this, this->field_ + "." + field};
+    Canvas3D child(std::string_view field) const {
+        return this->Field::child(field);
     }
+    /*!
+     * \since ver1.11
+     */
+    Canvas3D child(int index) const { return this->Field::child(index); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
+    Canvas3D operator[](std::string_view field) const { return child(field); }
+    /*!
+     * operator[](long, const char *)と解釈されるのを防ぐための定義
+     * \since ver1.11
+     */
+    Canvas3D operator[](const char *field) const { return child(field); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
+    Canvas3D operator[](int index) const { return child(index); }
+    /*!
+     * \brief nameの最後のピリオドの前までを新しい名前とするField
+     * \since ver1.11
+     */
+    Canvas3D parent() const { return this->Field::parent(); }
+
     /*!
      * \brief canvasの内容をリクエストする
      * \since ver1.7

--- a/src/include/webcface/client.h
+++ b/src/include/webcface/client.h
@@ -121,7 +121,7 @@ class WEBCFACE_DLL Client : public Member {
      *
      * \sa member(), members()
      */
-    EventTarget<Member, int> onMemberEntry();
+    EventTarget<Member> onMemberEntry();
 
     /*!
      * \brief FuncListenerを作成する

--- a/src/include/webcface/common/field_base.h
+++ b/src/include/webcface/common/field_base.h
@@ -33,6 +33,8 @@ struct FieldBase {
 struct FieldBaseComparable : public FieldBase {
     FieldBaseComparable() = default;
     FieldBaseComparable(const FieldBase &base) : FieldBase(base) {}
+    FieldBaseComparable(std::string_view member, std::string_view field)
+        : FieldBase(member, field) {}
 
     bool operator==(const FieldBaseComparable &rhs) const {
         return this->member_ == rhs.member_ && this->field_ == rhs.field_;

--- a/src/include/webcface/common/field_base.h
+++ b/src/include/webcface/common/field_base.h
@@ -20,9 +20,9 @@ struct FieldBase {
     std::string field_;
 
     FieldBase() = default;
-    FieldBase(const std::string &member, const std::string &field = "")
+    FieldBase(std::string_view member, std::string_view field = "")
         : member_(member), field_(field) {}
-    FieldBase(const FieldBase &base, const std::string &field)
+    FieldBase(const FieldBase &base, std::string_view field)
         : FieldBase(base.member_, field) {}
 
     bool operator==(const FieldBase &rhs) const {

--- a/src/include/webcface/common/val.h
+++ b/src/include/webcface/common/val.h
@@ -125,7 +125,17 @@ class ValAdaptor {
     ValType valType() const { return type; }
 
     /*!
+     * \brief 値が空かどうか調べる
+     * \since ver1.11
+     */
+    bool empty() const {
+        return (type == ValType::none_ || type == ValType::string_) &&
+               (!as_str || as_str->empty());
+    }
+
+    /*!
      * \brief 文字列として返す
+     * \since ver1.10
      *
      * std::stringのconst参照を返す。
      * 参照はこのValAdaptorが破棄されるまで有効
@@ -150,7 +160,7 @@ class ValAdaptor {
     }
     /*!
      * \brief 文字列として返す(コピー)
-     *
+     * \since ver1.10
      */
     std::string asString() const { return asStringRef(); }
     operator const std::string &() const { return asStringRef(); }
@@ -162,6 +172,7 @@ class ValAdaptor {
 
     /*!
      * \brief 数値として返す
+     * \since ver1.10
      *
      * as<T>(), Tはdoubleなどの実数型、intなどの整数型
      *
@@ -192,6 +203,7 @@ class ValAdaptor {
 
     /*!
      * \brief bool値を返す
+     * \since ver1.10
      *
      * * 文字列型が入っていた場合、空文字列でなければtrueを返す
      * * 数値型が入っていた場合、0でなければtrueを返す

--- a/src/include/webcface/event_target.h
+++ b/src/include/webcface/event_target.h
@@ -11,11 +11,10 @@ WEBCFACE_NS_BEGIN
  * \brief イベントを表し、コールバックの追加や削除ができるクラス。
  *
  */
-template <typename V, typename Key = FieldBaseComparable,
-          typename VBase = Field>
+template <typename ArgType>
 class EventTarget {
   public:
-    using CallbackList = eventpp::CallbackList<void(VBase)>;
+    using CallbackList = eventpp::CallbackList<void(ArgType)>;
 
   protected:
     CallbackList *cl = nullptr;
@@ -32,7 +31,7 @@ class EventTarget {
      * \brief イベントのコールバックの型
      *
      */
-    using EventCallback = std::function<void(V)>;
+    using EventCallback = std::function<void(ArgType)>;
     /*!
      * \brief コールバックのHandle
      *
@@ -44,7 +43,7 @@ class EventTarget {
      * \brief イベントを発生させる。
      *
      */
-    void triggerEvent(const VBase &arg) const { checkCl()(arg); }
+    void triggerEvent(const ArgType &arg) const { checkCl()(arg); }
 
     /*!
      * \brief listenerを追加する際に行わなければならない処理があればoverrideする

--- a/src/include/webcface/event_target.h
+++ b/src/include/webcface/event_target.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <functional>
 #include <stdexcept>
-#include <eventpp/eventdispatcher.h>
+#include <eventpp/callbacklist.h>
 #include "field.h"
 #include "common/def.h"
 
@@ -79,7 +79,7 @@ class EventTarget {
      */
     EventHandle appendListener(const EventCallback &callback) const {
         onAppend();
-        return checkCl().appendListener(callback);
+        return checkCl().append(callback);
     }
     /*!
      * \brief イベントのコールバックをリストの最後に追加する。
@@ -98,7 +98,7 @@ class EventTarget {
      */
     EventHandle prependListener(const EventCallback &callback) const {
         onAppend();
-        return checkCl().prependListener(callback);
+        return checkCl().prepend(callback);
     }
     /*!
      * \brief イベントのコールバックをリストの最初に追加する。
@@ -118,7 +118,7 @@ class EventTarget {
     EventHandle insertListener(const EventCallback &callback,
                                const EventHandle &before) const {
         onAppend();
-        return checkCl().insertListener(callback, before);
+        return checkCl().insert(callback, before);
     }
     /*!
      * \brief イベントのコールバックを間に挿入する。
@@ -137,13 +137,13 @@ class EventTarget {
      *
      */
     bool removeListener(const EventHandle &handle) const {
-        return checkCl().removeListener(handle);
+        return checkCl().remove(handle);
     }
     /*!
      * \brief コールバックが登録されているかを調べる。
      *
      */
-    bool hasAnyListener() const { return checkCl().hasAnyListener(); }
+    bool hasAnyListener() const { return !checkCl().empty(); }
     /*!
      * \brief handleがこのイベントのものかを調べる。
      *

--- a/src/include/webcface/field.h
+++ b/src/include/webcface/field.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <memory>
 #include <string>
+#include <string_view>
+#include <vector>
 #include "common/field_base.h"
 #include "common/def.h"
 
@@ -11,6 +13,15 @@ struct ClientData;
 }
 
 class Member;
+class Value;
+class Text;
+class Log;
+class View;
+class Image;
+class Func;
+class RobotModel;
+class Canvas2D;
+class Canvas3D;
 
 //! ClientDataの参照とメンバ名とデータ名を持つクラス
 struct WEBCFACE_DLL Field : public Common::FieldBase {
@@ -20,9 +31,9 @@ struct WEBCFACE_DLL Field : public Common::FieldBase {
 
     Field() = default;
     Field(const std::weak_ptr<Internal::ClientData> &data_w,
-          const std::string &member, const std::string &field = "")
+          std::string_view member, std::string_view field = "")
         : Common::FieldBase(member, field), data_w(data_w) {}
-    Field(const Field &base, const std::string &field)
+    Field(const Field &base, std::string_view field)
         : Field(base.data_w, base.member_, field) {}
 
     //! data_wをlockし、失敗したらruntime_errorを投げる
@@ -36,6 +47,37 @@ struct WEBCFACE_DLL Field : public Common::FieldBase {
     Member member() const;
     //! field名を返す
     std::string name() const { return field_; }
+
+    Field child(std::string_view field = "") const {
+        if (this->field_.empty()) {
+            return Field{*this, field};
+        } else if(field.empty()){
+            return *this;
+        } else {
+            return Field{*this, this->field_ + "." + std::string(field)};
+        }
+    }
+    Field child(int index) const { return child(std::to_string(index)); }
+    Field operator[](std::string_view field) const { return child(field); }
+    Field operator[](int index) const { return child(index); }
+
+    Value value(std::string_view field = "") const;
+    Text text(std::string_view field = "") const;
+    RobotModel robotModel(std::string_view field = "") const;
+    Image image(std::string_view field = "") const;
+    Func func(std::string_view field = "") const;
+    View view(std::string_view field = "") const;
+    Canvas3D canvas3D(std::string_view field = "") const;
+    Canvas2D canvas2D(std::string_view field = "") const;
+    
+    std::vector<Value> valueEntries() const;
+    std::vector<Text> textEntries() const;
+    std::vector<RobotModel> robotModelEntries() const;
+    std::vector<Func> funcEntries() const;
+    std::vector<View> viewEntries() const;
+    std::vector<Canvas3D> canvas3DEntries() const;
+    std::vector<Canvas2D> canvas2DEntries() const;
+    std::vector<Image> imageEntries() const;
 
     /*!
      * \brief memberがselfならtrue

--- a/src/include/webcface/field.h
+++ b/src/include/webcface/field.h
@@ -48,10 +48,10 @@ struct WEBCFACE_DLL Field : public Common::FieldBase {
     //! field名を返す
     std::string name() const { return field_; }
 
-    Field child(std::string_view field = "") const {
+    Field child(std::string_view field) const {
         if (this->field_.empty()) {
             return Field{*this, field};
-        } else if(field.empty()){
+        } else if (field.empty()) {
             return *this;
         } else {
             return Field{*this, this->field_ + "." + std::string(field)};
@@ -60,6 +60,14 @@ struct WEBCFACE_DLL Field : public Common::FieldBase {
     Field child(int index) const { return child(std::to_string(index)); }
     Field operator[](std::string_view field) const { return child(field); }
     Field operator[](int index) const { return child(index); }
+    Field parent() const {
+        auto i = this->field_.rfind('.');
+        if (i != std::string::npos) {
+            return Field{*this, this->field_.substr(0, i)};
+        } else {
+            return Field{*this, ""};
+        }
+    }
 
     Value value(std::string_view field = "") const;
     Text text(std::string_view field = "") const;
@@ -69,7 +77,7 @@ struct WEBCFACE_DLL Field : public Common::FieldBase {
     View view(std::string_view field = "") const;
     Canvas3D canvas3D(std::string_view field = "") const;
     Canvas2D canvas2D(std::string_view field = "") const;
-    
+
     std::vector<Value> valueEntries() const;
     std::vector<Text> textEntries() const;
     std::vector<RobotModel> robotModelEntries() const;

--- a/src/include/webcface/field.h
+++ b/src/include/webcface/field.h
@@ -23,6 +23,8 @@ class RobotModel;
 class Canvas2D;
 class Canvas3D;
 
+constexpr char field_separator = '.';
+
 //! ClientDataの参照とメンバ名とデータ名を持つクラス
 struct WEBCFACE_DLL Field : public Common::FieldBase {
     //! ClientDataの参照
@@ -43,31 +45,47 @@ struct WEBCFACE_DLL Field : public Common::FieldBase {
 
     bool expired() const;
 
-    //! Memberを返す
+    /*!
+     * \brief Memberを返す
+     *
+     */
     Member member() const;
-    //! field名を返す
+    /*!
+     * \brief field名を返す
+     *
+     */
     std::string name() const { return field_; }
 
-    Field child(std::string_view field) const {
-        if (this->field_.empty()) {
-            return Field{*this, field};
-        } else if (field.empty()) {
-            return *this;
-        } else {
-            return Field{*this, this->field_ + "." + std::string(field)};
-        }
-    }
+    /*!
+     * \brief nameのうちピリオドで区切られた最後の部分を取り出す
+     * \since ver1.11
+     */
+    std::string_view lastName() const;
+    /*!
+     * \brief nameの最後のピリオドの前までを新しい名前とするField
+     * \since ver1.11
+     */
+    Field parent() const;
+    /*!
+     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
+     * \since ver1.11
+     */
+    Field child(std::string_view field) const;
+    /*!
+     * \brief 「(thisの名前).(index)」を新しい名前とするField
+     * \since ver1.11
+     */
     Field child(int index) const { return child(std::to_string(index)); }
+    /*!
+     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
+     * \since ver1.11
+     */
     Field operator[](std::string_view field) const { return child(field); }
+    /*!
+     * \brief 「(thisの名前).(index)」を新しい名前とするField
+     * \since ver1.11
+     */
     Field operator[](int index) const { return child(index); }
-    Field parent() const {
-        auto i = this->field_.rfind('.');
-        if (i != std::string::npos) {
-            return Field{*this, this->field_.substr(0, i)};
-        } else {
-            return Field{*this, ""};
-        }
-    }
 
     Value value(std::string_view field = "") const;
     Text text(std::string_view field = "") const;

--- a/src/include/webcface/func.h
+++ b/src/include/webcface/func.h
@@ -49,8 +49,40 @@ class WEBCFACE_DLL Func : protected Field {
     Func(const Field &base, const std::string &field)
         : Func(Field{base, field}) {}
 
+    using Field::lastName;
     using Field::member;
     using Field::name;
+    /*!
+     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
+     *
+     */
+    Func child(std::string_view field) const {
+        return this->Field::child(field);
+    }
+    /*!
+     * \since ver1.11
+     */
+    Func child(int index) const { return this->Field::child(index); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
+    Func operator[](std::string_view field) const { return child(field); }
+    /*!
+     * operator[](long, const char *)と解釈されるのを防ぐための定義
+     * \since ver1.11
+     */
+    Func operator[](const char *field) const { return child(field); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
+    Func operator[](int index) const { return child(index); }
+    /*!
+     * \brief nameの最後のピリオドの前までを新しい名前とするField
+     * \since ver1.11
+     */
+    Func parent() const { return this->Field::parent(); }
 
   protected:
     Func &setRaw(const std::shared_ptr<FuncInfo> &v);
@@ -79,20 +111,6 @@ class WEBCFACE_DLL Func : protected Field {
     Func &operator=(const T &func) {
         return this->set(func);
     }
-    // /*!
-    //  * \brief セットした関数を置き換える
-    //  * \since ver1.10
-    //  *
-    //  * 他のプロパティ(wrapper, argsなど)は元のまま
-    //  *
-    //  */
-    // Func &replaceImpl(FuncType func);
-    // /*!
-    //  * \brief セットされている関数オブジェクトを取得
-    //  * \since ver1.10
-    //  *
-    //  */
-    // FuncType getImpl() const;
 
     /*!
      * \brief 引数にFuncCallHandleを取る関数を登録する

--- a/src/include/webcface/image.h
+++ b/src/include/webcface/image.h
@@ -27,11 +27,10 @@ class WEBCFACE_DLL Image : protected Field, public EventTarget<Image> {
 
     void onAppend() const override final;
 
-    Image &
-    request(std::optional<int> rows, std::optional<int> cols,
-            Common::ImageCompressMode cmp_mode, int quality,
-            std::optional<Common::ImageColorMode> color_mode,
-            std::optional<double> frame_rate);
+    Image &request(std::optional<int> rows, std::optional<int> cols,
+                   Common::ImageCompressMode cmp_mode, int quality,
+                   std::optional<Common::ImageColorMode> color_mode,
+                   std::optional<double> frame_rate);
 
   public:
     Image() = default;
@@ -39,16 +38,40 @@ class WEBCFACE_DLL Image : protected Field, public EventTarget<Image> {
     Image(const Field &base, const std::string &field)
         : Image(Field{base, field}) {}
 
+    using Field::lastName;
     using Field::member;
     using Field::name;
-
     /*!
-     * \return「(thisのフィールド名).(子フィールド名)」をフィールド名とするImage
+     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
      */
-    Image child(const std::string &field) {
-        return Image{*this, this->field_ + "." + field};
+    Image child(std::string_view field) const {
+        return this->Field::child(field);
     }
+    /*!
+     * \since ver1.11
+     */
+    Image child(int index) const { return this->Field::child(index); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
+    Image operator[](std::string_view field) const { return child(field); }
+    /*!
+     * operator[](long, const char *)と解釈されるのを防ぐための定義
+     * \since ver1.11
+     */
+    Image operator[](const char *field) const { return child(field); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
+    Image operator[](int index) const { return child(index); }
+    /*!
+     * \brief nameの最後のピリオドの前までを新しい名前とするField
+     * \since ver1.11
+     */
+    Image parent() const { return this->Field::parent(); }
 
     /*!
      * \brief 画像をセットする
@@ -127,8 +150,7 @@ class WEBCFACE_DLL Image : protected Field, public EventTarget<Image> {
      * \deprecated 1.7でMember::syncTime()に変更
      *
      */
-    [[deprecated]] std::chrono::system_clock::time_point
-    time() const;
+    [[deprecated]] std::chrono::system_clock::time_point time() const;
 
     //! 値やリクエスト状態をクリア
     Image &free();
@@ -142,8 +164,8 @@ class WEBCFACE_DLL Image : protected Field, public EventTarget<Image> {
      *
      */
     template <typename T>
-        requires std::same_as<T, Image>
-    bool operator==(const T &other) const {
+        requires std::same_as<T, Image> bool
+    operator==(const T &other) const {
         return static_cast<Field>(*this) == static_cast<Field>(other);
     }
     /*!
@@ -152,8 +174,8 @@ class WEBCFACE_DLL Image : protected Field, public EventTarget<Image> {
      *
      */
     template <typename T>
-        requires std::same_as<T, Image>
-    bool operator!=(const T &other) const {
+        requires std::same_as<T, Image> bool
+    operator!=(const T &other) const {
         return !(*this == other);
     }
 };

--- a/src/include/webcface/log.h
+++ b/src/include/webcface/log.h
@@ -10,7 +10,7 @@
 WEBCFACE_NS_BEGIN
 
 class Log;
-extern template class WEBCFACE_IMPORT EventTarget<Log, std::string>;
+extern template class WEBCFACE_IMPORT EventTarget<Log>;
 
 /*!
  * \brief ログの送受信データを表すクラス
@@ -18,7 +18,7 @@ extern template class WEBCFACE_IMPORT EventTarget<Log, std::string>;
  * fieldを継承しているがfield名は使用していない
  *
  */
-class WEBCFACE_DLL Log : protected Field, public EventTarget<Log, std::string> {
+class WEBCFACE_DLL Log : protected Field, public EventTarget<Log> {
     void onAppend() const override final;
 
   public:

--- a/src/include/webcface/member.h
+++ b/src/include/webcface/member.h
@@ -105,61 +105,61 @@ class WEBCFACE_DLL Member : protected Field {
      * コールバックの型は void(Value)
      *
      */
-    EventTarget<Value, std::string> onValueEntry() const;
+    EventTarget<Value> onValueEntry() const;
     /*!
      * \brief textが追加された時のイベント
      *
      * コールバックの型は void(Text)
      *
      */
-    EventTarget<Text, std::string> onTextEntry() const;
+    EventTarget<Text> onTextEntry() const;
     /*!
      * \brief robotModelが追加された時のイベント
      *
      * コールバックの型は void(RobotModel)
      *
      */
-    EventTarget<RobotModel, std::string> onRobotModelEntry() const;
+    EventTarget<RobotModel> onRobotModelEntry() const;
     /*!
      * \brief funcが追加された時のイベント
      *
      * コールバックの型は void(Func)
      *
      */
-    EventTarget<Func, std::string> onFuncEntry() const;
+    EventTarget<Func> onFuncEntry() const;
     /*!
      * \brief imageが追加されたときのイベント
      *
      * コールバックの型は void(Image)
      *
      */
-    EventTarget<Image, std::string> onImageEntry() const;
+    EventTarget<Image> onImageEntry() const;
     /*!
      * \brief viewが追加されたときのイベント
      *
      * コールバックの型は void(View)
      *
      */
-    EventTarget<View, std::string> onViewEntry() const;
+    EventTarget<View> onViewEntry() const;
     /*!
      * \brief canvas3dが追加されたときのイベント
      *
      * コールバックの型は void(Canvas3D)
      *
      */
-    EventTarget<Canvas3D, std::string> onCanvas3DEntry() const;
+    EventTarget<Canvas3D> onCanvas3DEntry() const;
     /*!
      * \brief canvas2dが追加されたときのイベント
      *
      * コールバックの型は void(Canvas2D)
      *
      */
-    EventTarget<Canvas2D, std::string> onCanvas2DEntry() const;
+    EventTarget<Canvas2D> onCanvas2DEntry() const;
     /*!
      * \brief Memberがsync()したときのイベント
      * コールバックの型は void(Member)
      */
-    EventTarget<Member, std::string> onSync() const;
+    EventTarget<Member> onSync() const;
 
     /*!
      * \brief 最後のsync()の時刻を返す
@@ -206,7 +206,7 @@ class WEBCFACE_DLL Member : protected Field {
      * \sa pingStatus()
      *
      */
-    EventTarget<Member, std::string> onPing() const;
+    EventTarget<Member> onPing() const;
 
     /*!
      * \brief Memberを比較

--- a/src/include/webcface/member.h
+++ b/src/include/webcface/member.h
@@ -37,8 +37,6 @@ class WEBCFACE_DLL Member : protected Field {
 
     using Field::child;
     using Field::operator[];
-    Field field(std::string_view field) const { return child(field); }
-    Field field(int index) const { return child(index); }
 
     using Field::canvas2D;
     using Field::canvas3D;

--- a/src/include/webcface/member.h
+++ b/src/include/webcface/member.h
@@ -14,15 +14,6 @@ namespace Internal {
 struct ClientData;
 }
 
-class Value;
-class Text;
-class Log;
-class View;
-class Image;
-class RobotModel;
-class Canvas2D;
-class Canvas3D;
-
 /*!
  * \brief Memberを指すクラス
  *
@@ -34,7 +25,7 @@ class WEBCFACE_DLL Member : protected Field {
   public:
     Member() = default;
     Member(const std::weak_ptr<Internal::ClientData> &data_w,
-           const std::string &member)
+           std::string_view member)
         : Field(data_w, member) {}
     Member(const Field &base) : Field(base.data_w, base.member_) {}
 
@@ -46,14 +37,18 @@ class WEBCFACE_DLL Member : protected Field {
 
     using Field::child;
     using Field::operator[];
-    Field field(const std::string &field) const { return child(field); }
+    Field field(std::string_view field) const { return child(field); }
     Field field(int index) const { return child(index); }
 
-    Value value(const std::string &field) const;
-    Text text(const std::string &field) const;
-    RobotModel robotModel(const std::string &field) const;
-    Image image(const std::string &field) const;
-    Func func(const std::string &field) const;
+    using Field::canvas2D;
+    using Field::canvas3D;
+    using Field::func;
+    using Field::image;
+    using Field::robotModel;
+    using Field::text;
+    using Field::value;
+    using Field::view;
+    Log log() const;
     /*!
      * \brief AnonymousFuncオブジェクトを作成しfuncをsetする
      *
@@ -63,16 +58,15 @@ class WEBCFACE_DLL Member : protected Field {
     AnonymousFunc func(const T &func) const {
         return AnonymousFunc{*this, func};
     }
-    View view(const std::string &field) const;
-    Canvas3D canvas3D(const std::string &field) const;
-    Canvas2D canvas2D(const std::string &field) const;
-    Log log() const;
 
-    /*!
-     * \brief このmemberが公開しているvalueのリストを返す。
-     *
-     */
-    std::vector<Value> valueEntries() const;
+    using Field::canvas2DEntries;
+    using Field::canvas3DEntries;
+    using Field::funcEntries;
+    using Field::imageEntries;
+    using Field::robotModelEntries;
+    using Field::textEntries;
+    using Field::valueEntries;
+    using Field::viewEntries;
     /*!
      * \brief このmemberが公開しているvalueのリストを返す。
      * \deprecated 1.6で valueEntries() に変更
@@ -81,19 +75,9 @@ class WEBCFACE_DLL Member : protected Field {
     [[deprecated]] std::vector<Value> values() const;
     /*!
      * \brief このmemberが公開しているtextのリストを返す。
-     *
-     */
-    std::vector<Text> textEntries() const;
-    /*!
-     * \brief このmemberが公開しているtextのリストを返す。
      * \deprecated 1.6で textEntries() に変更
      */
     [[deprecated]] std::vector<Text> texts() const;
-    /*!
-     * \brief このmemberが公開しているrobotModelのリストを返す。
-     *
-     */
-    std::vector<RobotModel> robotModelEntries() const;
     /*!
      * \brief このmemberが公開しているrobotModelのリストを返す。
      * \deprecated 1.6で robotModelEntries() に変更
@@ -102,40 +86,15 @@ class WEBCFACE_DLL Member : protected Field {
     [[deprecated]] std::vector<RobotModel> robotModels() const;
     /*!
      * \brief このmemberが公開しているfuncのリストを返す。
-     *
-     */
-    std::vector<Func> funcEntries() const;
-    /*!
-     * \brief このmemberが公開しているfuncのリストを返す。
      * \deprecated 1.6で funcEntries() に変更
      *
      */
     [[deprecated]] std::vector<Func> funcs() const;
     /*!
      * \brief このmemberが公開しているviewのリストを返す。
-     *
-     */
-    std::vector<View> viewEntries() const;
-    /*!
-     * \brief このmemberが公開しているviewのリストを返す。
      * \deprecated 1.6で viewEntries() に変更
      */
     [[deprecated]] std::vector<View> views() const;
-    /*!
-     * \brief このmemberが公開しているcanvas3dのリストを返す。
-     *
-     */
-    std::vector<Canvas3D> canvas3DEntries() const;
-    /*!
-     * \brief このmemberが公開しているcanvas2dのリストを返す。
-     *
-     */
-    std::vector<Canvas2D> canvas2DEntries() const;
-    /*!
-     * \brief このmemberが公開しているimageのリストを返す。
-     *
-     */
-    std::vector<Image> imageEntries() const;
     /*!
      * \brief このmemberが公開しているimageのリストを返す。
      * \deprecated 1.6で imageEntries() に変更

--- a/src/include/webcface/member.h
+++ b/src/include/webcface/member.h
@@ -36,13 +36,18 @@ class WEBCFACE_DLL Member : protected Field {
     Member(const std::weak_ptr<Internal::ClientData> &data_w,
            const std::string &member)
         : Field(data_w, member) {}
-    Member(const Field &base) : Field(base) {}
+    Member(const Field &base) : Field(base.data_w, base.member_) {}
 
     /*!
      * \brief Member名
      *
      */
     std::string name() const { return member_; }
+
+    using Field::child;
+    using Field::operator[];
+    Field field(const std::string &field) const { return child(field); }
+    Field field(int index) const { return child(index); }
 
     Value value(const std::string &field) const;
     Text text(const std::string &field) const;
@@ -252,8 +257,8 @@ class WEBCFACE_DLL Member : protected Field {
      *
      */
     template <typename T>
-        requires std::same_as<T, Member>
-    bool operator==(const T &other) const {
+        requires std::same_as<T, Member> bool
+    operator==(const T &other) const {
         return static_cast<Field>(*this) == static_cast<Field>(other);
     }
     /*!
@@ -262,8 +267,8 @@ class WEBCFACE_DLL Member : protected Field {
      *
      */
     template <typename T>
-        requires std::same_as<T, Member>
-    bool operator!=(const T &other) const {
+        requires std::same_as<T, Member> bool
+    operator!=(const T &other) const {
         return !(*this == other);
     }
 };

--- a/src/include/webcface/robot_model.h
+++ b/src/include/webcface/robot_model.h
@@ -39,9 +39,42 @@ class WEBCFACE_DLL RobotModel : protected Field,
         : RobotModel(Field{base, field}) {}
 
     friend class Canvas3D;
+    friend Internal::DataSetBuffer<RobotLink>;
+
+    using Field::lastName;
     using Field::member;
     using Field::name;
-    friend Internal::DataSetBuffer<RobotLink>;
+    /*!
+     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
+     * \since ver1.11
+     */
+    RobotModel child(std::string_view field) const {
+        return this->Field::child(field);
+    }
+    /*!
+     * \since ver1.11
+     */
+    RobotModel child(int index) const { return this->Field::child(index); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
+    RobotModel operator[](std::string_view field) const { return child(field); }
+    /*!
+     * operator[](long, const char *)と解釈されるのを防ぐための定義
+     * \since ver1.11
+     */
+    RobotModel operator[](const char *field) const { return child(field); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
+    RobotModel operator[](int index) const { return child(index); }
+    /*!
+     * \brief nameの最後のピリオドの前までを新しい名前とするField
+     * \since ver1.11
+     */
+    RobotModel parent() const { return this->Field::parent(); }
 
     /*!
      * \brief モデルを初期化

--- a/src/include/webcface/text.h
+++ b/src/include/webcface/text.h
@@ -248,8 +248,8 @@ class WEBCFACE_DLL InputRef {
             }
         } else {
             auto new_val = state->field.get();
-            if (*state->val != new_val) {
-                *state->val = new_val;
+            if (!state->val || *state->val != new_val) {
+                state->val = new_val;
             }
         }
         return *state->val;

--- a/src/include/webcface/text.h
+++ b/src/include/webcface/text.h
@@ -34,18 +34,40 @@ class WEBCFACE_DLL Text : protected Field, public EventTarget<Text> {
 
     friend class InputRef;
     friend struct InputRefState;
+    using Field::lastName;
     using Field::member;
     using Field::name;
-
     /*!
-     * \brief 子フィールドを返す
-     *
-     * \return「(thisのフィールド名).(子フィールド名)」をフィールド名とするText
+     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
      */
-    Text child(const std::string &field) const {
-        return Text{*this, this->field_ + "." + field};
+    Text child(std::string_view field) const {
+        return this->Field::child(field);
     }
+    /*!
+     * \since ver1.11
+     */
+    Text child(int index) const { return this->Field::child(index); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
+    Text operator[](std::string_view field) const { return child(field); }
+    /*!
+     * operator[](long, const char *)と解釈されるのを防ぐための定義
+     * \since ver1.11
+     */
+    Text operator[](const char *field) const { return child(field); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
+    Text operator[](int index) const { return child(index); }
+    /*!
+     * \brief nameの最後のピリオドの前までを新しい名前とするField
+     * \since ver1.11
+     */
+    Text parent() const { return this->Field::parent(); }
 
     // 1.10でstd::stringをValAdaptorに変更したら使えなくなった
     // using Dict = Common::Dict<std::shared_ptr<Common::ValAdaptor>>;
@@ -147,8 +169,8 @@ class WEBCFACE_DLL Text : protected Field, public EventTarget<Text> {
      *
      */
     template <typename T>
-        requires std::same_as<T, Text>
-    bool operator==(const T &other) const {
+        requires std::same_as<T, Text> bool
+    operator==(const T &other) const {
         return static_cast<Field>(*this) == static_cast<Field>(other);
     }
     /*!
@@ -157,8 +179,8 @@ class WEBCFACE_DLL Text : protected Field, public EventTarget<Text> {
      *
      */
     template <typename T>
-        requires std::same_as<T, Text>
-    bool operator!=(const T &other) const {
+        requires std::same_as<T, Text> bool
+    operator!=(const T &other) const {
         return !(*this == other);
     }
     bool operator<(const Text &) const = delete;
@@ -175,6 +197,7 @@ WEBCFACE_DLL std::ostream &operator<<(std::ostream &os, const Text &data);
 
 struct WEBCFACE_DLL InputRefState {
     Text field;
+    std::optional<ValAdaptor> val = std::nullopt;
     InputRefState() = default;
 };
 /*!
@@ -213,13 +236,23 @@ class WEBCFACE_DLL InputRef {
     /*!
      * \brief 値を返す
      *
+     * ver1.11からconst参照 (次に値を取得して別の値が返ったときまで有効)
+     *
      */
-    ValAdaptor get() const {
+    const ValAdaptor &get() const {
         if (expired()) {
-            return ValAdaptor();
+            if (!state->val) {
+                state->val.emplace();
+            } else if (!state->val->empty()) {
+                state->val.emplace();
+            }
         } else {
-            return state->field.get();
+            auto new_val = state->field.get();
+            if (*state->val != new_val) {
+                *state->val = new_val;
+            }
         }
+        return *state->val;
     }
 
     /*!
@@ -232,14 +265,53 @@ class WEBCFACE_DLL InputRef {
         return static_cast<T>(get());
     }
 
+    /*!
+     * \brief 値が空かどうか調べる
+     * \since ver1.11
+     */
+    bool empty() const { return get().empty(); }
+
+    /*!
+     * \brief 文字列として返す
+     * \since ver1.11
+     *
+     * std::stringのconst参照を返す。
+     * 参照は次に値を取得して別の値が返ったときまで有効
+     *
+     */
+    const std::string &asStringRef() const { return get().asStringRef(); }
+    /*!
+     * \brief 文字列として返す(コピー)
+     * \since ver1.11
+     */
+    std::string asString() const { return get().asString(); }
+    /*!
+     * \brief 数値として返す
+     * \since ver1.11
+     *
+     * as<T>(), Tはdoubleなどの実数型、intなどの整数型
+     *
+     */
     template <typename T>
-        requires std::constructible_from<ValAdaptor, T>
-    bool operator==(const T &other) const {
+        requires(std::convertible_to<double, T> && !std::same_as<T, bool>)
+    double as() const {
+        return get().as<T>();
+    }
+
+    /*!
+     * \brief bool値を返す
+     * \since ver1.11
+     */
+    bool asBool() const { return get().asBool(); }
+
+    template <typename T>
+        requires std::constructible_from<ValAdaptor, T> bool
+    operator==(const T &other) const {
         return get() == other;
     }
     template <typename T>
-        requires std::constructible_from<ValAdaptor, T>
-    bool operator!=(const T &other) const {
+        requires std::constructible_from<ValAdaptor, T> bool
+    operator!=(const T &other) const {
         return get() != other;
     }
 };

--- a/src/include/webcface/value.h
+++ b/src/include/webcface/value.h
@@ -34,9 +34,9 @@ class WEBCFACE_DLL Value : protected Field, public EventTarget<Value> {
     Value(const Field &base, std::string_view field)
         : Value(Field{base, field}) {}
 
+    using Field::lastName;
     using Field::member;
     using Field::name;
-
     Value child(std::string_view field) const {
         return this->Field::child(field);
     }
@@ -52,10 +52,32 @@ class WEBCFACE_DLL Value : protected Field, public EventTarget<Value> {
      */
     [[deprecated]] Value &set(const Dict &v);
     /*!
+     * \brief 値をまとめてセットする
+     * \since ver1.11
+     */
+    template <typename F>
+        requires std::invocable<F, Value>
+    Value &set(const F &setter) {
+        setter(*this);
+        return *this;
+    }
+    /*!
      * \brief 数値または配列をセットする
+     *
+     * ver1.11〜
+     * vが配列でなく、parent()の配列データが利用可能ならその要素をセットする
      *
      */
     Value &set(const VectorOpt<double> &v);
+    /*!
+     * \brief 配列をセット、またはすでにsetされていればリサイズする
+     * \since ver1.11
+     */
+    Value &resize(std::size_t size);
+    /*!
+     * \brief 値をセット、またはすでに配列がsetされていれば末尾に追加
+     */
+    Value &push_back(double v);
 
     /*!
      * \brief Dictの値を再帰的にセットする
@@ -66,14 +88,26 @@ class WEBCFACE_DLL Value : protected Field, public EventTarget<Value> {
         return *this;
     }
     /*!
+     * \brief 値をまとめてセットする
+     * \since ver1.11
+     */
+    template <typename F>
+        requires std::invocable<F, Value>
+    Value &operator=(const F &setter) {
+        this->set(setter);
+        return *this;
+    }
+    /*!
      * \brief 数値または配列をセットする
+     *
+     * ver1.11〜
+     * vが配列でなく、parent()の配列データが利用可能ならその要素をセットする
      *
      */
     Value &operator=(const VectorOpt<double> &v) {
         this->set(v);
         return *this;
     }
-
     /*!
      * \brief 値をリクエストする
      * \since ver1.7
@@ -82,6 +116,8 @@ class WEBCFACE_DLL Value : protected Field, public EventTarget<Value> {
     void request() const;
     /*!
      * \brief 値を返す
+     *
+     * ver1.11〜 parent()の配列データが利用可能ならその要素を返す
      *
      */
     std::optional<double> tryGet() const;

--- a/src/include/webcface/value.h
+++ b/src/include/webcface/value.h
@@ -31,28 +31,26 @@ class WEBCFACE_DLL Value : protected Field, public EventTarget<Value> {
   public:
     Value() = default;
     Value(const Field &base);
-    Value(const Field &base, const std::string &field)
+    Value(const Field &base, std::string_view field)
         : Value(Field{base, field}) {}
 
     using Field::member;
     using Field::name;
 
-    /*!
-     * \brief 子フィールドを返す
-     *
-     * \return「(thisのフィールド名).(子フィールド名)」をフィールド名とするValue
-     *
-     */
-    Value child(const std::string &field) const {
-        return Value{*this, this->field_ + "." + field};
+    Value child(std::string_view field) const {
+        return this->Field::child(field);
     }
+    Value child(int index) const { return this->Field::child(index); }
+    Value operator[](std::string_view field) const { return child(field); }
+    Value operator[](int index) const { return child(index); }
+    Value parent() const { return this->Field::parent(); }
 
     using Dict = Common::Dict<std::shared_ptr<Common::VectorOpt<double>>>;
     /*!
      * \brief Dictの値を再帰的にセットする
-     *
+     * \deprecated ver1.11〜
      */
-    Value &set(const Dict &v);
+    [[deprecated]] Value &set(const Dict &v);
     /*!
      * \brief 数値または配列をセットする
      *
@@ -61,9 +59,9 @@ class WEBCFACE_DLL Value : protected Field, public EventTarget<Value> {
 
     /*!
      * \brief Dictの値を再帰的にセットする
-     *
+     * \deprecated ver1.11〜
      */
-    Value &operator=(const Dict &v) {
+    [[deprecated]] Value &operator=(const Dict &v) {
         this->set(v);
         return *this;
     }
@@ -94,9 +92,9 @@ class WEBCFACE_DLL Value : protected Field, public EventTarget<Value> {
     std::optional<std::vector<double>> tryGetVec() const;
     /*!
      * \brief 値を再帰的に取得しDictで返す
-     *
+     * \deprecated ver1.11〜
      */
-    std::optional<Dict> tryGetRecurse() const;
+    [[deprecated]] std::optional<Dict> tryGetRecurse() const;
     /*!
      * \brief 値を返す
      *
@@ -111,12 +109,14 @@ class WEBCFACE_DLL Value : protected Field, public EventTarget<Value> {
     }
     /*!
      * \brief 値を再帰的に取得しDictで返す
-     *
+     * \deprecated ver1.11〜
      */
-    Dict getRecurse() const { return tryGetRecurse().value_or(Dict{}); }
+    [[deprecated]] Dict getRecurse() const {
+        return tryGetRecurse().value_or(Dict{});
+    }
     operator double() const { return get(); }
     operator std::vector<double>() const { return getVec(); }
-    operator Dict() const { return getRecurse(); }
+    [[deprecated]] operator Dict() const { return getRecurse(); }
     /*!
      * \brief syncの時刻を返す
      * \deprecated 1.7で Member::syncTime() に変更
@@ -214,8 +214,8 @@ class WEBCFACE_DLL Value : protected Field, public EventTarget<Value> {
      *
      */
     template <typename T>
-        requires std::same_as<T, Value>
-    bool operator==(const T &other) const {
+        requires std::same_as<T, Value> bool
+    operator==(const T &other) const {
         return static_cast<Field>(*this) == static_cast<Field>(other);
     }
     /*!
@@ -224,8 +224,8 @@ class WEBCFACE_DLL Value : protected Field, public EventTarget<Value> {
      *
      */
     template <typename T>
-        requires std::same_as<T, Value>
-    bool operator!=(const T &other) const {
+        requires std::same_as<T, Value> bool
+    operator!=(const T &other) const {
         return !(*this == other);
     }
     bool operator<(const Value &) const = delete;

--- a/src/include/webcface/value.h
+++ b/src/include/webcface/value.h
@@ -42,6 +42,10 @@ class WEBCFACE_DLL Value : protected Field, public EventTarget<Value> {
     }
     Value child(int index) const { return this->Field::child(index); }
     Value operator[](std::string_view field) const { return child(field); }
+    /*!
+     * operator[](long, const char *)と解釈されるのを防ぐため
+     */
+    Value operator[](const char *field) const { return child(field); }
     Value operator[](int index) const { return child(index); }
     Value parent() const { return this->Field::parent(); }
 

--- a/src/include/webcface/value.h
+++ b/src/include/webcface/value.h
@@ -37,16 +37,36 @@ class WEBCFACE_DLL Value : protected Field, public EventTarget<Value> {
     using Field::lastName;
     using Field::member;
     using Field::name;
+    /*!
+     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
+     *
+     */
     Value child(std::string_view field) const {
         return this->Field::child(field);
     }
+    /*!
+     * \since ver1.11
+     */
     Value child(int index) const { return this->Field::child(index); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
     Value operator[](std::string_view field) const { return child(field); }
     /*!
-     * operator[](long, const char *)と解釈されるのを防ぐため
+     * operator[](long, const char *)と解釈されるのを防ぐための定義
+     * \since ver1.11
      */
     Value operator[](const char *field) const { return child(field); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
     Value operator[](int index) const { return child(index); }
+    /*!
+     * \brief nameの最後のピリオドの前までを新しい名前とするField
+     * \since ver1.11
+     */
     Value parent() const { return this->Field::parent(); }
 
     using Dict = Common::Dict<std::shared_ptr<Common::VectorOpt<double>>>;
@@ -55,16 +75,6 @@ class WEBCFACE_DLL Value : protected Field, public EventTarget<Value> {
      * \deprecated ver1.11〜
      */
     [[deprecated]] Value &set(const Dict &v);
-    /*!
-     * \brief 値をまとめてセットする
-     * \since ver1.11
-     */
-    template <typename F>
-        requires std::invocable<F, Value>
-    Value &set(const F &setter) {
-        setter(*this);
-        return *this;
-    }
     /*!
      * \brief 数値または配列をセットする
      *
@@ -89,16 +99,6 @@ class WEBCFACE_DLL Value : protected Field, public EventTarget<Value> {
      */
     [[deprecated]] Value &operator=(const Dict &v) {
         this->set(v);
-        return *this;
-    }
-    /*!
-     * \brief 値をまとめてセットする
-     * \since ver1.11
-     */
-    template <typename F>
-        requires std::invocable<F, Value>
-    Value &operator=(const F &setter) {
-        this->set(setter);
         return *this;
     }
     /*!

--- a/src/include/webcface/view.h
+++ b/src/include/webcface/view.h
@@ -131,6 +131,7 @@ class WEBCFACE_DLL View : protected Field,
      *
      */
     template <typename T>
+        requires requires(T rhs) { std::ostream(nullptr) << rhs; }
     View &operator<<(T &&rhs) {
         static_cast<std::ostream &>(*this) << std::forward<T>(rhs);
         return *this;
@@ -228,8 +229,8 @@ class WEBCFACE_DLL View : protected Field,
      *
      */
     template <typename T>
-        requires std::same_as<T, View> bool
-    operator==(const T &other) const {
+        requires std::same_as<T, View>
+    bool operator==(const T &other) const {
         return static_cast<Field>(*this) == static_cast<Field>(other);
     }
     /*!
@@ -238,8 +239,8 @@ class WEBCFACE_DLL View : protected Field,
      *
      */
     template <typename T>
-        requires std::same_as<T, View> bool
-    operator!=(const T &other) const {
+        requires std::same_as<T, View>
+    bool operator!=(const T &other) const {
         return !(*this == other);
     }
 };

--- a/src/include/webcface/view.h
+++ b/src/include/webcface/view.h
@@ -43,20 +43,43 @@ class WEBCFACE_DLL View : protected Field,
     View &operator=(View &&rhs);
     ~View() override;
 
-    using Field::member;
-    using Field::name;
-
     friend Internal::DataSetBuffer<ViewComponent>;
 
+    using Field::lastName;
+    using Field::member;
+    using Field::name;
     /*!
-     * \brief 子フィールドを返す
-     *
-     * \return「(thisのフィールド名).(子フィールド名)」をフィールド名とするView
+     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
      */
-    View child(const std::string &field) const {
-        return View{*this, this->field_ + "." + field};
+    View child(std::string_view field) const {
+        return this->Field::child(field);
     }
+    /*!
+     * \since ver1.11
+     */
+    View child(int index) const { return this->Field::child(index); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
+    View operator[](std::string_view field) const { return child(field); }
+    /*!
+     * operator[](long, const char *)と解釈されるのを防ぐための定義
+     * \since ver1.11
+     */
+    View operator[](const char *field) const { return child(field); }
+    /*!
+     * child()と同じ
+     * \since ver1.11
+     */
+    View operator[](int index) const { return child(index); }
+    /*!
+     * \brief nameの最後のピリオドの前までを新しい名前とするField
+     * \since ver1.11
+     */
+    View parent() const { return this->Field::parent(); }
+
     /*!
      * \brief viewをリクエストする
      * \since ver1.7
@@ -162,6 +185,19 @@ class WEBCFACE_DLL View : protected Field,
      *
      */
     View &operator<<(ViewComponent &&vc);
+    /*!
+     * \brief コンポーネントを追加
+     * \since ver1.11
+     *
+     * カスタムコンポーネントとして引数にViewをとる関数を渡すことができる
+     *
+     */
+    template <typename F>
+        requires std::invocable<F, View &>
+    View &operator<<(const F &manip) {
+        manip(*this);
+        return *this;
+    }
 
     /*!
      * \brief コンポーネントなどを追加
@@ -192,8 +228,8 @@ class WEBCFACE_DLL View : protected Field,
      *
      */
     template <typename T>
-        requires std::same_as<T, View>
-    bool operator==(const T &other) const {
+        requires std::same_as<T, View> bool
+    operator==(const T &other) const {
         return static_cast<Field>(*this) == static_cast<Field>(other);
     }
     /*!
@@ -202,8 +238,8 @@ class WEBCFACE_DLL View : protected Field,
      *
      */
     template <typename T>
-        requires std::same_as<T, View>
-    bool operator!=(const T &other) const {
+        requires std::same_as<T, View> bool
+    operator!=(const T &other) const {
         return !(*this == other);
     }
 };

--- a/src/test/canvas2d_test.cc
+++ b/src/test/canvas2d_test.cc
@@ -41,19 +41,20 @@ TEST_F(Canvas2DTest, field) {
 }
 TEST_F(Canvas2DTest, eventTarget) {
     canvas("a", "b").appendListener(callback<Canvas2D>());
-    data_->canvas2d_change_event.dispatch(FieldBase{"a", "b"},
-                                          Field{data_, "a", "b"});
+    data_->canvas2d_change_event[FieldBase{"a", "b"}](Field{data_, "a", "b"});
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
 }
 TEST_F(Canvas2DTest, set) {
-    data_->canvas2d_change_event.appendListener(FieldBase{self_name, "b"},
-                                                callback());
+    data_->canvas2d_change_event[FieldBase{self_name, "b"}].append(callback());
     using namespace webcface::Geometries;
 
     auto v = canvas(self_name, "b").init(100, 150);
-    v.add(line({0, 0}, {3, 3}).color(ViewColor::red).onClick(func(self_name, "f")));
-    v.add(plane({0, 0}, 10, 10).color(ViewColor::yellow).onClick(afunc1([]{})));
+    v.add(line({0, 0}, {3, 3})
+              .color(ViewColor::red)
+              .onClick(func(self_name, "f")));
+    v.add(
+        plane({0, 0}, 10, 10).color(ViewColor::yellow).onClick(afunc1([] {})));
     v.sync();
     EXPECT_EQ(callback_called, 1);
     auto &canvas2d_data = **data_->canvas2d_store.getRecv(self_name, "b");

--- a/src/test/canvas2d_test.cc
+++ b/src/test/canvas2d_test.cc
@@ -26,7 +26,7 @@ class Canvas2DTest : public ::testing::Test {
         return AnonymousFunc{Field{data_, self_name, ""}, func};
     }
     int callback_called;
-    template <typename V = FieldBase>
+    template <typename V = Canvas2D>
     auto callback() {
         return [&](const V &) { ++callback_called; };
     }

--- a/src/test/canvas3d_test.cc
+++ b/src/test/canvas3d_test.cc
@@ -23,7 +23,7 @@ class Canvas3DTest : public ::testing::Test {
         return RobotModel{Field{data_, member, field}};
     }
     int callback_called;
-    template <typename V = FieldBase>
+    template <typename V = Canvas3D>
     auto callback() {
         return [&](const V &) { ++callback_called; };
     }

--- a/src/test/canvas3d_test.cc
+++ b/src/test/canvas3d_test.cc
@@ -38,14 +38,12 @@ TEST_F(Canvas3DTest, field) {
 }
 TEST_F(Canvas3DTest, eventTarget) {
     canvas("a", "b").appendListener(callback<Canvas3D>());
-    data_->canvas3d_change_event.dispatch(FieldBase{"a", "b"},
-                                          Field{data_, "a", "b"});
+    data_->canvas3d_change_event[FieldBase{"a", "b"}](Field{data_, "a", "b"});
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
 }
 TEST_F(Canvas3DTest, set) {
-    data_->canvas3d_change_event.appendListener(FieldBase{self_name, "b"},
-                                                callback());
+    data_->canvas3d_change_event[FieldBase{self_name, "b"}].append(callback());
     using namespace webcface::Geometries;
     using namespace webcface::RobotJoints;
     robot_model(self_name, "b")

--- a/src/test/client_data_test.cc
+++ b/src/test/client_data_test.cc
@@ -24,18 +24,30 @@ TEST_F(SyncDataStore2Test, setSend) {
     EXPECT_EQ(send.size(), 1);
     EXPECT_EQ(s2.transferSend(false).size(), 0);
     EXPECT_EQ(s2.transferSend(true).size(), 1);
+
     s2.setSend("a", "b"); // 同じデータ
     EXPECT_EQ(s2.getRecv(self_name, "a"), "b");
     send = s2.transferSend(false);
     EXPECT_FALSE(send.count("a"));
     EXPECT_EQ(send.size(), 0);
     EXPECT_EQ(s2.transferSend(true).size(), 1);
+
+    s2.setSend("a", "zzzzzz");
+    EXPECT_EQ(s2.getRecv(self_name, "a"), "zzzzzz");
+    s2.setSend("a", "b"); // 一度違うデータを送ってから同じデータ
+    EXPECT_EQ(s2.getRecv(self_name, "a"), "b");
+    send = s2.transferSend(false);
+    EXPECT_FALSE(send.count("a"));
+    EXPECT_EQ(send.size(), 0);
+    EXPECT_EQ(s2.transferSend(true).size(), 1);
+
     s2.setSend("a", "c"); // 違うデータ
     EXPECT_EQ(s2.getRecv(self_name, "a"), "c");
     send = s2.transferSend(false);
     EXPECT_EQ(send.at("a"), "c");
     EXPECT_EQ(send.size(), 1);
     EXPECT_EQ(s2.transferSend(true).size(), 1);
+
 }
 // TEST_F(SyncDataStore2Test, setRecv) {}
 TEST_F(SyncDataStore2Test, addReq) {

--- a/src/test/client_data_test.cc
+++ b/src/test/client_data_test.cc
@@ -47,7 +47,6 @@ TEST_F(SyncDataStore2Test, setSend) {
     EXPECT_EQ(send.at("a"), "c");
     EXPECT_EQ(send.size(), 1);
     EXPECT_EQ(s2.transferSend(true).size(), 1);
-
 }
 // TEST_F(SyncDataStore2Test, setRecv) {}
 TEST_F(SyncDataStore2Test, addReq) {
@@ -117,12 +116,9 @@ TEST_F(SyncDataStore2Test, clearRecv) {
     EXPECT_EQ(s2.getRecv("a", "b"), std::nullopt);
 }
 TEST_F(SyncDataStore2Test, setEntry) {
-    s2.setEntry("a");
-    EXPECT_EQ(s2.getMembers().size(), 1);
-    EXPECT_EQ(s2.getMembers().at(0), "a");
     s2.setEntry("a", "b");
     EXPECT_EQ(s2.getEntry("a").size(), 1);
-    EXPECT_EQ(s2.getEntry("a").at(0), "b");
+    EXPECT_EQ(s2.getEntry("a").count("b"), 1);
 }
 
 class SyncDataStore1Test : public ::testing::Test {

--- a/src/test/data_test.cc
+++ b/src/test/data_test.cc
@@ -24,7 +24,7 @@ class DataTest : public ::testing::Test {
     }
     Log log(const std::string &member) { return Log{Field{data_, member}}; }
     int callback_called;
-    template <typename V = FieldBase>
+    template <typename V>
     auto callback() {
         return [&](const V &) { ++callback_called; };
     }
@@ -70,14 +70,16 @@ TEST_F(DataTest, eventTarget) {
     callback_called = 0;
 }
 TEST_F(DataTest, valueSet) {
-    data_->value_change_event[FieldBase{self_name, "b"}].append(callback());
+    data_->value_change_event[FieldBase{self_name, "b"}].append(
+        callback<Value>());
     value(self_name, "b").set(123);
     EXPECT_EQ(**data_->value_store.getRecv(self_name, "b"), 123);
     EXPECT_EQ(callback_called, 1);
     EXPECT_THROW(value("a", "b").set(123), std::invalid_argument);
 }
 TEST_F(DataTest, valueSetVec) {
-    data_->value_change_event[FieldBase{self_name, "d"}].append(callback());
+    data_->value_change_event[FieldBase{self_name, "d"}].append(
+        callback<Value>());
     value(self_name, "d").set({1, 2, 3, 4, 5});
     value(self_name, "d2").set(std::vector<double>{1, 2, 3, 4, 5});
     value(self_name, "d3").set(std::vector<int>{1, 2, 3, 4, 5});
@@ -111,7 +113,8 @@ TEST_F(DataTest, valueSetVec) {
     EXPECT_EQ((**data_->value_store.getRecv(self_name, "d7")).size(), 5);
 }
 TEST_F(DataTest, textSet) {
-    data_->text_change_event[FieldBase{self_name, "b"}].append(callback());
+    data_->text_change_event[FieldBase{self_name, "b"}].append(
+        callback<Text>());
     text(self_name, "b").set("c");
     EXPECT_EQ(
         static_cast<std::string>(**data_->text_store.getRecv(self_name, "b")),
@@ -137,12 +140,14 @@ TEST_F(DataTest, dict) {
     EXPECT_EQ(a["v"].getVec().at(0), 1);
 }
 TEST_F(DataTest, valueSetDict) {
-    data_->value_change_event[FieldBase{self_name, "d"}].append(callback());
+    data_->value_change_event[FieldBase{self_name, "d"}].append(
+        callback<Value>());
     value(self_name, "d").set({{"a", 100}});
     // dにはセットしてないのでeventは発動しない
     EXPECT_EQ(callback_called, 0);
 
-    data_->value_change_event[FieldBase{self_name, "d.a"}].append(callback());
+    data_->value_change_event[FieldBase{self_name, "d.a"}].append(
+        callback<Value>());
     value(self_name, "d")
         .set({{"a", 1},
               {"b", 2},

--- a/src/test/func_test.cc
+++ b/src/test/func_test.cc
@@ -29,6 +29,7 @@ class FuncTest : public ::testing::Test {
 };
 
 TEST_F(FuncTest, valAdaptor) {
+    EXPECT_FALSE(ValAdaptor(10).empty());
     EXPECT_EQ(static_cast<int>(ValAdaptor(10)), 10);
     EXPECT_EQ(static_cast<double>(ValAdaptor(10)), 10.0);
     EXPECT_EQ(static_cast<bool>(ValAdaptor(0)), false);
@@ -36,6 +37,7 @@ TEST_F(FuncTest, valAdaptor) {
     EXPECT_EQ(static_cast<bool>(ValAdaptor(2)), true);
     EXPECT_EQ(static_cast<std::string>(ValAdaptor(10)), "10");
 
+    EXPECT_FALSE(ValAdaptor(1.5).empty());
     EXPECT_EQ(static_cast<int>(ValAdaptor(1.5)), 1);
     EXPECT_EQ(static_cast<double>(ValAdaptor(1.5)), 1.5);
     EXPECT_EQ(static_cast<bool>(ValAdaptor(0.0)), false);
@@ -43,6 +45,7 @@ TEST_F(FuncTest, valAdaptor) {
     EXPECT_EQ(static_cast<bool>(ValAdaptor(1.5)), true);
     EXPECT_EQ(static_cast<std::string>(ValAdaptor(1.5)), "1.500000");
 
+    EXPECT_FALSE(ValAdaptor(true).empty());
     EXPECT_EQ(static_cast<int>(ValAdaptor(true)), 1);
     EXPECT_EQ(static_cast<int>(ValAdaptor(false)), 0);
     EXPECT_EQ(static_cast<double>(ValAdaptor(true)), 1.0);
@@ -51,6 +54,7 @@ TEST_F(FuncTest, valAdaptor) {
     EXPECT_EQ(static_cast<bool>(ValAdaptor(false)), false);
     EXPECT_EQ(static_cast<std::string>(ValAdaptor(true)), "1");
 
+    EXPECT_FALSE(ValAdaptor("1.5").empty());
     EXPECT_EQ(static_cast<int>(ValAdaptor("1.5")), 1);
     EXPECT_EQ(static_cast<double>(ValAdaptor("1.5")), 1.5);
     EXPECT_EQ(static_cast<bool>(ValAdaptor("")), false);
@@ -60,6 +64,10 @@ TEST_F(FuncTest, valAdaptor) {
     EXPECT_EQ(static_cast<bool>(ValAdaptor("1.5")), true);
     EXPECT_EQ(static_cast<bool>(ValAdaptor("hoge")), true);
     EXPECT_EQ(static_cast<std::string>(ValAdaptor("1.5")), "1.5");
+
+    EXPECT_TRUE(ValAdaptor().empty());
+    EXPECT_TRUE(ValAdaptor("").empty());
+    EXPECT_TRUE(ValAdaptor(std::string("")).empty());
 }
 TEST_F(FuncTest, field) {
     EXPECT_EQ(func("a", "b").member().name(), "a");

--- a/src/test/image_test.cc
+++ b/src/test/image_test.cc
@@ -112,7 +112,7 @@ class ImageTest : public ::testing::Test {
         return Image{Field{data_, member, field}};
     }
     int callback_called;
-    template <typename V = FieldBase>
+    template <typename V = Image>
     auto callback() {
         return [&](const V &) { ++callback_called; };
     }

--- a/src/test/image_test.cc
+++ b/src/test/image_test.cc
@@ -33,7 +33,7 @@ TEST_F(ImageFrameTest, baseRawPtrCtor) {
     EXPECT_EQ(img.cols(), 100);
     ASSERT_NE(img.dataPtr(), nullptr);
     EXPECT_NE(img.dataPtr()->data(), dp->data());
-    EXPECT_EQ(img.dataPtr()->size(), 100*100*3);
+    EXPECT_EQ(img.dataPtr()->size(), 100 * 100 * 3);
     EXPECT_EQ(img.channels(), 3);
     EXPECT_EQ(img.color_mode(), ImageColorMode::bgr);
     EXPECT_EQ(img.compress_mode(), ImageCompressMode::raw);
@@ -127,18 +127,16 @@ TEST_F(ImageTest, field) {
 }
 TEST_F(ImageTest, eventTarget) {
     image("a", "b").appendListener(callback<Image>());
-    data_->image_change_event.dispatch(FieldBase{"a", "b"},
-                                       Field{data_, "a", "b"});
+    data_->image_change_event[FieldBase{"a", "b"}](Field{data_, "a", "b"});
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
 }
 TEST_F(ImageTest, imageSet) {
-    data_->image_change_event.appendListener(FieldBase{self_name, "b"},
-                                             callback());
+    data_->image_change_event[FieldBase{self_name, "b"}].append(callback());
     auto dp = std::make_shared<std::vector<unsigned char>>(100 * 100 * 3);
     image(self_name, "b").set(ImageFrame{100, 100, dp});
-    EXPECT_EQ(data_->image_store.getRecv(self_name, "b")->rows() , 100);
-    EXPECT_EQ(data_->image_store.getRecv(self_name, "b")->cols() , 100);
+    EXPECT_EQ(data_->image_store.getRecv(self_name, "b")->rows(), 100);
+    EXPECT_EQ(data_->image_store.getRecv(self_name, "b")->cols(), 100);
     EXPECT_EQ(data_->image_store.getRecv(self_name, "b")->dataPtr(), dp);
     EXPECT_EQ(callback_called, 1);
     EXPECT_THROW(image("a", "b").set(ImageFrame{}), std::invalid_argument);

--- a/src/test/member_test.cc
+++ b/src/test/member_test.cc
@@ -42,19 +42,15 @@ TEST_F(MemberTest, field) {
 }
 
 TEST_F(MemberTest, getEntry) {
-    data_->value_store.setEntry("a");
     data_->value_store.setEntry("a", "a");
     EXPECT_EQ(member("a").valueEntries().size(), 1);
     EXPECT_EQ(member("a").valueEntries()[0].name(), "a");
-    data_->text_store.setEntry("a");
     data_->text_store.setEntry("a", "a");
     EXPECT_EQ(member("a").textEntries().size(), 1);
     EXPECT_EQ(member("a").textEntries()[0].name(), "a");
-    data_->func_store.setEntry("a");
     data_->func_store.setEntry("a", "a");
     EXPECT_EQ(member("a").funcEntries().size(), 1);
     EXPECT_EQ(member("a").funcEntries()[0].name(), "a");
-    data_->view_store.setEntry("a");
     data_->view_store.setEntry("a", "a");
     EXPECT_EQ(member("a").viewEntries().size(), 1);
     EXPECT_EQ(member("a").viewEntries()[0].name(), "a");

--- a/src/test/member_test.cc
+++ b/src/test/member_test.cc
@@ -61,28 +61,28 @@ TEST_F(MemberTest, getEntry) {
 }
 TEST_F(MemberTest, eventTarget) {
     member("a").onValueEntry().appendListener(callback<Value>());
-    data_->value_entry_event.dispatch("a", Field{data_, "a", "a"});
+    data_->value_entry_event["a"](Field{data_, "a", "a"});
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
     member("a").onTextEntry().appendListener(callback<Text>());
-    data_->text_entry_event.dispatch("a", Field{data_, "a", "a"});
+    data_->text_entry_event["a"](Field{data_, "a", "a"});
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
     member("a").onFuncEntry().appendListener(callback<Func>());
-    data_->func_entry_event.dispatch("a", Field{data_, "a", "a"});
+    data_->func_entry_event["a"](Field{data_, "a", "a"});
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
     member("a").onViewEntry().appendListener(callback<View>());
-    data_->view_entry_event.dispatch("a", Field{data_, "a", "a"});
+    data_->view_entry_event["a"](Field{data_, "a", "a"});
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
     member("a").onSync().appendListener(callback<Member>());
-    data_->sync_event.dispatch("a", Field{data_, "a"});
+    data_->sync_event["a"](Field{data_, "a"});
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
 
     member("a").onPing().appendListener(callback<Member>());
-    data_->ping_event.dispatch("a", Field{data_, "a"});
+    data_->ping_event["a"](Field{data_, "a"});
     EXPECT_EQ(callback_called, 1);
     EXPECT_TRUE(data_->ping_status_req);
     callback_called = 0;

--- a/src/test/robot_model_test.cc
+++ b/src/test/robot_model_test.cc
@@ -32,21 +32,21 @@ TEST_F(RobotModelTest, field) {
 }
 TEST_F(RobotModelTest, eventTarget) {
     model("a", "b").appendListener(callback<RobotModel>());
-    data_->robot_model_change_event.dispatch(FieldBase{"a", "b"},
-                                             Field{data_, "a", "b"});
+    data_->robot_model_change_event[FieldBase{"a", "b"}](
+        Field{data_, "a", "b"});
     EXPECT_EQ(callback_called, 1);
 }
 TEST_F(RobotModelTest, set) {
-    data_->robot_model_change_event.appendListener(FieldBase{self_name, "b"},
-                                                   callback());
+    data_->robot_model_change_event[FieldBase{self_name, "b"}].append(
+        callback());
     model(self_name, "b").set({RobotLink{"a", Geometry{}, ViewColor::black}});
     EXPECT_EQ((*data_->robot_model_store.getRecv(self_name, "b"))->size(), 1);
     EXPECT_EQ(callback_called, 1);
     EXPECT_THROW(model("a", "b").set({}), std::invalid_argument);
 }
 TEST_F(RobotModelTest, sync) {
-    data_->robot_model_change_event.appendListener(FieldBase{self_name, "b"},
-                                                   callback());
+    data_->robot_model_change_event[FieldBase{self_name, "b"}].append(
+        callback());
     auto m = model(self_name, "b");
     m << RobotLink{"1", Geometry{}, ViewColor::black};
     m << RobotLink{"2", Geometry{}, ViewColor::black};
@@ -67,13 +67,14 @@ TEST_F(RobotModelTest, sync) {
         m2 << RobotLink{"3", Geometry{}, ViewColor::black};
     }
     EXPECT_EQ((*data_->robot_model_store.getRecv(self_name, "b2"))->size(), 3);
-    
+
     EXPECT_THROW(model("a", "b").init().sync(), std::invalid_argument);
 }
 
 TEST_F(RobotModelTest, get) {
     data_->robot_model_store.setRecv(
-        "a", "b", std::make_shared<std::vector<RobotLink>>(
+        "a", "b",
+        std::make_shared<std::vector<RobotLink>>(
             std::vector<RobotLink>{{"a", Geometry{}, ViewColor::black}}));
     EXPECT_EQ(model("a", "b").tryGet()->size(), 1);
     EXPECT_EQ(model("a", "b").get().size(), 1);

--- a/src/test/robot_model_test.cc
+++ b/src/test/robot_model_test.cc
@@ -18,7 +18,7 @@ class RobotModelTest : public ::testing::Test {
         return RobotModel{Field{data_, member, field}};
     }
     int callback_called;
-    template <typename V = FieldBase>
+    template <typename V = RobotModel>
     auto callback() {
         return [&](const V &) { ++callback_called; };
     }

--- a/src/test/view_test.cc
+++ b/src/test/view_test.cc
@@ -30,7 +30,7 @@ class ViewTest : public ::testing::Test {
         return AnonymousFunc{Field{data_, self_name, ""}, func};
     }
     int callback_called;
-    template <typename V = FieldBase>
+    template <typename V = View>
     auto callback() {
         return [&](const V &) { ++callback_called; };
     }

--- a/src/test/view_test.cc
+++ b/src/test/view_test.cc
@@ -45,14 +45,12 @@ TEST_F(ViewTest, field) {
 }
 TEST_F(ViewTest, eventTarget) {
     view("a", "b").appendListener(callback<View>());
-    data_->view_change_event.dispatch(FieldBase{"a", "b"},
-                                      Field{data_, "a", "b"});
+    data_->view_change_event[FieldBase{"a", "b"}](Field{data_, "a", "b"});
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
 }
 TEST_F(ViewTest, viewSet) {
-    data_->view_change_event.appendListener(FieldBase{self_name, "b"},
-                                            callback());
+    data_->view_change_event[FieldBase{self_name, "b"}].append(callback());
     using namespace webcface::ViewComponents;
     auto v = view(self_name, "b");
     v << "a\n" << 1;

--- a/src/test/view_test.cc
+++ b/src/test/view_test.cc
@@ -69,6 +69,17 @@ TEST_F(ViewTest, viewSet) {
         called_ref3++;
         EXPECT_EQ(val, "aaa");
     });
+    int manip_called = 0;
+    auto manip = [&](webcface::View &v2) {
+        manip_called++;
+        EXPECT_EQ(&v, &v2);
+    };
+    auto manip2 = [&](webcface::View v2) {
+        manip_called++;
+        EXPECT_EQ(v, v2);
+    };
+    v << manip << manip2;
+    EXPECT_EQ(manip_called, 2);
     v.sync();
     EXPECT_EQ(callback_called, 1);
     auto &view_data = **data_->view_store.getRecv(self_name, "b");


### PR DESCRIPTION
* Field::child, operator[], parent, lastName 追加
  * Value,Text,View,Func に対しても child, operator[], parent, lastName 追加
* Member::value, text, valueEntries, textEntries ...etcをField::に移動
* Value::set, get でparentの配列の要素を参照する機能追加
* Value::resize, push_back 追加
* Value::Dictをdeprecatedにした
* EventTarget::callbackList() 追加 (close #226)
* イベントのコールバックの引数型変更
* InputRef::get の戻り値をconst参照にした
* InputRef::asStringRef, asString, as<>, asBool 追加
* ValAdaptor::empty, InputRef::empty 追加
* View::operator<<(function) 追加 (#218)
* AsyncFuncResult::onStarted, onResult 追加
* DataStore2::setEntry(member), getMembers() 削除 → ClientData::member_entry 追加
