### PR TITLE
Fix cmake (v1.11.4)

### DIFF
--- a/.github/workflows/cmake-test-windows-msvc.yml
+++ b/.github/workflows/cmake-test-windows-msvc.yml
@@ -18,7 +18,7 @@ jobs:
         include:
         - dep: with-opencv
           use_opencv: on
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - uses: actions/checkout@v4
     # - name: vcpkg build
@@ -42,18 +42,16 @@ jobs:
       run: echo "c:\tools\opencv\build\x64\vc16\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     
     - name: Configure CMake
-      run: >
-        cmake -B build
-        -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-        -DWEBCFACE_TEST=on
-        -DWEBCFACE_EXAMPLE=on
-        -DWEBCFACE_TEST_TIMEOUT=1000
-        -DWEBCFACE_USE_OPENCV=${{matrix.use_opencv}}
-        -DCMAKE_PREFIX_PATH=c:\tools\opencv\build\x64\vc16\lib
+      run: |
+          ${VS_INST_PATH} = & "${env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe" -latest -property installationPath
+          Write-Output "  <-> VS Install Path: ${VS_INST_PATH}"
+          Import-Module ${VS_INST_PATH}/Common7/Tools/Microsoft.VisualStudio.DevShell.dll
+          Enter-VsDevShell -VsInstallPath ${VS_INST_PATH} -SkipAutomaticLocation -DevCmdArguments '-arch=${{matrix.config.arch}} -no_logo'
+          cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DWEBCFACE_TEST=on -DWEBCFACE_EXAMPLE=on -DWEBCFACE_TEST_TIMEOUT=1000 -DWEBCFACE_USE_OPENCV=${{matrix.use_opencv}} -DCMAKE_PREFIX_PATH=c:\tools\opencv\build\x64\vc16\lib
     # ${{ steps.vcpkg.outputs.vcpkg-cmake-config }}
 
     - name: Build
-      run: cmake --build build
+      run: cmake --build build --config ${{env.BUILD_TYPE}}
 
     - name: Test
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/build*/
+build*/
 /out/
 /.vs/
 /CMakeSettings.json
@@ -7,3 +7,4 @@
 /src/include/webcface/common/def.h
 version.rc
 /Testing/
+/.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.11.4] - 2024-06-12
+### Changed
+* CMakeListsでfetchするcrowのタグを固定 (#277)
+
 ## [1.11.3] - 2024-05-03
 ### Changed
 * def.hとversion.rcの生成をbuildディレクトリ内に変更 (#259)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,10 +83,6 @@ if(WEBCFACE_COVERAGE)
     endif()
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(-Wno-psabi) # refer to PR#9
-endif()
-
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     add_compile_definitions(
         _CRT_SECURE_NO_WARNINGS
@@ -273,9 +269,6 @@ if(NOT asio_POPULATED)
         ${asio_SOURCE_DIR}/asio/include
     )
     target_compile_definitions(asio INTERFACE ASIO_STANDALONE)
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        target_compile_options(asio INTERFACE -Wno-deprecated-declarations)
-    endif()
     if(MINGW)
         target_link_libraries(asio INTERFACE ws2_32 wsock32)
     endif()
@@ -298,9 +291,6 @@ if(NOT crow_POPULATED)
         ${crow_SOURCE_DIR}/include
     )
     target_link_libraries(Crow INTERFACE asio)
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        target_compile_options(Crow INTERFACE -Wno-type-limits)
-    endif()
 endif()
 
 message(STATUS "Fetching cli11 Source...")
@@ -345,24 +335,39 @@ if(WEBCFACE_TEST)
 endif()
 
 ###############################################################################
+include(CheckCXXCompilerFlag)
+function(add_cxx_compile_options_if FLAG NAME)
+    check_cxx_compiler_flag(${FLAG} FLAG_${NAME}_EXISTS)
+    if(FLAG_${NAME}_EXISTS)
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${FLAG}>)
+    endif()
+endfunction()
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wall -Wextra -Wpedantic -Werror)
     add_compile_options(-Wno-error=deprecated-declarations)
