### PR TITLE
SyncInitEnd実装

### DIFF
--- a/client/include/webcface/c_wcf/client.h
+++ b/client/include/webcface/c_wcf/client.h
@@ -71,10 +71,13 @@ WEBCFACE_DLL wcfStatus wcfStart(wcfClient *wcli);
  * * wcfAutoReconnect が無効の場合は1回目の接続のみ待機し、
  * 失敗しても再接続せずreturnする。
  *
+ * \param wcli
+ * \param interval autoRecvが無効の場合、初期化が完了するまで一定間隔ごとに
+ * wcfRecv() をこのスレッドで呼び出す。
  * \return wcliが無効ならWCF_BAD_WCLI
  * \sa wcfStart(), wcfAutoReconnect()
  */
-WEBCFACE_DLL wcfStatus wcfWaitConnection(wcfClient *wcli);
+WEBCFACE_DLL wcfStatus wcfWaitConnection(wcfClient *wcli, int interval);
 /*!
  * \brief 通信が切断されたときに自動で再試行するかどうかを設定する。
  * \since ver1.11.1

--- a/client/include/webcface/client.h
+++ b/client/include/webcface/client.h
@@ -103,10 +103,12 @@ class WEBCFACE_DLL Client : public Member {
      *
      * * ver1.11.1以降: autoReconnect が false
      * の場合は1回目の接続のみ待機し、失敗しても再接続せずreturnする。
-     *
-     * \sa start(), autoReconnect()
+     * * ver2.0以降: autoRecvが無効の場合、初期化が完了するまで一定間隔
+     * (デフォルト=100μs) ごとに recv() をこのスレッドで呼び出す。
+     * 
+     * \sa start(), autoReconnect(), autoRecv()
      */
-    void waitConnection();
+    void waitConnection(std::chrono::microseconds interval = std::chrono::microseconds(100));
 
   private:
     void recvImpl(std::optional<std::chrono::microseconds> timeout);

