### PR TITLE
websocketのスレッド内の処理を関数に分割

### DIFF
--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -75,6 +75,8 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
      */
     std::atomic<bool> closing = false;
     std::atomic<bool> connected = false;
+    std::atomic<bool> recv_thread_running = false;
+    std::atomic<bool> auto_reconnect = true;
     std::mutex connect_state_m;
     std::condition_variable connect_state_cond;
 
@@ -99,7 +101,7 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
      */
     WEBCFACE_DLL std::string syncDataFirst();
     /*!
-     * \brief sync() 1回分のメッセージをキューに入れる
+     * \brief sync() 1回分のメッセージ
      *
      * value, text, view, log, funcの送信データの前回からの差分が含まれる。
      * 各種reqはsyncとは無関係に送信される
@@ -108,7 +110,8 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
      * (syncDataFirst()内から呼ばれる)
      *
      */
-    WEBCFACE_DLL void syncData(bool is_first);
+    WEBCFACE_DLL std::string syncData(bool is_first);
+    WEBCFACE_DLL std::string syncData(bool is_first, std::stringstream &buffer, int &len);
 
     /*!
      * \brief 送信したいメッセージを入れるキュー

--- a/src/client/client_internal.h
+++ b/src/client/client_internal.h
@@ -53,9 +53,9 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
 
     std::string host;
     int port;
-    std::array<void *, 3> curl_handles;
     void *current_curl_handle;
-    bool current_curl_closed;
+    bool current_curl_success, current_curl_closed;
+    std::string current_curl_path;
     std::string current_ws_buf;
 
     /*!

--- a/src/client/client_ws.cc
+++ b/src/client/client_ws.cc
@@ -159,14 +159,16 @@ void recvFrame(Internal::ClientData *data, char *buffer, std::size_t rlen,
     } else {
         data->current_ws_buf.append(buffer, rlen);
     }
-    if (meta && meta->bytesleft == 0 && !data->current_ws_buf.empty()) {
+    if (meta && meta->bytesleft == 0) {
         data->logger_internal->trace("message received len={}",
                                      data->current_ws_buf.size());
         std::size_t sent;
         curl_ws_send(handle, nullptr, 0, &sent, 0, CURLWS_PONG);
-        // data->recv_queue.push(data->current_ws_buf);
-        data->onRecv(data->current_ws_buf);
-        data->current_ws_buf.clear();
+        if (!data->current_ws_buf.empty()) {
+            // data->recv_queue.push(data->current_ws_buf);
+            data->onRecv(data->current_ws_buf);
+            data->current_ws_buf.clear();
+        }
     }
 }
 void recv(std::shared_ptr<Internal::ClientData> data) {

--- a/src/client/client_ws.cc
+++ b/src/client/client_ws.cc
@@ -13,27 +13,22 @@ WEBCFACE_NS_BEGIN
 namespace Internal {
 namespace WebSocket {
 
-void init(std::shared_ptr<Internal::ClientData> data) {
+void init(std::shared_ptr<Internal::ClientData> data, bool use_cb) {
     if (data->host.empty()) {
         data->host = "127.0.0.1";
     }
     // try TCP, unixSocketPathWSLInterop and unixSocketPath
     // use latter if multiple connections were available
-    data->curl_handles.fill(nullptr);
-    std::array<std::optional<CURLcode>, 3> curl_result;
-    curl_result.fill(std::nullopt);
-    std::array<std::string, 3> paths;
-    for (std::size_t attempt = 0;
-         attempt < data->curl_handles.size() && !data->closing.load();
+    for (std::size_t attempt = 0; attempt < 3 && !data->closing.load();
          attempt++) {
-        CURL *handle = data->curl_handles[attempt] = curl_easy_init();
-        curl_result[attempt] = std::nullopt;
+        CURL *handle = curl_easy_init();
         if (std::getenv("WEBCFACE_TRACE") != nullptr) {
             curl_easy_setopt(handle, CURLOPT_VERBOSE, 1L);
         }
         switch (attempt) {
-        case 0:
-            paths[attempt] = data->host + ':' + std::to_string(data->port);
+        case 2:
+            data->current_curl_path =
+                data->host + ':' + std::to_string(data->port);
             curl_easy_setopt(handle, CURLOPT_URL,
                              ("ws://" + data->host + "/").c_str());
             break;
@@ -42,20 +37,19 @@ void init(std::shared_ptr<Internal::ClientData> data) {
                 continue;
             }
             if (Message::Path::detectWSL1()) {
-                paths[attempt] =
+                data->current_curl_path =
                     Message::Path::unixSocketPathWSLInterop(data->port)
                         .string();
                 curl_easy_setopt(handle, CURLOPT_UNIX_SOCKET_PATH,
-                                 paths[attempt].c_str());
+                                 data->current_curl_path.c_str());
                 curl_easy_setopt(handle, CURLOPT_URL,
                                  ("ws://" + data->host + "/").c_str());
                 break;
             }
-            if (Message::Path::detectWSL2() &&
-                !(curl_result[0] && curl_result[0] == CURLE_OK)) {
+            if (Message::Path::detectWSL2()) {
                 std::string win_host = Message::Path::wsl2Host();
                 if (!win_host.empty()) {
-                    paths[attempt] =
+                    data->current_curl_path =
                         win_host + ':' + std::to_string(data->port);
                     curl_easy_setopt(handle, CURLOPT_URL,
                                      ("ws://" + win_host + "/").c_str());
@@ -63,62 +57,116 @@ void init(std::shared_ptr<Internal::ClientData> data) {
                 }
             }
             continue;
-        case 2:
+        case 0:
             if (data->host != "127.0.0.1") {
                 continue;
             }
-            paths[attempt] = Message::Path::unixSocketPath(data->port).string();
+            data->current_curl_path =
+                Message::Path::unixSocketPath(data->port).string();
             curl_easy_setopt(handle, CURLOPT_UNIX_SOCKET_PATH,
-                             paths[attempt].c_str());
+                             data->current_curl_path.c_str());
             curl_easy_setopt(handle, CURLOPT_URL,
                              ("ws://" + data->host + "/").c_str());
             break;
         }
-        data->logger_internal->trace("trying {}...", paths[attempt]);
+        data->logger_internal->trace("trying {}...", data->current_curl_path);
         curl_easy_setopt(handle, CURLOPT_PORT, static_cast<long>(data->port));
-        curl_easy_setopt(handle, CURLOPT_CONNECT_ONLY, 2L);
-        curl_result[attempt] = curl_easy_perform(handle);
-        if (*curl_result[attempt] != CURLE_OK) {
-            data->logger_internal->trace(
-                "connection failed {}",
-                static_cast<int>(*curl_result[attempt]));
+
+        if (use_cb) {
+            curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, cb);
+            curl_easy_setopt(handle, CURLOPT_WRITEDATA, data.get());
+        } else {
+            curl_easy_setopt(handle, CURLOPT_CONNECT_ONLY, 2L);
         }
-    }
-    CURL *handle = nullptr;
-    std::string path;
-    for (int attempt = static_cast<int>(data->curl_handles.size() - 1);
-         attempt >= 0; attempt--) {
-        if (curl_result[attempt] && *curl_result[attempt] == CURLE_OK) {
-            handle = static_cast<CURL *>(data->curl_handles[attempt]);
-            path = std::move(paths[attempt]);
-            break;
+        data->current_curl_success = false;
+        data->current_curl_handle = handle;
+        // use_cbがtrueならここでcurl内部のループに入り繰り返しcbが呼ばれる
+        // falseなら即座にreturnしretに結果が入る
+        auto ret = curl_easy_perform(handle);
+
+        if (ret != CURLE_OK) {
+            data->logger_internal->trace("connection failed {}",
+                                         static_cast<int>(ret));
         }
-    }
-    data->current_curl_handle = handle;
-    if (handle) {
-        send(data, data->syncDataFirst());
-        {
-            std::lock_guard lock(data->connect_state_m);
-            data->connected.store(true);
-            data->connect_state_cond.notify_all();
+        if (!use_cb && ret == CURLE_OK) {
+            data->current_curl_success = true;
+            initSuccess(data.get());
+            return;
         }
-        data->logger_internal->debug("connected to {}", path);
-        data->current_curl_closed = false;
+        if (use_cb && data->current_curl_success) {
+            deinit(data);
+            return;
+        }
+        curl_easy_cleanup(handle);
+        data->current_curl_handle = nullptr;
     }
 }
-void close(std::shared_ptr<Internal::ClientData> data) {
+void initSuccess(Internal::ClientData *data) {
+    send(data, data->syncDataFirst());
+    {
+        std::lock_guard lock(data->connect_state_m);
+        data->connected.store(true);
+        data->connect_state_cond.notify_all();
+    }
+    data->logger_internal->debug("connected to {}", data->current_curl_path);
+    data->current_curl_closed = false;
+}
+void deinit(std::shared_ptr<Internal::ClientData> data) {
     {
         std::lock_guard lock(data->connect_state_m);
         data->connected.store(false);
         data->connect_state_cond.notify_all();
     }
-    data->message_queue->clear();
-    data->syncDataFirst(); // 次の接続時の最初のメッセージ
 
-    for (auto &handle : data->curl_handles) {
-        if (handle) {
-            curl_easy_cleanup(static_cast<CURL *>(handle));
-        }
+    if (data->current_curl_handle) {
+        curl_easy_cleanup(static_cast<CURL *>(data->current_curl_handle));
+        data->current_curl_handle = nullptr;
+    }
+}
+
+size_t cb(char *buffer, size_t size, size_t nmemb, void *clientp) {
+    auto data = static_cast<Internal::ClientData *>(clientp);
+    data->logger_internal->trace("callback called");
+    if (!data->current_curl_success) {
+        data->current_curl_success = true;
+        initSuccess(data);
+    }
+
+    CURL *handle = static_cast<CURL *>(data->current_curl_handle);
+    size_t rlen = size * nmemb;
+    const curl_ws_frame *meta = curl_ws_meta(handle);
+    recvFrame(data, buffer, rlen, meta);
+    return rlen;
+}
+
+void recvFrame(Internal::ClientData *data, char *buffer, std::size_t rlen,
+               const void *meta_v) {
+    CURL *handle = static_cast<CURL *>(data->current_curl_handle);
+    auto meta = static_cast<const curl_ws_frame *>(meta_v);
+    if (meta && meta->flags & CURLWS_CLOSE) {
+        data->logger_internal->debug("connection closed");
+        data->current_curl_closed = true;
+    } else if (meta && static_cast<std::size_t>(meta->offset) >
+                           data->current_ws_buf.size()) {
+        data->current_ws_buf.append(static_cast<std::size_t>(meta->offset) -
+                                        data->current_ws_buf.size(),
+                                    '\0');
+        data->current_ws_buf.append(buffer, rlen);
+    } else if (meta && static_cast<std::size_t>(meta->offset) <
+                           data->current_ws_buf.size()) {
+        data->current_ws_buf.replace(static_cast<std::size_t>(meta->offset),
+                                     rlen, buffer, rlen);
+    } else {
+        data->current_ws_buf.append(buffer, rlen);
+    }
+    if (meta && meta->bytesleft == 0 && !data->current_ws_buf.empty()) {
+        data->logger_internal->trace("message received len={}",
+                                     data->current_ws_buf.size());
+        std::size_t sent;
+        curl_ws_send(handle, nullptr, 0, &sent, 0, CURLWS_PONG);
+        // data->recv_queue.push(data->current_ws_buf);
+        data->onRecv(data->current_ws_buf);
+        data->current_ws_buf.clear();
     }
 }
 void recv(std::shared_ptr<Internal::ClientData> data) {
@@ -132,46 +180,22 @@ void recv(std::shared_ptr<Internal::ClientData> data) {
     char buffer[1024];
     do {
         ret = curl_ws_recv(handle, buffer, sizeof(buffer), &rlen, &meta);
-        if (meta && meta->flags & CURLWS_CLOSE) {
-            data->logger_internal->debug("connection closed");
-            data->current_curl_closed = true;
-            break;
-        } else if (meta && static_cast<std::size_t>(meta->offset) >
-                               data->current_ws_buf.size()) {
-            data->current_ws_buf.append(static_cast<std::size_t>(meta->offset) -
-                                            data->current_ws_buf.size(),
-                                        '\0');
-            data->current_ws_buf.append(buffer, rlen);
-        } else if (meta && static_cast<std::size_t>(meta->offset) <
-                               data->current_ws_buf.size()) {
-            data->current_ws_buf.replace(static_cast<std::size_t>(meta->offset),
-                                         rlen, buffer, rlen);
-        } else {
-            data->current_ws_buf.append(buffer, rlen);
-        }
-        if (ret != CURLE_AGAIN && ret != CURLE_OK) {
-            data->logger_internal->debug("connection closed {}",
-                                         static_cast<int>(ret));
-            data->current_curl_closed = true;
-            break;
-        }
+        recvFrame(data.get(), buffer, rlen, meta);
     } while (meta && meta->bytesleft > 0 && ret != CURLE_AGAIN);
-    if (ret == CURLE_OK && meta && meta->bytesleft == 0 &&
-        !data->current_ws_buf.empty()) {
-        data->logger_internal->trace("message received len={}",
-                                     data->current_ws_buf.size());
-        std::size_t sent;
-        curl_ws_send(handle, nullptr, 0, &sent, 0, CURLWS_PONG);
-        // data->recv_queue.push(data->current_ws_buf);
-        data->onRecv(data->current_ws_buf);
-        data->current_ws_buf.clear();
-    }
 }
-void send(std::shared_ptr<Internal::ClientData> data, const std::string &msg) {
+
+void send(Internal::ClientData *data, const std::string &msg) {
     data->logger_internal->trace("sending message");
     std::size_t sent;
     CURL *handle = static_cast<CURL *>(data->current_curl_handle);
     curl_ws_send(handle, msg.c_str(), msg.size(), &sent, 0, CURLWS_BINARY);
+    // data->logger_internal->trace("sending done");
+}
+void close(Internal::ClientData *data) {
+    data->logger_internal->trace("closing");
+    std::size_t sent;
+    CURL *handle = static_cast<CURL *>(data->current_curl_handle);
+    curl_ws_send(handle, nullptr, 0, &sent, 0, CURLWS_CLOSE);
     // data->logger_internal->trace("sending done");
 }
 

--- a/src/client/client_ws.cc
+++ b/src/client/client_ws.cc
@@ -1,186 +1,180 @@
+#include "client_ws.h"
+#include "client_internal.h"
 #include <webcface/client.h>
 #include "../message/unix_path.h"
-#include "client_internal.h"
 #include <curl/curl.h>
 #include <string>
 #include <chrono>
 #include <thread>
 #include <cstdint>
 #include <cstdlib>
-#include <array>
 
 WEBCFACE_NS_BEGIN
+namespace Internal {
+namespace WebSocket {
 
-void Internal::messageThreadMain(std::shared_ptr<Internal::ClientData> data,
-                                 std::string host, int port) {
-    if (host.empty()) {
-        host = "127.0.0.1";
+void init(std::shared_ptr<Internal::ClientData> data) {
+    if (data->host.empty()) {
+        data->host = "127.0.0.1";
     }
-    while (!data->closing.load() && port > 0) {
-        // try TCP, unixSocketPathWSLInterop and unixSocketPath
-        // use latter if multiple connections were available
-        std::array<CURL *, 3> handles;
-        handles.fill(nullptr);
-        std::array<std::optional<CURLcode>, 3> curl_result;
-        curl_result.fill(std::nullopt);
-        std::array<std::string, 3> paths;
-        for (std::size_t attempt = 0;
-             attempt < handles.size() && !data->closing.load(); attempt++) {
-            CURL *handle = handles[attempt] = curl_easy_init();
-            curl_result[attempt] = std::nullopt;
-            if (std::getenv("WEBCFACE_TRACE") != nullptr) {
-                curl_easy_setopt(handle, CURLOPT_VERBOSE, 1L);
-            }
-            switch (attempt) {
-            case 0:
-                paths[attempt] = host + ':' + std::to_string(port);
-                curl_easy_setopt(handle, CURLOPT_URL,
-                                 ("ws://" + host + "/").c_str());
-                break;
-            case 1:
-                if (host != "127.0.0.1") {
-                    continue;
-                }
-                if (Message::Path::detectWSL1()) {
-                    paths[attempt] =
-                        Message::Path::unixSocketPathWSLInterop(port).string();
-                    curl_easy_setopt(handle, CURLOPT_UNIX_SOCKET_PATH,
-                                     paths[attempt].c_str());
-                    curl_easy_setopt(handle, CURLOPT_URL,
-                                     ("ws://" + host + "/").c_str());
-                    break;
-                }
-                if (Message::Path::detectWSL2() &&
-                    !(curl_result[0] && curl_result[0] == CURLE_OK)) {
-                    std::string win_host = Message::Path::wsl2Host();
-                    if (!win_host.empty()) {
-                        paths[attempt] = win_host + ':' + std::to_string(port);
-                        curl_easy_setopt(handle, CURLOPT_URL,
-                                         ("ws://" + win_host + "/").c_str());
-                        break;
-                    }
-                }
+    // try TCP, unixSocketPathWSLInterop and unixSocketPath
+    // use latter if multiple connections were available
+    data->curl_handles.fill(nullptr);
+    std::array<std::optional<CURLcode>, 3> curl_result;
+    curl_result.fill(std::nullopt);
+    std::array<std::string, 3> paths;
+    for (std::size_t attempt = 0;
+         attempt < data->curl_handles.size() && !data->closing.load();
+         attempt++) {
+        CURL *handle = data->curl_handles[attempt] = curl_easy_init();
+        curl_result[attempt] = std::nullopt;
+        if (std::getenv("WEBCFACE_TRACE") != nullptr) {
+            curl_easy_setopt(handle, CURLOPT_VERBOSE, 1L);
+        }
+        switch (attempt) {
+        case 0:
+            paths[attempt] = data->host + ':' + std::to_string(data->port);
+            curl_easy_setopt(handle, CURLOPT_URL,
+                             ("ws://" + data->host + "/").c_str());
+            break;
+        case 1:
+            if (data->host != "127.0.0.1") {
                 continue;
-            case 2:
-                if (host != "127.0.0.1") {
-                    continue;
-                }
-                paths[attempt] = Message::Path::unixSocketPath(port).string();
+            }
+            if (Message::Path::detectWSL1()) {
+                paths[attempt] =
+                    Message::Path::unixSocketPathWSLInterop(data->port)
+                        .string();
                 curl_easy_setopt(handle, CURLOPT_UNIX_SOCKET_PATH,
                                  paths[attempt].c_str());
                 curl_easy_setopt(handle, CURLOPT_URL,
-                                 ("ws://" + host + "/").c_str());
+                                 ("ws://" + data->host + "/").c_str());
                 break;
             }
-            data->logger_internal->trace("trying {}...", paths[attempt]);
-            curl_easy_setopt(handle, CURLOPT_PORT, static_cast<long>(port));
-            curl_easy_setopt(handle, CURLOPT_CONNECT_ONLY, 2L);
-            curl_result[attempt] = curl_easy_perform(handle);
-            if (*curl_result[attempt] != CURLE_OK) {
-                data->logger_internal->trace(
-                    "connection failed {}",
-                    static_cast<int>(*curl_result[attempt]));
-            }
-        }
-        CURL *handle = nullptr;
-        std::string path;
-        for (int attempt = static_cast<int>(handles.size() - 1); attempt >= 0;
-             attempt--) {
-            if (curl_result[attempt] && *curl_result[attempt] == CURLE_OK) {
-                handle = handles[attempt];
-                path = std::move(paths[attempt]);
-                break;
-            }
-        }
-        if (handle != nullptr && !data->closing.load()) {
-            {
-                std::lock_guard lock(data->connect_state_m);
-                data->connected.store(true);
-                data->connect_state_cond.notify_all();
-            }
-            data->logger_internal->debug("connected to {}", path);
-            std::string buf_s;
-            do {
-                // data->logger_internal->trace("loop");
-                bool closed = false;
-                CURLcode ret;
-                // 受信ループ
-                while (true) {
-                    std::size_t rlen = 0;
-                    // data->logger_internal->trace("recv");
-                    const curl_ws_frame *meta = nullptr;
-                    char buffer[1024];
-                    do {
-                        ret = curl_ws_recv(handle, buffer, sizeof(buffer),
-                                           &rlen, &meta);
-                        if (meta && meta->flags & CURLWS_CLOSE) {
-                            data->logger_internal->debug("connection closed");
-                            closed = true;
-                            break;
-                        } else if (meta && static_cast<std::size_t>(
-                                               meta->offset) > buf_s.size()) {
-                            buf_s.append(
-                                static_cast<std::size_t>(meta->offset) -
-                                    buf_s.size(),
-                                '\0');
-                            buf_s.append(buffer, rlen);
-                        } else if (meta && static_cast<std::size_t>(
-                                               meta->offset) < buf_s.size()) {
-                            buf_s.replace(
-                                static_cast<std::size_t>(meta->offset), rlen,
-                                buffer, rlen);
-                        } else {
-                            buf_s.append(buffer, rlen);
-                        }
-                    } while (meta && meta->bytesleft > 0);
-                    if (buf_s.empty()) {
-                        break;
-                    }
-                    if (ret == CURLE_OK && meta && meta->bytesleft == 0) {
-                        data->logger_internal->trace("message received len={}",
-                                                     buf_s.size());
-                        data->recv_queue.push(buf_s);
-                        std::size_t sent;
-                        curl_ws_send(handle, nullptr, 0, &sent, 0, CURLWS_PONG);
-                        buf_s.clear();
-                    }
-                }
-                if (ret != CURLE_AGAIN && ret != CURLE_OK) {
-                    data->logger_internal->debug("connection closed {}",
-                                                 static_cast<int>(ret));
-                    closed = true;
-                }
-                if (closed) {
+            if (Message::Path::detectWSL2() &&
+                !(curl_result[0] && curl_result[0] == CURLE_OK)) {
+                std::string win_host = Message::Path::wsl2Host();
+                if (!win_host.empty()) {
+                    paths[attempt] =
+                        win_host + ':' + std::to_string(data->port);
+                    curl_easy_setopt(handle, CURLOPT_URL,
+                                     ("ws://" + win_host + "/").c_str());
                     break;
                 }
-                // 最低一回はqueueが空になるまで送信する。
-                while (auto msg = data->message_queue->pop()) {
-                    data->logger_internal->trace("sending message");
-                    std::size_t sent;
-                    curl_ws_send(handle, msg->c_str(), msg->size(), &sent, 0,
-                                 CURLWS_BINARY);
-                    // data->logger_internal->trace("sending done");
-                }
-                // data->logger_internal->trace("yield");
-                std::this_thread::yield();
-            } while (!data->closing.load());
-            {
-                std::lock_guard lock(data->connect_state_m);
-                data->connected.store(false);
-                data->connect_state_cond.notify_all();
             }
-            data->message_queue->clear();
-            data->syncDataFirst(); // 次の接続時の最初のメッセージ
-        }
-        for (auto &handle : handles) {
-            if (handle) {
-                curl_easy_cleanup(handle);
+            continue;
+        case 2:
+            if (data->host != "127.0.0.1") {
+                continue;
             }
+            paths[attempt] = Message::Path::unixSocketPath(data->port).string();
+            curl_easy_setopt(handle, CURLOPT_UNIX_SOCKET_PATH,
+                             paths[attempt].c_str());
+            curl_easy_setopt(handle, CURLOPT_URL,
+                             ("ws://" + data->host + "/").c_str());
+            break;
         }
-        if (!data->closing.load()) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        data->logger_internal->trace("trying {}...", paths[attempt]);
+        curl_easy_setopt(handle, CURLOPT_PORT, static_cast<long>(data->port));
+        curl_easy_setopt(handle, CURLOPT_CONNECT_ONLY, 2L);
+        curl_result[attempt] = curl_easy_perform(handle);
+        if (*curl_result[attempt] != CURLE_OK) {
+            data->logger_internal->trace(
+                "connection failed {}",
+                static_cast<int>(*curl_result[attempt]));
+        }
+    }
+    CURL *handle = nullptr;
+    std::string path;
+    for (int attempt = static_cast<int>(data->curl_handles.size() - 1);
+         attempt >= 0; attempt--) {
+        if (curl_result[attempt] && *curl_result[attempt] == CURLE_OK) {
+            handle = static_cast<CURL *>(data->curl_handles[attempt]);
+            path = std::move(paths[attempt]);
+            break;
+        }
+    }
+    data->current_curl_handle = handle;
+    if (handle) {
+        send(data, data->syncDataFirst());
+        {
+            std::lock_guard lock(data->connect_state_m);
+            data->connected.store(true);
+            data->connect_state_cond.notify_all();
+        }
+        data->logger_internal->debug("connected to {}", path);
+        data->current_curl_closed = false;
+    }
+}
+void close(std::shared_ptr<Internal::ClientData> data) {
+    {
+        std::lock_guard lock(data->connect_state_m);
+        data->connected.store(false);
+        data->connect_state_cond.notify_all();
+    }
+    data->message_queue->clear();
+    data->syncDataFirst(); // 次の接続時の最初のメッセージ
+
+    for (auto &handle : data->curl_handles) {
+        if (handle) {
+            curl_easy_cleanup(static_cast<CURL *>(handle));
         }
     }
 }
+void recv(std::shared_ptr<Internal::ClientData> data) {
+    // data->logger_internal->trace("loop");
+    CURL *handle = static_cast<CURL *>(data->current_curl_handle);
+    CURLcode ret;
 
+    std::size_t rlen = 0;
+    // data->logger_internal->trace("recv");
+    const curl_ws_frame *meta = nullptr;
+    char buffer[1024];
+    do {
+        ret = curl_ws_recv(handle, buffer, sizeof(buffer), &rlen, &meta);
+        if (meta && meta->flags & CURLWS_CLOSE) {
+            data->logger_internal->debug("connection closed");
+            data->current_curl_closed = true;
+            break;
+        } else if (meta && static_cast<std::size_t>(meta->offset) >
+                               data->current_ws_buf.size()) {
+            data->current_ws_buf.append(static_cast<std::size_t>(meta->offset) -
+                                            data->current_ws_buf.size(),
+                                        '\0');
+            data->current_ws_buf.append(buffer, rlen);
+        } else if (meta && static_cast<std::size_t>(meta->offset) <
+                               data->current_ws_buf.size()) {
+            data->current_ws_buf.replace(static_cast<std::size_t>(meta->offset),
+                                         rlen, buffer, rlen);
+        } else {
+            data->current_ws_buf.append(buffer, rlen);
+        }
+        if (ret != CURLE_AGAIN && ret != CURLE_OK) {
+            data->logger_internal->debug("connection closed {}",
+                                         static_cast<int>(ret));
+            data->current_curl_closed = true;
+            break;
+        }
+    } while (meta && meta->bytesleft > 0 && ret != CURLE_AGAIN);
+    if (ret == CURLE_OK && meta && meta->bytesleft == 0 &&
+        !data->current_ws_buf.empty()) {
+        data->logger_internal->trace("message received len={}",
+                                     data->current_ws_buf.size());
+        std::size_t sent;
+        curl_ws_send(handle, nullptr, 0, &sent, 0, CURLWS_PONG);
+        // data->recv_queue.push(data->current_ws_buf);
+        data->onRecv(data->current_ws_buf);
+        data->current_ws_buf.clear();
+    }
+}
+void send(std::shared_ptr<Internal::ClientData> data, const std::string &msg) {
+    data->logger_internal->trace("sending message");
+    std::size_t sent;
+    CURL *handle = static_cast<CURL *>(data->current_curl_handle);
+    curl_ws_send(handle, msg.c_str(), msg.size(), &sent, 0, CURLWS_BINARY);
+    // data->logger_internal->trace("sending done");
+}
+
+} // namespace WebSocket
+} // namespace Internal
 WEBCFACE_NS_END

--- a/src/client/client_ws.h
+++ b/src/client/client_ws.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <webcface/common/def.h>
+#include "client_internal.h"
+
+WEBCFACE_NS_BEGIN
+namespace Internal {
+namespace WebSocket {
+/*!
+ * \brief WebSocketに接続する
+ *
+ * 成功すると
+ * data->syncDataFirst()をsendし、
+ * data->connectedをtrueにし、
+ * data->current_curl_handleがnullptrでない値になる
+ *
+ */
+WEBCFACE_DLL void init(std::shared_ptr<Internal::ClientData> data);
+/*!
+ * \brief 切断しhandleをfreeする
+ *
+ */
+WEBCFACE_DLL void close(std::shared_ptr<Internal::ClientData> data);
+/*!
+ * \brief messageを1回受信しdata->onRecvを呼ぶ
+ *
+ */
+WEBCFACE_DLL void recv(std::shared_ptr<Internal::ClientData> data);
+/*!
+ * \brief メッセージを送信する
+ *
+ */
+WEBCFACE_DLL void send(std::shared_ptr<Internal::ClientData> data,
+                       const std::string &msg);
+
+} // namespace WebSocket
+} // namespace Internal
+WEBCFACE_NS_END

