### PR TITLE
deprecatedの修正

### DIFF
--- a/client/include/webcface/c_wcf/client.h
+++ b/client/include/webcface/c_wcf/client.h
@@ -99,16 +99,28 @@ WEBCFACE_DLL wcfStatus WEBCFACE_CALL wcfAutoReconnect(wcfClient *wcli,
  * それがすべて完了するまでこの関数はブロックされる。
  * * データを何も受信しなかった場合、サーバーに接続していない場合、
  * または接続試行中やデータ送信中など受信ができない場合は、
- * timeout経過後にreturnする。
- * timeout=0 または負の値なら即座にreturnする。
- * * timeoutが100μs以上の場合、データを何も受信できなければ100μsおきに再試行する。
+ * 即座にreturnする。
+ *
+ * \return wcliが無効ならWCF_BAD_WCLI
+ * \sa wcfWaitRecvFor(), wcfWaitRecv(), wcfAutoRecv()
+ */
+WEBCFACE_DLL wcfStatus WEBCFACE_CALL wcfRecv(wcfClient *wcli);
+/*!
+ * \brief サーバーからデータを受信する
+ * \since ver2.0
+ *
+ * * wcfRecv()と同じだが、何も受信できなければ
+ * timeout 経過後に再試行してreturnする。
+ * timeout=0 または負の値なら再試行せず即座にreturnする。(wcfRecv()と同じ)
+ * * timeoutが100μs以上の場合、100μsおきに繰り返し再試行し、timeout経過後return
  *
  * \param wcli
  * \param timeout (μs単位)
  * \return wcliが無効ならWCF_BAD_WCLI
- * \sa wcfWaitRecv(), wcfAutoRecv()
+ * \sa wcfRecv(), wcfWaitRecv(), wcfAutoRecv()
  */
-WEBCFACE_DLL wcfStatus WEBCFACE_CALL wcfRecv(wcfClient *wcli, int timeout);
+WEBCFACE_DLL wcfStatus WEBCFACE_CALL wcfWaitRecvFor(wcfClient *wcli,
+                                                    int timeout);
 /*!
  * \brief サーバーからデータを受信する
  * \since ver2.0
@@ -120,23 +132,19 @@ WEBCFACE_DLL wcfStatus WEBCFACE_CALL wcfRecv(wcfClient *wcli, int timeout);
  */
 WEBCFACE_DLL wcfStatus WEBCFACE_CALL wcfWaitRecv(wcfClient *wcli);
 /*!
- * \brief 別スレッドでwcfRecv()を自動的に呼び出す間隔を設定する。
+ * \brief 別スレッドでwcfRecv()を自動的に呼び出すようにする。
  * \since ver2.0
  *
  * * wcfStart() や wcfWaitConnection() より前に設定する必要がある。
- * * autoRecvが有効の場合、別スレッドで一定間隔ごとにrecv()が呼び出され、
- * 各種コールバック(onEntry, onChange,
- * Funcなど)も別のスレッドで呼ばれることになる
+ * * autoRecvが有効の場合、別スレッドで一定間隔(100μs)ごとにrecv()が呼び出され、
+ * 各種コールバック (onEntry, onChange, Funcなど)
+ * も別のスレッドで呼ばれることになる
  * (そのためmutexなどを適切に設定すること)
- * * デフォルトでは無効なので、手動でrecv()を呼び出す必要がある
+ * * デフォルトでは無効なので、手動でwcfRecv()などを呼び出す必要がある
  *
- * \param wcli
- * \param interval (μs単位)
- * 1以上を指定するとその間隔で自動でrecv()が呼び出されるようになる。
- * 0または負の値を指定するとautoRecvは無効。
- * \sa recv(), recvUntil(), waitRecv()
+ * \sa wcfRecv(), wcfWaitRecvFor(), wcfWaitRecv()
  */
-WEBCFACE_DLL wcfStatus WEBCFACE_CALL wcfAutoRecv(wcfClient *wcli, int interval);
+WEBCFACE_DLL wcfStatus WEBCFACE_CALL wcfAutoRecv(wcfClient *wcli);
 /*!
  * \brief 送信用にセットしたデータをすべて送信キューに入れる。
  * \since ver1.5

--- a/client/include/webcface/client.h
+++ b/client/include/webcface/client.h
@@ -130,22 +130,31 @@ class WEBCFACE_DLL Client : public Member {
      * timeout=0 または負の値なら即座にreturnする。
      * * timeoutが100μs以上の場合、データを何も受信できなければ100μsおきに再試行する。
      *
-     * \sa autoRecv(), recvUntil(), waitRecv()
+     * \sa waitRecvFor(), waitRecvUntil(), waitRecv(), autoRecv()
      */
-    void
-    recv(std::chrono::microseconds timeout = std::chrono::microseconds(0)) {
-        recvImpl(timeout);
-    }
+    void recv() { recvImpl(std::chrono::microseconds(0)); }
     /*!
      * \brief サーバーからデータを受信する
      * \since ver2.0
      *
-     * recv() と同じだが、timeoutを絶対時間で指定
+     * * recv()と同じだが、何も受信できなければ
+     * timeout 経過後に再試行してreturnする。
+     * timeout=0 または負の値なら再試行せず即座にreturnする。(recv()と同じ)
+     * * timeoutが100μs以上の場合、100μsおきに繰り返し再試行し、timeout経過後return
      *
-     * \sa recv(), waitRecv()
+     * \sa recv(), waitRecvUntil(), waitRecv(), autoRecv()
+     */
+    void waitRecvFor(std::chrono::microseconds timeout) { recvImpl(timeout); }
+    /*!
+     * \brief サーバーからデータを受信する
+     * \since ver2.0
+     *
+     * waitRecvFor() と同じだが、timeoutを絶対時間で指定
+     *
+     * \sa recv(), waitRecvFor(), waitRecv(), autoRecv()
      */
     template <typename Clock, typename Duration>
-    void recvUntil(std::chrono::time_point<Clock, Duration> timeout) {
+    void waitRecvUntil(std::chrono::time_point<Clock, Duration> timeout) {
         recvImpl(std::chrono::duration_cast<std::chrono::microseconds>(
             timeout - Clock::now()));
     }
@@ -153,9 +162,9 @@ class WEBCFACE_DLL Client : public Member {
      * \brief サーバーからデータを受信する
      * \since ver2.0
      *
-     * recv()と同じだが、何か受信するまで無制限に待機する
+     * waitRecvFor()と同じだが、何か受信するまで無制限に待機する
      *
-     * \sa recv(), recvUntil()
+     * \sa recv(), waitRecvFor(), waitRecvUntil(), autoRecv()
      */
     void waitRecv() { recvImpl(std::nullopt); }
 
@@ -164,18 +173,16 @@ class WEBCFACE_DLL Client : public Member {
      * \since ver2.0
      *
      * * wcfStart() や wcfWaitConnection() より前に設定する必要がある。
-     * * autoRecvが有効の場合、別スレッドで一定間隔ごとにrecv()が呼び出され、
-     * 各種コールバック(onEntry, onChange,
-     * Func::run()など)も別のスレッドで呼ばれることになる
+     * * autoRecvが有効の場合、別スレッドで一定間隔(100μs)ごとにrecv()が呼び出され、
+     * 各種コールバック (onEntry, onChange, Func::run()など)
+     * も別のスレッドで呼ばれることになる
      * (そのためmutexなどを適切に設定すること)
-     * * デフォルトでは無効なので、手動でrecv()を呼び出す必要がある
+     * * デフォルトでは無効なので、手動でrecv()などを呼び出す必要がある
      *
      * \param enabled trueにすると自動でrecv()が呼び出されるようになる
-     * \param interval recvを呼び出す間隔 (1μs以上)
-     * \sa recv(), recvUntil(), waitRecv()
+     * \sa recv(), waitRecvFor(), waitRecvUntil(), waitRecv()
      */
-    void autoRecv(bool enabled, std::chrono::microseconds interval =
-                                    std::chrono::microseconds(100));
+    void autoRecv(bool enabled);
 
     /*!
      * \brief 送信用にセットしたデータをすべて送信キューに入れる。
@@ -232,7 +239,8 @@ class WEBCFACE_DLL Client : public Member {
      *
      * \sa member(), members()
      */
-    Client &onMemberEntry(std::function<void WEBCFACE_CALL_FP(Member)> callback);
+    Client &
+    onMemberEntry(std::function<void WEBCFACE_CALL_FP(Member)> callback);
 
     /*!
      * \brief webcfaceに出力するstreambuf

--- a/client/src/c_wcf/client.cc
+++ b/client/src/c_wcf/client.cc
@@ -66,12 +66,20 @@ wcfStatus wcfAutoReconnect(wcfClient *wcli, int enabled) {
     wcli_->autoReconnect(enabled);
     return WCF_OK;
 }
-wcfStatus wcfRecv(wcfClient *wcli, int timeout) {
+wcfStatus wcfRecv(wcfClient *wcli) {
     auto wcli_ = getWcli(wcli);
     if (!wcli_) {
         return WCF_BAD_WCLI;
     }
-    wcli_->recv(std::chrono::microseconds(timeout));
+    wcli_->recv();
+    return WCF_OK;
+}
+wcfStatus wcfWaitRecvFor(wcfClient *wcli, int timeout) {
+    auto wcli_ = getWcli(wcli);
+    if (!wcli_) {
+        return WCF_BAD_WCLI;
+    }
+    wcli_->waitRecvFor(std::chrono::microseconds(timeout));
     return WCF_OK;
 }
 wcfStatus wcfWaitRecv(wcfClient *wcli) {
@@ -82,12 +90,12 @@ wcfStatus wcfWaitRecv(wcfClient *wcli) {
     wcli_->waitRecv();
     return WCF_OK;
 }
-wcfStatus wcfAutoRecv(wcfClient *wcli, int interval) {
+wcfStatus wcfAutoRecv(wcfClient *wcli) {
     auto wcli_ = getWcli(wcli);
     if (!wcli_) {
         return WCF_BAD_WCLI;
     }
-    wcli_->autoRecv(interval >= 1, std::chrono::microseconds(interval));
+    wcli_->autoRecv(true);
     return WCF_OK;
 }
 wcfStatus wcfSync(wcfClient *wcli) {

--- a/client/src/client.cc
+++ b/client/src/client.cc
@@ -199,33 +199,47 @@ bool internal::recvMain(const std::shared_ptr<ClientData> &data,
 }
 void Client::recvImpl(std::optional<std::chrono::microseconds> timeout) {
     auto start_t = std::chrono::steady_clock::now();
-    auto next_recv_t = start_t;
     constexpr std::chrono::microseconds interval(100);
     while (true) {
         std::unique_lock lock(data->connect_state_m);
-        if (!timeout || next_recv_t < start_t + *timeout) {
-            // 少なくともintervalぶんは待機する
-            data->connect_state_cond.wait_until(
-                lock, next_recv_t, [&] { return data->closing.load(); });
-        }
-        // 遅くともtimeout経過したらreturnする
         if (timeout) {
+            // recv()が可能になるまで待つ
+            // 遅くともtimeout経過したら抜ける
             data->connect_state_cond.wait_until(lock, start_t + *timeout, [&] {
                 return data->closing.load() ||
                        (data->connected && !data->using_curl);
             });
+            if (data->closing.load() || !data->connected || data->using_curl) {
+                // timeoutし、recv準備完了でない場合return
+                return;
+            }
         } else {
+            // recv()が可能になるまで無制限に待つ
             data->connect_state_cond.wait(lock, [&] {
                 return data->closing.load() ||
                        (data->connected && !data->using_curl);
             });
         }
-        if (data->closing.load() || !data->connected || data->using_curl) {
+        if (data->closing.load()) {
             return;
         }
-        next_recv_t = std::chrono::steady_clock::now() + interval;
+
+        auto next_recv_t = std::chrono::steady_clock::now() + interval;
         bool has_recv = internal::recvMain(data, lock);
         if (has_recv) {
+            return;
+        }
+
+        if (!timeout || next_recv_t < start_t + *timeout) {
+            // interval < timeout の場合、interval分待機
+            data->connect_state_cond.wait_until(
+                lock, next_recv_t, [&] { return data->closing.load(); });
+        } else {
+            // interval > timeout の場合、timeout分待機
+            data->connect_state_cond.wait_until(
+                lock, start_t + *timeout, [&] { return data->closing.load(); });
+        }
+        if (data->closing.load()) {
             return;
         }
     }
@@ -324,9 +338,9 @@ void Client::waitConnection(std::chrono::microseconds interval) {
         first_loop = false;
     }
 }
-void Client::autoRecv(bool enabled, std::chrono::microseconds interval) {
-    if (enabled && interval.count() > 0) {
-        data->auto_recv_us.store(static_cast<int>(interval.count()));
+void Client::autoRecv(bool enabled) {
+    if (enabled /* && interval.count() > 0 */) {
+        data->auto_recv_us.store(100);
     } else {
         data->auto_recv_us.store(0);
     }

--- a/docs/30_func.md
+++ b/docs/30_func.md
@@ -437,17 +437,27 @@ Func::runAsync() は関数の実行を開始し、終了を待たずに続行し
 
 AsyncFuncResultからは started と result が取得できます。
 * started は対象の関数が存在して実行が開始したときにtrueになり、存在しなければ即座にfalseとなります。
-    どちらも返ってこない場合は通信に失敗しています。
+どちらも返ってこない場合は通信に失敗しています。
 * result は実行が完了したときに返ります。関数の戻り値、または発生した例外の情報を含んでいます。
 
 <div class="tabbed">
 
 - <b class="tab-title">C++</b>
+    startedとresultはstd::shared_futureであり、
+    <del>取得できるまで待機するならget(), ブロックせず完了したか確認したければwait_for()などが使えます。</del>
+
+    \warning
+    <span class="since-c">2.0</span>
+    以下のように get() などで結果が返ってくるまで待機することができますが、
+    結果を受信するために Client::recv() が必要になったためデッドロックする危険性があります。
     ```cpp
     AsyncFuncResult res = wcli.member("foo").func("hoge").runAsync(1, "aa");
     double ans = res.result.get();
     ```
-    startedとresultはstd::shared_futureです。取得できるまで待機するならget(), ブロックせず完了したか確認したければwait_for()などが使えます。例外はresult.get()が投げます。
+    Client::autoRecv() を有効にしておくか、recv()を呼び出すのとは別のスレッドで
+    get() で待機する分には問題ありません。
+    
+    * 実行した関数が例外を投げた場合はresult.get()が投げます。
 
     <span class="since-c">2.0</span>
     `onStarted()`, `onResult()` で値が返ってきたときに実行されるコールバックを設定することができます。

--- a/examples/benchmark.cc
+++ b/examples/benchmark.cc
@@ -26,7 +26,7 @@ int main() {
             wcli1.text("a") = std::string(s, static_cast<char>('a' + i));
             wcli1.sync();
             do {
-                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                wcli2.waitRecv();
             } while (!recv_t);
             int latency = static_cast<int>(
                 std::chrono::duration_cast<std::chrono::microseconds>(*recv_t -

--- a/examples/benchmark.cc
+++ b/examples/benchmark.cc
@@ -12,7 +12,7 @@ int main() {
     auto bench1_recv = wcli2.member(wcli1.name());
     std::chrono::steady_clock::time_point start_t;
     std::optional<std::chrono::steady_clock::time_point> recv_t;
-    bench1_recv.text("a").appendListener([&](auto) {
+    bench1_recv.text("a").onChange([&](auto) {
         std::cout << "recv" << std::endl;
         recv_t = std::chrono::steady_clock::now();
     });

--- a/examples/c_example.c
+++ b/examples/c_example.c
@@ -21,7 +21,7 @@ int main(void) {
         }
         // ...
         wcfSync(wcli);
-        wcfWaitRecvFor(wcli, 100e3);
+        wcfWaitRecvFor(wcli, 100000);
     }
     return 0;
 }

--- a/examples/c_example.c
+++ b/examples/c_example.c
@@ -21,6 +21,7 @@ int main(void) {
         }
         // ...
         wcfSync(wcli);
+        wcfWaitRecvFor(wcli, 100e3);
     }
     return 0;
 }

--- a/examples/canvas2d.cc
+++ b/examples/canvas2d.cc
@@ -11,8 +11,6 @@ int main() {
     double i = 0;
 
     while (true) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
         {
             auto cv = wcli.canvas2D("canvas");
             cv.init(100, 100);
@@ -64,5 +62,6 @@ int main() {
         i += 0.5;
 
         wcli.sync();
+        wcli.waitRecvFor(std::chrono::milliseconds(100));
     }
 }

--- a/examples/canvas3d.cc
+++ b/examples/canvas3d.cc
@@ -76,7 +76,7 @@ int main() {
     double i = 0;
 
     while (true) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        // std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
         {
             auto world = wcli.canvas3D("omniwheel_world");
@@ -99,5 +99,6 @@ int main() {
         i += 0.5;
 
         wcli.sync();
+        wcli.waitRecvFor(std::chrono::milliseconds(100));
     }
 }

--- a/examples/cv-recv.cc
+++ b/examples/cv-recv.cc
@@ -15,6 +15,7 @@ int main() {
     img.request();
     img.appendListener([](auto) { std::cout << "image updated" << std::endl; });
     while (true) {
+        wcli.waitRecv();
         // auto mat = wcli.member("example_image_send").image("sample").mat();
         // NG
         // auto mat2 = img.mat(); // OK
@@ -29,10 +30,10 @@ int main() {
             cv::imwrite("recv_image.png", mat2);
             break;
         }
-        std::this_thread::yield();
     }
     img.request(webcface::sizeWH(300, 300));
     while (true) {
+        wcli.waitRecv();
         // auto mat2 = img.mat(); // OK
         auto img_frame = img.get();
         if (!img_frame.empty()) {
@@ -46,10 +47,10 @@ int main() {
             cv::waitKey(1); // Wait for a keystroke in the window
             break;
         }
-        std::this_thread::yield();
     }
     img.request(std::nullopt, webcface::ImageColorMode::gray);
     while (true) {
+        wcli.waitRecv();
         // auto mat2 = img.mat(); // OK
         auto img_frame = img.get();
         if (!img_frame.empty()) {
@@ -65,6 +66,7 @@ int main() {
     }
     img.request(std::nullopt, webcface::ImageCompressMode::jpeg, 20);
     while (true) {
+        wcli.waitRecv();
         // auto mat2 = img.mat(); // OK
         auto img_frame = img.get();
         if (!img_frame.empty()) {
@@ -73,10 +75,10 @@ int main() {
             cv::waitKey(1); // Wait for a keystroke in the window
             break;
         }
-        std::this_thread::yield();
     }
     img.request(std::nullopt, webcface::ImageCompressMode::png, 1);
     while (true) {
+        wcli.waitRecv();
         // auto mat2 = img.mat(); // OK
         auto img_frame = img.get();
         if (!img_frame.empty()) {
@@ -85,6 +87,5 @@ int main() {
             cv::waitKey(0); // Wait for a keystroke in the window
             break;
         }
-        std::this_thread::yield();
     }
 }

--- a/examples/func.cc
+++ b/examples/func.cc
@@ -16,11 +16,11 @@ int main() {
     webcface::Client wcli("example_func");
 
     // 関数を登録
-    wcli.func("func1") = hello;
+    wcli.func("func1").set(hello);
 
-    wcli.func("lambda") = [](const std::string &str) {
+    wcli.func("lambda").set([](const std::string &str) {
         std::cout << "lambda(" << str << ")" << std::endl;
-    };
+    });
 
     // 引数付きの関数は引数名や各種情報をセットできる
     using Arg = webcface::Arg;
@@ -33,9 +33,8 @@ int main() {
     wcli.func("func_double").set([](double) -> double { return 1.5; });
     wcli.func("func_str").set([](std::string) -> std::string { return "1"; });
 
+    wcli.sync();
     while (true) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-        wcli.sync();
+        wcli.waitRecv();
     }
 }

--- a/examples/image-recv.cc
+++ b/examples/image-recv.cc
@@ -15,6 +15,7 @@ int main() {
     img.request();
     img.onChange([](auto) { std::cout << "image updated" << std::endl; });
     while (true) {
+        wcli.waitRecv();
         auto img_frame = img.get();
         if (!img_frame.empty()) {
             std::cout << "1. Normal" << std::endl;
@@ -26,10 +27,10 @@ int main() {
             m.write("webcface-example-image-recv-1.png");
             break;
         }
-        std::this_thread::yield();
     }
     img.request(webcface::sizeWH(300, 300));
     while (true) {
+        wcli.waitRecv();
         // auto mat2 = img.mat(); // OK
         auto img_frame = img.get();
         if (!img_frame.empty()) {
@@ -44,10 +45,10 @@ int main() {
             m.write("webcface-example-image-recv-2.png");
             break;
         }
-        std::this_thread::yield();
     }
     img.request(std::nullopt, webcface::ImageColorMode::gray);
     while (true) {
+        wcli.waitRecv();
         // auto mat2 = img.mat(); // OK
         auto img_frame = img.get();
         if (!img_frame.empty()) {
@@ -62,10 +63,11 @@ int main() {
             m.write("webcface-example-image-recv-3.jpg");
             break;
         }
-        std::this_thread::yield();
+        wcli.waitRecv();
     }
     img.request(std::nullopt, webcface::ImageCompressMode::jpeg, 20);
     while (true) {
+        wcli.waitRecv();
         // auto mat2 = img.mat(); // OK
         auto img_frame = img.get();
         if (!img_frame.empty()) {
@@ -79,10 +81,10 @@ int main() {
                       static_cast<int>(img_frame.data().size()));
             break;
         }
-        std::this_thread::yield();
     }
     img.request(std::nullopt, webcface::ImageCompressMode::png, 1);
     while (true) {
+        wcli.waitRecv();
         // auto mat2 = img.mat(); // OK
         auto img_frame = img.get();
         if (!img_frame.empty()) {
@@ -96,7 +98,6 @@ int main() {
                       static_cast<int>(img_frame.data().size()));
             break;
         }
-        std::this_thread::yield();
     }
     std::cout << "Images are in current directory." << std::endl;
 }

--- a/examples/image-recv.cc
+++ b/examples/image-recv.cc
@@ -13,7 +13,7 @@ int main() {
 
     webcface::Image img = wcli.member("example_image_send").image("sample");
     img.request();
-    img.appendListener([](auto) { std::cout << "image updated" << std::endl; });
+    img.onChange([](auto) { std::cout << "image updated" << std::endl; });
     while (true) {
         auto img_frame = img.get();
         if (!img_frame.empty()) {

--- a/examples/log.cc
+++ b/examples/log.cc
@@ -28,9 +28,10 @@ int main() {
     int i = 0;
 
     while (true) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        // std::this_thread::sleep_for(std::chrono::milliseconds(100));
         wcli.loggerOStream() << "info " << i++ << std::endl;
 
         wcli.sync();
+        wcli.waitRecvFor(std::chrono::milliseconds(100));
     }
 }

--- a/examples/recv.cc
+++ b/examples/recv.cc
@@ -39,7 +39,7 @@ int main() {
     c.start();
     auto func_m = c.member("example_func");
     while (true) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        // std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         // example_mainのtestの値を取得する
         std::cout << "example_main.test = "
                   << c.member("example_value").value("test") << std::endl;
@@ -57,5 +57,6 @@ int main() {
         func_m.func("func_int").runAsync(1);
         func_m.func("func_double").runAsync(1.0);
         func_m.func("func_str").runAsync("1");
+        c.waitRecvFor(std::chrono::milliseconds(100));
     }
 }

--- a/examples/value.cc
+++ b/examples/value.cc
@@ -27,7 +27,7 @@ int main() {
     double i = 0;
 
     while (true) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        // std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
         // valueを更新
         wcli.value("test") = i;
@@ -36,5 +36,6 @@ int main() {
         i += 0.5;
 
         wcli.sync();
+        wcli.waitRecvFor(std::chrono::milliseconds(100));
     }
 }

--- a/examples/view.cc
+++ b/examples/view.cc
@@ -10,7 +10,7 @@ int main() {
     int i = 0;
 
     while (true) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        // std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
         {
             // viewを送信
@@ -85,5 +85,6 @@ int main() {
         }
         i++;
         wcli.sync();
+        wcli.waitRecvFor(std::chrono::milliseconds(100));
     }
 }

--- a/tests/c_wcf_test.cc
+++ b/tests/c_wcf_test.cc
@@ -97,12 +97,12 @@ TEST_F(CClientTest, connectionByWait) {
 TEST_F(CClientTest, noConnectionByRecv) {
     EXPECT_FALSE(dummy_s->connected());
     EXPECT_FALSE(wcfIsConnected(wcli_));
-    EXPECT_EQ(wcfRecv(wcli_, 0), WCF_OK);
+    EXPECT_EQ(wcfRecv(wcli_), WCF_OK);
     wait();
     EXPECT_FALSE(dummy_s->connected());
     EXPECT_FALSE(wcfIsConnected(wcli_));
 
-    EXPECT_EQ(wcfRecv(nullptr, 0), WCF_BAD_WCLI);
+    EXPECT_EQ(wcfRecv(nullptr), WCF_BAD_WCLI);
 }
 
 TEST_F(CClientTest, valueSend) {
@@ -224,7 +224,7 @@ TEST_F(CClientTest, textReq) {
 
 TEST_F(CClientTest, funcRun) {
     using namespace std::string_literals;
-    EXPECT_EQ(wcfAutoRecv(wcli_, 100), WCF_OK);
+    EXPECT_EQ(wcfAutoRecv(wcli_), WCF_OK);
     EXPECT_EQ(wcfStart(wcli_), WCF_OK);
 
     wcfMultiVal args[3] = {
@@ -330,7 +330,7 @@ TEST_F(CClientTest, funcRun) {
 
 TEST_F(CClientTest, funcListen) {
     using namespace std::string_literals;
-    EXPECT_EQ(wcfAutoRecv(wcli_, 100), WCF_OK);
+    EXPECT_EQ(wcfAutoRecv(wcli_), WCF_OK);
     EXPECT_EQ(wcfStart(wcli_), WCF_OK);
 
     int arg_types[3] = {WCF_VAL_INT, WCF_VAL_DOUBLE, WCF_VAL_STRING};

--- a/tests/c_wcf_test.cc
+++ b/tests/c_wcf_test.cc
@@ -2,7 +2,6 @@
 #include "webcface/internal/client_internal.h"
 #include <webcface/member.h>
 #include <webcface/client.h>
-#include <webcface/logger.h>
 #include <webcface/value.h>
 #include <webcface/text.h>
 #include <webcface/log.h>

--- a/tests/canvas2d_test.cc
+++ b/tests/canvas2d_test.cc
@@ -66,7 +66,7 @@ TEST_F(Canvas2DTest, field) {
     EXPECT_THROW(Canvas2D().tryGet(), std::runtime_error);
 }
 TEST_F(Canvas2DTest, eventTarget) {
-    canvas("a", "b").appendListener(callback<Canvas2D>());
+    canvas("a", "b").onChange(callback<Canvas2D>());
     data_->canvas2d_change_event["a"_ss]["b"_ss]->operator()(field("a", "b"));
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
@@ -164,7 +164,7 @@ TEST_F(Canvas2DTest, get) {
     EXPECT_EQ(data_->canvas2d_store.transferReq().at("a"_ss).at("c"_ss), 2);
     EXPECT_EQ(canvas(self_name, "b").tryGet(), std::nullopt);
     EXPECT_EQ(data_->canvas2d_store.transferReq().count(self_name), 0);
-    canvas("a", "d").appendListener(callback<Canvas2D>());
+    canvas("a", "d").onChange(callback<Canvas2D>());
     EXPECT_EQ(data_->canvas2d_store.transferReq().at("a"_ss).at("d"_ss), 3);
 }
 

--- a/tests/canvas3d_test.cc
+++ b/tests/canvas3d_test.cc
@@ -58,7 +58,7 @@ TEST_F(Canvas3DTest, field) {
     EXPECT_THROW(Canvas3D().tryGet(), std::runtime_error);
 }
 TEST_F(Canvas3DTest, eventTarget) {
-    canvas("a", "b").appendListener(callback<Canvas3D>());
+    canvas("a", "b").onChange(callback<Canvas3D>());
     data_->canvas3d_change_event["a"_ss]["b"_ss]->operator()(field("a", "b"));
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
@@ -162,7 +162,7 @@ TEST_F(Canvas3DTest, get) {
     EXPECT_EQ(data_->canvas3d_store.transferReq().at("a"_ss).at("c"_ss), 2);
     EXPECT_EQ(canvas(self_name, "b").tryGet(), std::nullopt);
     EXPECT_EQ(data_->canvas3d_store.transferReq().count(self_name), 0);
-    canvas("a", "d").appendListener(callback<Canvas3D>());
+    canvas("a", "d").onChange(callback<Canvas3D>());
     EXPECT_EQ(data_->canvas3d_store.transferReq().at("a"_ss).at("d"_ss), 3);
 }
 

--- a/tests/client_test.cc
+++ b/tests/client_test.cc
@@ -450,19 +450,19 @@ TEST_F(ClientTest, autoRecvThread) {
 }
 TEST_F(ClientTest, recvTimeout) {
     auto start = std::chrono::steady_clock::now();
-    wcli_->recv(std::chrono::milliseconds(WEBCFACE_TEST_TIMEOUT));
+    wcli_->waitRecvFor(std::chrono::milliseconds(WEBCFACE_TEST_TIMEOUT));
     auto end = std::chrono::steady_clock::now();
     EXPECT_GE(std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
                   .count(),
               WEBCFACE_TEST_TIMEOUT * 0.9);
     start = std::chrono::steady_clock::now();
-    wcli_->recv(std::chrono::milliseconds(0));
+    wcli_->recv();
     end = std::chrono::steady_clock::now();
     EXPECT_LE(std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
                   .count(),
               WEBCFACE_TEST_TIMEOUT * 0.1);
     start = std::chrono::steady_clock::now();
-    wcli_->recv(std::chrono::milliseconds(-WEBCFACE_TEST_TIMEOUT));
+    wcli_->waitRecvFor(std::chrono::milliseconds(-WEBCFACE_TEST_TIMEOUT));
     end = std::chrono::steady_clock::now();
     EXPECT_LE(std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
                   .count(),
@@ -470,19 +470,19 @@ TEST_F(ClientTest, recvTimeout) {
 }
 TEST_F(ClientTest, recvUntilTimeout) {
     auto start = std::chrono::steady_clock::now();
-    wcli_->recvUntil(start + std::chrono::milliseconds(WEBCFACE_TEST_TIMEOUT));
+    wcli_->waitRecvUntil(start + std::chrono::milliseconds(WEBCFACE_TEST_TIMEOUT));
     auto end = std::chrono::steady_clock::now();
     EXPECT_GE(std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
                   .count(),
               WEBCFACE_TEST_TIMEOUT * 0.9);
     start = std::chrono::steady_clock::now();
-    wcli_->recvUntil(start);
+    wcli_->waitRecvUntil(start);
     end = std::chrono::steady_clock::now();
     EXPECT_LE(std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
                   .count(),
               WEBCFACE_TEST_TIMEOUT * 0.1);
     start = std::chrono::steady_clock::now();
-    wcli_->recvUntil(start - std::chrono::milliseconds(WEBCFACE_TEST_TIMEOUT));
+    wcli_->waitRecvUntil(start - std::chrono::milliseconds(WEBCFACE_TEST_TIMEOUT));
     end = std::chrono::steady_clock::now();
     EXPECT_LE(std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
                   .count(),

--- a/tests/client_test.cc
+++ b/tests/client_test.cc
@@ -2,7 +2,6 @@
 #include "webcface/internal/client_internal.h"
 #include <webcface/member.h>
 #include <webcface/client.h>
-#include <webcface/logger.h>
 #include <webcface/value.h>
 #include <webcface/text.h>
 #include <webcface/log.h>
@@ -390,7 +389,7 @@ TEST_F(ClientTest, valueReq) {
         EXPECT_EQ(obj.field, "b"_ss);
         EXPECT_EQ(obj.req_id, 1);
     });
-    wcli_->member("a").value("b").appendListener(callback<Value>());
+    wcli_->member("a").value("b").onChange(callback<Value>());
     dummy_s->send(message::Res<message::Value>{
         1, ""_ss,
         std::make_shared<std::vector<double>>(std::vector<double>{1, 2, 3})});
@@ -418,7 +417,7 @@ TEST_F(ClientTest, recvThread) {
     while (!dummy_s->connected() || !wcli_->connected()) {
         wait();
     }
-    wcli_->member("a").value("b").appendListener([&](const Value &) {
+    wcli_->member("a").value("b").onChange([&](const Value &) {
         EXPECT_EQ(std::this_thread::get_id(), main_id);
         callback_called++;
     });
@@ -438,7 +437,7 @@ TEST_F(ClientTest, autoRecvThread) {
     while (!dummy_s->connected() || !wcli_->connected()) {
         wait();
     }
-    wcli_->member("a").value("b").appendListener([&](const Value &) {
+    wcli_->member("a").value("b").onChange([&](const Value &) {
         EXPECT_NE(std::this_thread::get_id(), main_id);
         callback_called++;
     });
@@ -530,7 +529,7 @@ TEST_F(ClientTest, textReq) {
         EXPECT_EQ(obj.field, "b"_ss);
         EXPECT_EQ(obj.req_id, 1);
     });
-    wcli_->member("a").text("b").appendListener(callback<Text>());
+    wcli_->member("a").text("b").onChange(callback<Text>());
     dummy_s->send(message::Res<message::Text>{
         1, ""_ss, std::make_shared<ValAdaptor>("z")});
     dummy_s->send(message::Res<message::Text>{
@@ -620,7 +619,7 @@ TEST_F(ClientTest, viewReq) {
         EXPECT_EQ(obj.field, "b"_ss);
         EXPECT_EQ(obj.req_id, 1);
     });
-    wcli_->member("a").view("b").appendListener(callback<View>());
+    wcli_->member("a").view("b").onChange(callback<View>());
 
     auto v = std::make_shared<
         std::unordered_map<std::string, message::ViewComponent>>(
@@ -796,7 +795,7 @@ TEST_F(ClientTest, canvas2DReq) {
         EXPECT_EQ(obj.field, "b"_ss);
         EXPECT_EQ(obj.req_id, 1);
     });
-    wcli_->member("a").canvas2D("b").appendListener(callback<Canvas2D>());
+    wcli_->member("a").canvas2D("b").onChange(callback<Canvas2D>());
 
     auto v = std::make_shared<
         std::unordered_map<std::string, message::Canvas2DComponent>>(
@@ -1054,7 +1053,7 @@ TEST_F(ClientTest, canvas3DReq) {
         EXPECT_EQ(obj.field, "b"_ss);
         EXPECT_EQ(obj.req_id, 1);
     });
-    wcli_->member("a").canvas3D("b").appendListener(callback<Canvas3D>());
+    wcli_->member("a").canvas3D("b").onChange(callback<Canvas3D>());
 
     auto v = std::make_shared<
         std::unordered_map<std::string, message::Canvas3DComponent>>(
@@ -1193,7 +1192,7 @@ TEST_F(ClientTest, robotModelReq) {
         EXPECT_EQ(obj.field, "b"_ss);
         EXPECT_EQ(obj.req_id, 1);
     });
-    wcli_->member("a").robotModel("b").appendListener(callback<RobotModel>());
+    wcli_->member("a").robotModel("b").onChange(callback<RobotModel>());
     dummy_s->send(message::Res<message::RobotModel>(
         1, ""_ss,
         std::make_shared<std::vector<message::RobotLink>>(
@@ -1245,7 +1244,7 @@ TEST_F(ClientTest, imageReq) {
                   (message::ImageReq{std::nullopt, std::nullopt, std::nullopt,
                                      ImageCompressMode::raw, 0, std::nullopt}));
     });
-    wcli_->member("a").image("b").appendListener(callback<Image>());
+    wcli_->member("a").image("b").onChange(callback<Image>());
     ImageFrame img(sizeWH(100, 100),
                    std::make_shared<std::vector<unsigned char>>(100 * 100 * 3),
                    ImageColorMode::bgr);
@@ -1300,7 +1299,7 @@ TEST_F(ClientTest, logReq) {
     wcli_->member("a").log().tryGet();
     dummy_s->waitRecv<message::LogReq>(
         [&](const auto &obj) { EXPECT_EQ(obj.member, "a"_ss); });
-    wcli_->member("a").log().appendListener(callback<Log>());
+    wcli_->member("a").log().onChange(callback<Log>());
 
     dummy_s->send(message::SyncInit{{}, "a"_ss, 10, "", "", ""});
     wcli_->waitRecv();

--- a/tests/data_test.cc
+++ b/tests/data_test.cc
@@ -78,22 +78,22 @@ TEST_F(DataTest, field) {
     EXPECT_THROW(Log().tryGet(), std::runtime_error);
 }
 TEST_F(DataTest, eventTarget) {
-    value("a", "b").appendListener(callback<Value>());
+    value("a", "b").onChange(callback<Value>());
     data_->value_change_event["a"_ss]["b"_ss]->operator()(field("a", "b"));
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
     value("a", "b").onChange(nullptr);
     EXPECT_FALSE(*data_->value_change_event["a"_ss]["b"_ss]);
-    value("a", "b").appendListener(callbackVoid());
+    value("a", "b").onChange(callbackVoid());
     data_->value_change_event["a"_ss]["b"_ss]->operator()(field("a", "b"));
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
 
-    text("a", "b").appendListener(callback<Text>());
+    text("a", "b").onChange(callback<Text>());
     data_->text_change_event["a"_ss]["b"_ss]->operator()(field("a", "b"));
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
-    log("a").appendListener(callback<Log>());
+    log("a").onChange(callback<Log>());
     data_->log_append_event["a"_ss]->operator()(field("a"));
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
@@ -186,7 +186,7 @@ TEST_F(DataTest, valueGet) {
     EXPECT_EQ(data_->value_store.transferReq().at("a"_ss).at("c"_ss), 2);
     EXPECT_EQ(value(self_name, "b").tryGet(), std::nullopt);
     EXPECT_EQ(data_->value_store.transferReq().count(self_name), 0);
-    value("a", "d").appendListener(callback<Value>());
+    value("a", "d").onChange(callback<Value>());
     EXPECT_EQ(data_->value_store.transferReq().at("a"_ss).at("d"_ss), 3);
 }
 TEST_F(DataTest, textGet) {
@@ -207,7 +207,7 @@ TEST_F(DataTest, textGet) {
     EXPECT_EQ(data_->text_store.transferReq().at("a"_ss).at("c"_ss), 2);
     EXPECT_EQ(text(self_name, "b").tryGet(), std::nullopt);
     EXPECT_EQ(data_->text_store.transferReq().count(self_name), 0);
-    text("a", "d").appendListener(callback<Text>());
+    text("a", "d").onChange(callback<Text>());
     EXPECT_EQ(data_->text_store.transferReq().at("a"_ss).at("d"_ss), 3);
 }
 TEST_F(DataTest, logGet) {
@@ -238,7 +238,7 @@ TEST_F(DataTest, logGet) {
     EXPECT_EQ(log(self_name).tryGet()->size(), 0);
     EXPECT_EQ(log(self_name).tryGetW()->size(), 0);
     EXPECT_EQ(data_->log_store.transferReq().count(self_name), 0);
-    log("d").appendListener(callback<Log>());
+    log("d").onChange(callback<Log>());
     EXPECT_EQ(data_->log_store.transferReq().at("d"_ss), true);
 }
 TEST_F(DataTest, logClear) {

--- a/tests/image_test.cc
+++ b/tests/image_test.cc
@@ -99,7 +99,7 @@ TEST_F(ImageTest, field) {
     EXPECT_THROW(Image().tryGet(), std::runtime_error);
 }
 TEST_F(ImageTest, eventTarget) {
-    image("a", "b").appendListener(callback<Image>());
+    image("a", "b").onChange(callback<Image>());
     data_->image_change_event["a"_ss]["b"_ss]->operator()(field("a", "b"));
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
@@ -148,7 +148,7 @@ TEST_F(ImageTest, imageGet) {
                                  ImageCompressMode::raw, 0, std::nullopt}));
     EXPECT_EQ(image(self_name, "b").tryGet(), std::nullopt);
     EXPECT_EQ(data_->image_store.transferReq().count(self_name), 0);
-    image("a", "d").appendListener(callback<Image>());
+    image("a", "d").onChange(callback<Image>());
     EXPECT_EQ(data_->image_store.transferReq().at("a"_ss).at("d"_ss), 3);
     EXPECT_EQ(data_->image_store.getReqInfo("a"_ss, "d"_ss),
               (message::ImageReq{std::nullopt, std::nullopt, std::nullopt,

--- a/tests/robot_model_test.cc
+++ b/tests/robot_model_test.cc
@@ -52,7 +52,7 @@ TEST_F(RobotModelTest, field) {
     EXPECT_THROW(RobotModel().tryGet(), std::runtime_error);
 }
 TEST_F(RobotModelTest, eventTarget) {
-    model("a", "b").appendListener(callback<RobotModel>());
+    model("a", "b").onChange(callback<RobotModel>());
     data_->robot_model_change_event["a"_ss]["b"_ss]->operator()(
         field("a", "b"));
     EXPECT_EQ(callback_called, 1);
@@ -109,6 +109,6 @@ TEST_F(RobotModelTest, get) {
     EXPECT_EQ(data_->robot_model_store.transferReq().at("a"_ss).at("c"_ss), 2);
     EXPECT_EQ(model(self_name, "b").tryGet(), std::nullopt);
     EXPECT_EQ(data_->robot_model_store.transferReq().count(self_name), 0);
-    model("a", "d").appendListener(callback<RobotModel>());
+    model("a", "d").onChange(callback<RobotModel>());
     EXPECT_EQ(data_->robot_model_store.transferReq().at("a"_ss).at("d"_ss), 3);
 }

--- a/tests/view_test.cc
+++ b/tests/view_test.cc
@@ -74,7 +74,7 @@ TEST_F(ViewTest, field) {
     EXPECT_THROW(View().tryGet(), std::runtime_error);
 }
 TEST_F(ViewTest, eventTarget) {
-    view("a", "b").appendListener(callback<View>());
+    view("a", "b").onChange(callback<View>());
     data_->view_change_event["a"_ss]["b"_ss]->operator()(field("a", "b"));
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
@@ -252,7 +252,7 @@ TEST_F(ViewTest, viewGet) {
     EXPECT_EQ(data_->view_store.transferReq().at("a"_ss).at("c"_ss), 2);
     EXPECT_EQ(view(self_name, "b").tryGet(), std::nullopt);
     EXPECT_EQ(data_->view_store.transferReq().count(self_name), 0);
-    view("a", "d").appendListener(callback<View>());
+    view("a", "d").onChange(callback<View>());
     EXPECT_EQ(data_->view_store.transferReq().at("a"_ss).at("d"_ss), 3);
 }
 


### PR DESCRIPTION
- **deprecatedの修正**
- **recv()とwaitRecvFor()を分けた**
- **Func::run()が危険すぎる問題**