--- a/client/include/webcface/member.h
+++ b/client/include/webcface/member.h
@@ -196,29 +196,30 @@ class WEBCFACE_DLL Member : protected Field {
     /*!
      * \brief 通信速度を調べる
      *
-     * 初回の呼び出しで通信速度データをリクエストし、
+     * * 初回の呼び出しで通信速度データをリクエストし、
      * sync()後通信速度が得られるようになる
+     * * ver2.0〜 Client自身に対しても使用可能
+     * (Client::pingStatus() または member("自分の名前").pingStatus())
+     *
      * \return 初回→ std::nullopt, 2回目以降(取得できれば)→ pingの往復時間 (ms)
      * \sa onPing()
-     *
      */
     std::optional<int> pingStatus() const;
     /*!
      * \brief 通信速度が更新された時のイベント
      *
-     * コールバックの型は void(Member)
+     * * コールバックの型は void(Member)
+     * * 通常は約5秒に1回更新される。
+     * * pingStatus() と同様、通信速度データのリクエストも行う。
+     * * ver2.0〜 Client自身に対しても使用可能
      *
-     * 通常は約5秒に1回更新される。
-     * pingStatus() と同様、通信速度データのリクエストも行う。
      * \sa pingStatus()
-     *
      */
     Member &onPing(std::function<void(Member)> callback);
 
     /*!
      * \brief Memberを比較
      * \since ver1.11
-     *
      */
     template <typename T>
         requires std::same_as<T, Member> bool

--- a/client/src/c_wcf/client.cc
+++ b/client/src/c_wcf/client.cc
@@ -50,12 +50,12 @@ wcfStatus wcfStart(wcfClient *wcli) {
     wcli_->start();
     return WCF_OK;
 }
-wcfStatus wcfWaitConnection(wcfClient *wcli) {
+wcfStatus wcfWaitConnection(wcfClient *wcli, int interval) {
     auto wcli_ = getWcli(wcli);
     if (!wcli_) {
         return WCF_BAD_WCLI;
     }
-    wcli_->waitConnection();
+    wcli_->waitConnection(std::chrono::microseconds(interval));
     return WCF_OK;
 }
 wcfStatus wcfAutoReconnect(wcfClient *wcli, int enabled) {

--- a/docs/01_client.md
+++ b/docs/01_client.md
@@ -49,7 +49,10 @@ Client オブジェクトを作り、start() を呼ぶことでサーバーへ�
     // または wcli.waitConnection();
     ```
 
-    * `start()` の代わりに `waitConnection()` を使うと接続が完了するまで待機することができます。
+    * <del>`start()` の代わりに `waitConnection()` を使うと接続が完了するまで待機することができます。</del>
+    * <span class="since-c">2.0</span>
+    `start()` の代わりに `waitConnection(interval)` を使うと接続が完了してEntry(=他のクライアントが送信しているデータのリスト)をすべて受信するまで待機することができます。
+        * waitConnectionは通信完了までの間interval間隔でrecv()を呼び出します。(デフォルト: 100μs) 詳細は後述の送受信の説明を参照
     * 接続できているかどうかは `wcli.connected()` で取得できます。
     * 通信が切断された場合は自動で再接続します。
         * <span class="since-c">1.11.1</span>
@@ -94,6 +97,11 @@ Client オブジェクトを作り、start() を呼ぶことでサーバーへ�
     * <span class="since-c">2.0</span>
     ワイド文字列を使用したい場合はそれぞれ `wcfInitDefaultW()`, `wcfInitW()`
     (詳細はこのページのEncodingの章を参照)
+    * <span class="since-c">2.0</span>
+    `wcfStart()` の代わりに `wcfWaitConnection(interval)` を使うと接続が完了してEntry(=他のクライアントが送信しているデータのリスト)をすべて受信するまで待機することができます。
+        * wcfWaitConnectionは通信完了までの間interval(μs)間隔でrecv()を呼び出します。
+        (C++側のデフォルトは100なので、理由がなければ100程度を指定しておけばよいです。
+        詳細は後述の送受信の説明を参照)
     * 接続できているかどうかは `wcfIsConnected(wcli)` で取得できます。
     * 通信が切断された場合は自動で再接続します。
 

--- a/docs/02_member.md
+++ b/docs/02_member.md
@@ -92,6 +92,9 @@ Client::onMemberEntry() で新しいメンバーが接続されたときのイ�
     wcli.onMemberEntry([](webcface::Member m){/* ... */});
     ```
 
+    <span class="since-c">2.0</span>
+    Client::waitConnection()はこのクライアントが接続する前から存在したメンバーすべてについてコールバックを呼んでからreturnします。
+
     \note webcfaceが受け取る関数オブジェクトは基本的にコピーではなくムーブされます。
 
 - <b class="tab-title">JavaScript</b>
@@ -163,6 +166,8 @@ Member::libVersion(), Member::libName(), Member::remoteAddr() でクライアン
 ## ping
 
 Member::pingStatus() でそのクライアントの通信速度を取得できます。(int型で、単位はms)
+ここでは通信速度とはサーバーとクライアントの間で1往復データを送受信するのにかかる遅延です。
+
 通信速度の情報は5秒に1回更新され、更新されたときにonPingイベントが発生します
 
 デフォルトの状態ではpingの情報は受信しませんが、pingStatusまたはonPingに1回アクセスすることでpingの情報がリクエストされ、それ以降は値が送られてくるようになります。
@@ -176,6 +181,13 @@ Member::pingStatus() でそのクライアントの通信速度を取得でき�
         std::cout << m.name() << ": " << m.pingStatus() << " ms" << std::endl;
     });
     ```
+    * ver1.11以前では `onPing().appendListener(...)`
+    * <span class="since-c">1.7</span>
+    appendListener, prependListener ではコールバックの引数が不要な場合は引数のない関数も渡すことができます。
+    * <span class="since-c">1.11</span>
+    onMemberEntry() と同様、 callbackList() でCallbackListにアクセスできます。
+    * <span class="since-c">2.0</span>
+    自分自身のping値も取得できるようになりました。(`wcli.pingStatus()`, `wcli.onPing(...)`)
 
 - <b class="tab-title">JavaScript</b>
     ```ts
@@ -192,22 +204,6 @@ Member::pingStatus() でそのクライアントの通信速度を取得でき�
     ```
 
 </div>
-
-<details><summary>C++ 〜ver1.11</summary>
-
-```cpp
-wcli.member("foo").onPing().appendListener([](webcface::Member m){
-    std::cout << m.name() << ": " << m.pingStatus() << " ms" << std::endl;
-});
-```
-
-<span class="since-c">1.7</span>
-appendListener, prependListener ではコールバックの引数が不要な場合は引数のない関数も渡すことができます。
-
-<span class="since-c">1.11</span>
-onMemberEntry() と同様、 callbackList() でCallbackListにアクセスできます。
-
-</details>
 
 <div class="section_buttons">
 

--- a/docs/10_value.md
+++ b/docs/10_value.md
@@ -454,7 +454,7 @@ Member::onValueEntry() で新しくデータが追加されたときのコール
 
 ただし、コールバックを設定する前から存在したデータについてはコールバックは呼び出されません。
 すべてのデータに対してコールバックが呼ばれるようにしたい場合は、
-Member名がわかっていれば初回の Client::sync() 前に、
+Member名がわかっていれば<del>初回の Client::sync()</del> Client::start() 前に、
 そうでなければ Client::onMemberEntry() イベントのコールバックの中で各種イベントを設定すればよいです。
 
 イベントの詳細な使い方はonMemberEntryと同様です([Member](./02_member.md) のページを参照してください)。
@@ -468,6 +468,9 @@ Member名がわかっていれば初回の Client::sync() 前に、
     ```
 
     ver1.11以前では `.onValueEntry().appendListener(...)`
+
+    <span class="since-c">2.0</span>
+    Client::waitConnection()はこのクライアントが接続する前から存在したデータすべてについてコールバックを呼んでからreturnします。
 
 - <b class="tab-title">JavaScript</b>
     ```ts

--- a/docs/90_message.md
+++ b/docs/90_message.md
@@ -29,14 +29,23 @@ data = {
 * Mが空でない場合のみ、サーバーがm,aを設定し各クライアントに送信し、クライアントは新しいMemberのidを知ることができます
 	* member idはクライアントごとにサーバーが一意に振る1以上の整数です
 
-### svr version (kind = 88)
+### sync init end (kind = 88)
+
+(ver1.11まで: svr version)
+
 ```js
 data = {
 	n: string, // server name
 	v: string, // server version
+	m: number, // member id
 }
 ```
-* サーバーからクライアントに1回送られます
+* <del>サーバーからクライアントに1回送られます</del>
+* <span class="since-c">2.0</span>
+クライアントからサーバーに sync init が送られたあと、
+サーバーはクライアントにすべてのentryを送り、最後に sync init end を送ります
+	* クライアントはwaitConnection()でこれが送られてくるまで待機します
+* <span class="since-c">2.0</span> member id 追加 (sync init をしたメンバーのid)
 
 ### ping (kind = 89)
 ```js

--- a/message/include/webcface/message/message.h
+++ b/message/include/webcface/message/message.h
@@ -55,7 +55,8 @@ enum MessageKindEnum {
     log = 85,
     log_req = 86,
     sync = 87,
-    svr_version = 88,
+    sync_init_end = 88,
+    // svr_version = 88,
     ping = 89,
     ping_status = 90,
     ping_status_req = 91,
@@ -115,10 +116,13 @@ struct WEBCFACE_DLL SyncInit : public MessageBase<MessageKind::sync_init> {
 /*!
  * \brief serverのバージョン情報(server->client)
  *
- * serverはSyncInit受信後にこれを返す
+ * (ver1.11まで: SvrVersion)
+ *
+ * serverはSyncInitを受信してEntryをすべて送信し終わった後にこれを返す
  *
  */
-struct WEBCFACE_DLL SvrVersion : public MessageBase<MessageKind::svr_version> {
+struct WEBCFACE_DLL SyncInitEnd
+    : public MessageBase<MessageKind::sync_init_end> {
     /*!
      * \brief serverの名前
      *
@@ -131,7 +135,13 @@ struct WEBCFACE_DLL SvrVersion : public MessageBase<MessageKind::svr_version> {
      *
      */
     std::string ver;
-    MSGPACK_DEFINE_MAP(MSGPACK_NVP("n", svr_name), MSGPACK_NVP("v", ver))
+    /*!
+     * \brief クライアントのmember id
+     *
+     */
+    unsigned int member_id;
+    MSGPACK_DEFINE_MAP(MSGPACK_NVP("n", svr_name), MSGPACK_NVP("v", ver),
+                       MSGPACK_NVP("m", member_id))
 };
 /*!
  * \brief ping(server->client->server)

--- a/message/src/message.cc
+++ b/message/src/message.cc
@@ -88,7 +88,7 @@ unpack(const std::string &message,
                 MSG_PARSE(LogReq)
                 MSG_PARSE(FuncInfo)
                 MSG_PARSE(Sync)
-                MSG_PARSE(SvrVersion)
+                MSG_PARSE(SyncInitEnd)
                 MSG_PARSE(Ping)
                 MSG_PARSE(PingStatus)
                 MSG_PARSE(PingStatusReq)

--- a/server-store/src/member_data.cc
+++ b/server-store/src/member_data.cc
@@ -188,8 +188,6 @@ void MemberData::onRecv(const std::string &message) {
                     }
                 });
             }
-            this->pack(webcface::message::SvrVersion{
-                {}, WEBCFACE_SERVER_NAME, WEBCFACE_VERSION});
             // 逆に新しいMemberに他の全Memberのentryを通知
             store->forEachWithName([&](auto cd) {
                 if (cd->member_id != this->member_id) {
@@ -271,6 +269,9 @@ void MemberData::onRecv(const std::string &message) {
                     }
                 }
             });
+            logger->trace("send sync_init_end");
+            this->pack(webcface::message::SyncInitEnd{
+                {}, WEBCFACE_SERVER_NAME, WEBCFACE_VERSION, this->member_id});
             break;
         }
         case MessageKind::sync: {
@@ -914,7 +915,7 @@ void MemberData::onRecv(const std::string &message) {
         case MessageKind::res + MessageKind::canvas2d:
         case MessageKind::entry + MessageKind::image:
         case MessageKind::res + MessageKind::image:
-        case MessageKind::svr_version:
+        case MessageKind::sync_init_end:
         case MessageKind::ping_status:
             if (!message_kind_warned[kind]) {
                 logger->warn("Invalid message Kind {}", kind);

--- a/server-store/src/store.cc
+++ b/server-store/src/store.cc
@@ -93,7 +93,7 @@ void ServerStorage::forEach(const std::function<void(MemberDataPtr)> &func) {
 void ServerStorage::forEachWithName(
     const std::function<void(MemberDataPtr)> &func) {
     for (const auto &cd : clients_by_id) {
-        if (cd.second->sync_init) {
+        if (cd.second->sync_init && !cd.second->name.empty()) {
             func(cd.second);
         }
     }


### PR DESCRIPTION
close #268 
close #35 
* messageのSvrVersionをSyncInitEndに改名、member idのフィールドを追加 (kindはそのまま)
* SyncInitEndはEntryがすべて終わってから送られてくるようにした
* onPing(), pingStatus() がClient自身にも使えるようになった
* waitConnection() はSyncInitEndが完了するまで待機するようにした
* Store::forEachWithName() の実装が間違ってたのを修正 (名前のないクライアントも返していた) (逆に修正するとバグることある?)