-    add_compile_options(-Wno-psabi) # refer to PR#9
-    add_compile_options( # inside opencv
-        $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-enum-enum-conversion>
-    )
-    add_compile_options( # inside fmt (fmtlib/fmt#3354)
-        -Wno-array-bounds
-        -Wno-stringop-overflow
-    )
+    add_compile_options(-Wno-error=psabi) # refer to PR#9
+    # crow
+    add_compile_options(-Wno-error=type-limits)
+    # inside opencv
+    add_cxx_compile_options_if(-Wno-error=deprecated-enum-enum-conversion DEPRECATED_ENUM)
+    # inside fmt (fmtlib/fmt#3354)
+    add_compile_options(-Wno-error=array-bounds -Wno-error=stringop-overflow)
+    # (fmtlib/fmt#3415)
+    add_cxx_compile_options_if(-Wno-error=dangling-reference DANGLING_REFERENCE)
 endif()
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     add_compile_options(-Wall -Wextra -Wpedantic -Werror)
     add_compile_options(-Wno-error=deprecated-declarations)
-    add_compile_options( # inside opencv
-        -Wno-c11-extensions
-        $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-enum-enum-conversion>
+    add_compile_options(
+        --system-header-prefix=msgpack.hpp
+        --system-header-prefix=eventpp/
+        --system-header-prefix=spdlog/
+        --system-header-prefix=curl/
+        --system-header-prefix=crow.h
+        --system-header-prefix=opencv2/
+        --system-header-prefix=utf8.h
+        --system-header-prefix=CLI/
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(webcface
     LANGUAGES CXX C
-    VERSION 1.11.3
+    VERSION 1.11.4
     HOMEPAGE_URL "https://github.com/na-trium-144/webcface"
     DESCRIPTION "Web-based RPC & UI Library"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,8 +288,7 @@ FetchContent_Declare(crow
     # GIT_REPOSITORY https://github.com/CrowCpp/Crow.git
     # GIT_TAG 921ce6f
     GIT_REPOSITORY https://github.com/na-trium-144/Crow.git
-    GIT_TAG unix_socket
-    CONFIGURE_COMMAND ""
+    GIT_TAG 5f5372ed80860dfcef788972bb0fd3972f715842
 )
 FetchContent_GetProperties(crow)
 if(NOT crow_POPULATED)

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "WebCFace"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "1.11.3"
+PROJECT_NUMBER         = "1.11.4"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Debianなど他のディストリビューションで動作するかはわか�
 <details open><summary>x86_64</summary>
 
 ```sh
-curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.3/webcface_1.11.3-ubuntu24.04_amd64.deb
+curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.4/webcface_1.11.4-ubuntu24.04_amd64.deb
 curl -fLO https://github.com/na-trium-144/webcface-webui/releases/download/v1.6.0/webcface-webui_1.6.0-s_amd64.deb
 curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.4/webcface-tools_1.4.4-ubuntu24.04_amd64.deb
 ```
@@ -82,7 +82,7 @@ curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.
 <details><summary>arm64</summary>
 
 ```sh
-curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.3/webcface_1.11.3-ubuntu24.04_arm64.deb
+curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.4/webcface_1.11.4-ubuntu24.04_arm64.deb
 curl -fLO https://github.com/na-trium-144/webcface-webui/releases/download/v1.6.0/webcface-webui_1.6.0-s_arm64.deb
 curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.4/webcface-tools_1.4.4-ubuntu24.04_arm64.deb
 ```
@@ -91,7 +91,7 @@ curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.
 <details><summary>armhf</summary>
 
 ```sh
-curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.3/webcface_1.11.3-ubuntu24.04_armhf.deb
+curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.4/webcface_1.11.4-ubuntu24.04_armhf.deb
 curl -fLO https://github.com/na-trium-144/webcface-webui/releases/download/v1.6.0/webcface-webui_1.6.0-s_armhf.deb
 curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.4/webcface-tools_1.4.4-ubuntu24.04_armhf.deb
 ```
@@ -101,7 +101,7 @@ curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.
 <details open><summary>x86_64</summary>
 
 ```sh
-curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.3/webcface_1.11.3-ubuntu22.04_amd64.deb
+curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.4/webcface_1.11.4-ubuntu22.04_amd64.deb
 curl -fLO https://github.com/na-trium-144/webcface-webui/releases/download/v1.6.0/webcface-webui_1.6.0-s_amd64.deb
 curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.4/webcface-tools_1.4.4-ubuntu22.04_amd64.deb
 ```
@@ -110,7 +110,7 @@ curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.
 <details><summary>arm64</summary>
 
 ```sh
-curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.3/webcface_1.11.3-ubuntu22.04_arm64.deb
+curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.4/webcface_1.11.4-ubuntu22.04_arm64.deb
 curl -fLO https://github.com/na-trium-144/webcface-webui/releases/download/v1.6.0/webcface-webui_1.6.0-s_arm64.deb
 curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.4/webcface-tools_1.4.4-ubuntu22.04_arm64.deb
 ```
@@ -119,7 +119,7 @@ curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.
 <details><summary>armhf</summary>
 
 ```sh
-curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.3/webcface_1.11.3-ubuntu22.04_armhf.deb
+curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.4/webcface_1.11.4-ubuntu22.04_armhf.deb
 curl -fLO https://github.com/na-trium-144/webcface-webui/releases/download/v1.6.0/webcface-webui_1.6.0-s_armhf.deb
 curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.4/webcface-tools_1.4.4-ubuntu22.04_armhf.deb
 ```
@@ -129,7 +129,7 @@ curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.
 <details><summary>x86_64</summary>
 
 ```sh
-curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.3/webcface_1.11.3-ubuntu20.04_amd64.deb
+curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.4/webcface_1.11.4-ubuntu20.04_amd64.deb
 curl -fLO https://github.com/na-trium-144/webcface-webui/releases/download/v1.6.0/webcface-webui_1.6.0-s_amd64.deb
 curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.4/webcface-tools_1.4.4-ubuntu20.04_amd64.deb
 ```
@@ -138,7 +138,7 @@ curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.
 <details><summary>arm64</summary>
 
 ```sh
-curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.3/webcface_1.11.3-ubuntu20.04_arm64.deb
+curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.4/webcface_1.11.4-ubuntu20.04_arm64.deb
 curl -fLO https://github.com/na-trium-144/webcface-webui/releases/download/v1.6.0/webcface-webui_1.6.0-s_arm64.deb
 curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.4/webcface-tools_1.4.4-ubuntu20.04_arm64.deb
 ```
@@ -147,7 +147,7 @@ curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.
 <details><summary>armhf</summary>
 
 ```sh
-curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.3/webcface_1.11.3-ubuntu20.04_armhf.deb
+curl -fLO https://github.com/na-trium-144/webcface/releases/download/v1.11.4/webcface_1.11.4-ubuntu20.04_armhf.deb
 curl -fLO https://github.com/na-trium-144/webcface-webui/releases/download/v1.6.0/webcface-webui_1.6.0-s_armhf.deb
 curl -fLO https://github.com/na-trium-144/webcface-tools/releases/download/v1.4.4/webcface-tools_1.4.4-ubuntu20.04_armhf.deb
 ```

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
 	<name>webcface</name>
-	<version>1.11.3</version>
+	<version>1.11.4</version>
 	<description>Web-based RPC &amp; UI Library</description>
 	<maintainer email="na-trium-144@users.noreply.github.com">na-trium-144</maintainer>
 	<license>MIT</license>


### PR DESCRIPTION
* CMakeListsでfetchするcrowのタグを固定
* .gitignoreに.cache追加
* windowsのciをwindows-2019に変更