--- a/src/client/client_ws.h
+++ b/src/client/client_ws.h
@@ -8,29 +8,63 @@ namespace WebSocket {
 /*!
  * \brief WebSocketに接続する
  *
+ * use_cbがfalseの場合、接続を1回試行しreturn
  * 成功すると
+ * data->current_curl_successをtrueにし、
+ * initSuccess()を呼び、
+ * data->current_curl_handle にhandleが入る
+ *
+ * use_cbがtrueの場合、接続後curl内部のループが回る
+ * 切断されたときdeinit()を呼びreturnする
+ *
+ */
+WEBCFACE_DLL void init(std::shared_ptr<Internal::ClientData> data, bool use_cb);
+/*!
+ * \brief 接続に成功したときの初期化処理
+ *
+ * init()の中で呼ばれ、
  * data->syncDataFirst()をsendし、
  * data->connectedをtrueにし、
- * data->current_curl_handleがnullptrでない値になる
+ * data->current_curl_closedをfalseにする
  *
  */
-WEBCFACE_DLL void init(std::shared_ptr<Internal::ClientData> data);
+WEBCFACE_DLL void initSuccess(Internal::ClientData *data);
 /*!
- * \brief 切断しhandleをfreeする
+ * \brief handleをfreeする
  *
  */
-WEBCFACE_DLL void close(std::shared_ptr<Internal::ClientData> data);
+WEBCFACE_DLL void deinit(std::shared_ptr<Internal::ClientData> data);
+
 /*!
- * \brief messageを1回受信しdata->onRecvを呼ぶ
+ * \brief curlから呼ばれるコールバック
+ *
+ * 初回の呼び出しでinitSuccessを呼び、
+ * それ以降はrecvFrameを呼ぶ
+ *
+ */
+WEBCFACE_DLL size_t cb(char *buffer, size_t size, size_t nmemb, void *clientp);
+/*!
+ * \brief messageを1回受信しrecvFrameを呼ぶ
  *
  */
 WEBCFACE_DLL void recv(std::shared_ptr<Internal::ClientData> data);
 /*!
+ * \brief メッセージを処理しdata->onRecvを呼ぶ
+ *
+ */
+WEBCFACE_DLL void recvFrame(Internal::ClientData *data, char *buffer,
+                            std::size_t rlen, const void *meta_v);
+
+/*!
  * \brief メッセージを送信する
  *
  */
-WEBCFACE_DLL void send(std::shared_ptr<Internal::ClientData> data,
-                       const std::string &msg);
+WEBCFACE_DLL void send(Internal::ClientData *data, const std::string &msg);
+/*!
+ * \brief curlws_closeを送る
+ *
+ */
+WEBCFACE_DLL void close(Internal::ClientData *data);
 
 } // namespace WebSocket
 } // namespace Internal

--- a/src/include/webcface/client.h
+++ b/src/include/webcface/client.h
@@ -68,18 +68,33 @@ class WEBCFACE_DLL Client : public Member {
     void close();
 
     /*!
-     * \brief (ver1.2で追加) サーバーに接続を開始する。
+     * \brief 通信が切断されたときに自動で再試行するかどうかを設定する。
+     * \since ver1.12
      *
+     * デフォルトはtrue
+     *
+     */
+    void autoReconnect(bool enabled);
+    /*!
+     * \brief 通信が切断されたときに自動で再試行するかどうかを取得する。
+     * \since ver1.12
+     */
+    bool autoReconnect() const;
+
+    /*!
+     * \brief サーバーへの接続を開始する。
+     * \since ver1.2
      */
     void start();
     /*!
-     * \brief (ver1.2で追加) サーバーに接続が成功するまで待機する。
+     * \brief サーバーへの接続を開始し、成功するまで待機する。
+     * \since ver1.2
+     * ver1.12以降: 接続が成功したかどうか(connected()の値)を返す。
+     * autoReconnect がfalseの場合は接続失敗でfalseを返すこともある。
      *
-     * 接続していない場合、start()を呼び出す。
      * \sa start()
-     *
      */
-    void waitConnection();
+    bool waitConnection();
 
     /*!
      * \brief 送信用にセットしたデータをすべて送信キューに入れる。
@@ -87,8 +102,8 @@ class WEBCFACE_DLL Client : public Member {
      * 実際に送信をするのは別スレッドであり、この関数はブロックしない。
      *
      * ver1.2以降: サーバーに接続していない場合、start()を呼び出す。
-     * \sa start()
      *
+     * \sa start()
      */
     void sync();
 
@@ -96,8 +111,8 @@ class WEBCFACE_DLL Client : public Member {
      * \brief 他のmemberにアクセスする
      *
      * (ver1.7から)nameが空の場合 *this を返す
-     * \sa members(), onMemberEntry()
      *
+     * \sa members(), onMemberEntry()
      */
     Member member(const std::string &name) {
         if (name.empty()) {

--- a/src/server/websock.cc
+++ b/src/server/websock.cc
@@ -143,6 +143,7 @@ Server::Server(int port, const spdlog::sink_ptr &sink,
             .onopen([this, sink, level](crow::websocket::connection &conn) {
                 std::lock_guard lock(server_mtx);
                 store->newClient(&conn, conn.get_remote_ip(), sink, level);
+                conn.send_binary("");
             })
             .onclose([this](crow::websocket::connection &conn,
                             const std::string & /*reason*/) {

--- a/src/test/client_test.cc
+++ b/src/test/client_test.cc
@@ -91,6 +91,31 @@ TEST_F(ClientTest, connectionByWait) {
     EXPECT_TRUE(dummy_s->connected());
     EXPECT_TRUE(wcli_->connected());
 }
+TEST_F(ClientTest, noAutoReconnect) {
+    EXPECT_TRUE(wcli_->autoReconnect());
+    EXPECT_FALSE(wcli_->connected());
+    wcli_->autoReconnect(false);
+    EXPECT_FALSE(wcli_->autoReconnect());
+    wcli_->waitConnection();
+    EXPECT_FALSE(wcli_->connected());
+
+    dummy_s = std::make_shared<DummyServer>(false);
+    wait();
+    EXPECT_FALSE(dummy_s->connected());
+    EXPECT_FALSE(wcli_->connected());
+    wcli_->waitConnection();
+    EXPECT_TRUE(dummy_s->connected());
+    EXPECT_TRUE(wcli_->connected());
+
+    dummy_s.reset();
+    wait();
+    EXPECT_FALSE(wcli_->connected());
+
+    dummy_s = std::make_shared<DummyServer>(false);
+    wait();
+    EXPECT_FALSE(dummy_s->connected());
+    EXPECT_FALSE(wcli_->connected());
+}
 TEST_F(ClientTest, connectionBySync) {
     dummy_s = std::make_shared<DummyServer>(false);
     wait();

--- a/src/test/dummy_client.cc
+++ b/src/test/dummy_client.cc
@@ -78,7 +78,7 @@ DummyClient::DummyClient(bool use_unix)
                           buf_s.clear();
                       }
                   }
-                  if (ret != CURLE_AGAIN) {
+                  if (ret != CURLE_AGAIN && ret != CURLE_OK) {
                       dummy_logger->debug("connection closed {}",
                                           static_cast<int>(ret));
                       break;

--- a/src/test/dummy_server.cc
+++ b/src/test/dummy_server.cc
@@ -40,16 +40,19 @@ DummyServer::DummyServer(bool use_unix)
           CROW_WEBSOCKET_ROUTE((*server), "/")
               // route.websocket<std::remove_reference<decltype(*app)>::type>(app.get())
               .onopen([&](crow::websocket::connection &conn) {
+                  std::lock_guard lock(m);
                   connPtr = &conn;
                   dummy_logger->info("ws_open");
                   conn.send_binary("");
               })
               .onclose([&](crow::websocket::connection &, const std::string &) {
+                  std::lock_guard lock(m);
                   connPtr = nullptr;
                   dummy_logger->info("ws_close");
               })
               .onmessage([&](crow::websocket::connection &,
                              const std::string &data, bool) {
+                  std::lock_guard lock(m);
                   dummy_logger->info("ws_message");
                   auto unpacked = Message::unpack(data, dummy_logger);
                   for (const auto &m : unpacked) {
@@ -69,6 +72,7 @@ DummyServer::DummyServer(bool use_unix)
       }) {}
 
 void DummyServer::send(std::string msg) {
+    std::lock_guard lock(m);
     if (connPtr) {
         dummy_logger->info("send {} bytes", msg.size());
         reinterpret_cast<crow::websocket::connection *>(connPtr)->send_binary(

--- a/src/test/dummy_server.cc
+++ b/src/test/dummy_server.cc
@@ -42,6 +42,7 @@ DummyServer::DummyServer(bool use_unix)
               .onopen([&](crow::websocket::connection &conn) {
                   connPtr = &conn;
                   dummy_logger->info("ws_open");
+                  conn.send_binary("");
               })
               .onclose([&](crow::websocket::connection &, const std::string &) {
                   connPtr = nullptr;

--- a/src/test/dummy_server.h
+++ b/src/test/dummy_server.h
@@ -34,6 +34,7 @@ struct DummyServer {
     void *connPtr = nullptr;
     std::shared_ptr<void> server_;
     std::shared_ptr<spdlog::logger> dummy_logger;
+    std::mutex m;
 
     std::thread t;
     explicit DummyServer(bool use_unix = false);


### PR DESCRIPTION
* fix #251 
* 以前のサーバーとは通信できない (serverが接続完了時にメッセージを送信するようにしないとcurlのコールバックが呼ばれず止まってしまう)