### PR TITLE
recvの仕様を再度変更

### DIFF
--- a/client/include/webcface/c_wcf/client.h
+++ b/client/include/webcface/c_wcf/client.h
@@ -71,15 +71,13 @@ WEBCFACE_DLL wcfStatus WEBCFACE_CALL wcfStart(wcfClient *wcli);
  *
  * * wcfAutoReconnect が無効の場合は1回目の接続のみ待機し、
  * 失敗しても再接続せずreturnする。
- *
- * \param wcli
- * \param interval autoRecvが無効の場合、初期化が完了するまで一定間隔ごとに
+ * * autoRecvが無効の場合、初期化が完了するまで
  * wcfRecv() をこのスレッドで呼び出す。
+ *
  * \return wcliが無効ならWCF_BAD_WCLI
  * \sa wcfStart(), wcfAutoReconnect()
  */
-WEBCFACE_DLL wcfStatus WEBCFACE_CALL wcfWaitConnection(wcfClient *wcli,
-                                                       int interval);
+WEBCFACE_DLL wcfStatus WEBCFACE_CALL wcfWaitConnection(wcfClient *wcli);
 /*!
  * \brief 通信が切断されたときに自動で再試行するかどうかを設定する。
  * \since ver1.11.1

--- a/client/include/webcface/client.h
+++ b/client/include/webcface/client.h
@@ -105,7 +105,7 @@ class WEBCFACE_DLL Client : public Member {
      *
      * * ver1.11.1以降: autoReconnect が false
      * の場合は1回目の接続のみ待機し、失敗しても再接続せずreturnする。
-     * * ver2.0以降: autoRecvが無効の場合、初期化が完了するまで recv()
+     * * ver2.0以降: autoRecvが無効の場合、初期化が完了するまで waitRecv()
      * をこのスレッドで呼び出す。
      *
      * \sa start(), autoReconnect(), autoRecv()
@@ -123,11 +123,8 @@ class WEBCFACE_DLL Client : public Member {
      * * データを受信した場合、各種コールバック(onEntry, onChange,
      * Func::run()など)をこのスレッドで呼び出し、
      * それがすべて完了するまでこの関数はブロックされる。
-     * * データを何も受信しなかった場合、サーバーに接続していない場合、
-     * または接続試行中やデータ送信中など受信ができない場合は、
-     * timeout経過後にreturnする。
-     * timeout=0 または負の値なら即座にreturnする。
-     * * timeoutが100μs以上の場合、データを何も受信できなければ100μsおきに再試行する。
+     * * データをまだ何も受信していない場合やサーバーに接続していない場合は、
+     * 即座にreturnする。
      *
      * \sa waitRecvFor(), waitRecvUntil(), waitRecv(), autoRecv()
      */
@@ -139,6 +136,8 @@ class WEBCFACE_DLL Client : public Member {
      * * recv()と同じだが、何も受信できなければ
      * timeout 経過後に再試行してreturnする。
      * timeout=0 または負の値なら再試行せず即座にreturnする。(recv()と同じ)
+     * * autoReconnectがfalseでサーバーに接続できてない場合はreturnする。
+     * (deadlock回避)
      * * timeoutが100μs以上の場合、100μsおきに繰り返し再試行し、timeout経過後return
      *
      * \sa recv(), waitRecvUntil(), waitRecv(), autoRecv()
@@ -161,7 +160,9 @@ class WEBCFACE_DLL Client : public Member {
      * \brief サーバーからデータを受信する
      * \since ver2.0
      *
-     * waitRecvFor()と同じだが、何か受信するまで無制限に待機する
+     * * waitRecvFor()と同じだが、何か受信するまで無制限に待機する
+     * * autoReconnectがfalseでサーバーに接続できてない場合はreturnする。
+     * (deadlock回避)
      *
      * \sa recv(), waitRecvFor(), waitRecvUntil(), autoRecv()
      */

--- a/client/include/webcface/client.h
+++ b/client/include/webcface/client.h
@@ -105,13 +105,12 @@ class WEBCFACE_DLL Client : public Member {
      *
      * * ver1.11.1以降: autoReconnect が false
      * の場合は1回目の接続のみ待機し、失敗しても再接続せずreturnする。
-     * * ver2.0以降: autoRecvが無効の場合、初期化が完了するまで一定間隔
-     * (デフォルト=100μs) ごとに recv() をこのスレッドで呼び出す。
+     * * ver2.0以降: autoRecvが無効の場合、初期化が完了するまで recv()
+     * をこのスレッドで呼び出す。
      *
      * \sa start(), autoReconnect(), autoRecv()
      */
-    void waitConnection(
-        std::chrono::microseconds interval = std::chrono::microseconds(100));
+    void waitConnection();
 
   private:
     void recvImpl(std::optional<std::chrono::microseconds> timeout);

--- a/client/include/webcface/internal/client_internal.h
+++ b/client/include/webcface/internal/client_internal.h
@@ -27,8 +27,10 @@ class Log;
 
 namespace internal {
 
-WEBCFACE_DLL void WEBCFACE_CALL wsThreadMain(const std::shared_ptr<ClientData> &data);
-WEBCFACE_DLL void WEBCFACE_CALL recvThreadMain(const std::shared_ptr<ClientData> &data);
+WEBCFACE_DLL void WEBCFACE_CALL
+wsThreadMain(const std::shared_ptr<ClientData> &data);
+WEBCFACE_DLL void WEBCFACE_CALL
+recvThreadMain(const std::shared_ptr<ClientData> &data);
 
 struct ClientData : std::enable_shared_from_this<ClientData> {
     WEBCFACE_DLL explicit ClientData(const SharedString &name,
@@ -125,7 +127,7 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
      */
     std::queue<std::string> sync_queue, recv_queue;
 
-    WEBCFACE_DLL void message_push(std::string &&msg) {
+    void message_push(std::string &&msg) {
         std::lock_guard lock(this->ws_m);
         this->sync_queue.push(std::move(msg));
         this->ws_cond.notify_all();
@@ -150,7 +152,8 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
      * * timeoutがnulloptならclosingまで永遠にreturnしない
      *
      */
-    WEBCFACE_DLL void recvImpl(std::optional<std::chrono::microseconds> timeout);
+    WEBCFACE_DLL void
+    recvImpl(std::optional<std::chrono::microseconds> timeout);
 
     /*!
      * \brief 初期化時に送信するメッセージ

--- a/client/include/webcface/internal/client_internal.h
+++ b/client/include/webcface/internal/client_internal.h
@@ -35,6 +35,9 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
                                      const SharedString &host = nullptr,
                                      int port = -1);
 
+    WEBCFACE_DLL void close();
+    WEBCFACE_DLL ~ClientData();
+
     /*!
      * \brief Client自身の名前
      *
@@ -143,12 +146,11 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
      * \brief recv_queueのメッセージを処理する
      *
      * * メッセージがなければtimeout後にreturn
+     * * auto_reconnectがfalseで接続できてない場合はreturn (deadlock回避)
      * * timeoutがnulloptならclosingまで永遠にreturnしない
-     * * condはreturnする追加の条件 (mutexはかかっていない)
      *
      */
-    WEBCFACE_DLL void recvImpl(std::optional<std::chrono::microseconds> timeout,
-                               const std::function<bool()> &cond = nullptr);
+    WEBCFACE_DLL void recvImpl(std::optional<std::chrono::microseconds> timeout);
 
     /*!
      * \brief 初期化時に送信するメッセージ

--- a/client/include/webcface/internal/client_ws.h
+++ b/client/include/webcface/internal/client_ws.h
@@ -27,7 +27,7 @@ WEBCFACE_DLL void close(const std::shared_ptr<internal::ClientData> &data);
  *
  */
 WEBCFACE_DLL bool recv(const std::shared_ptr<internal::ClientData> &data,
-                       const std::function<void(const std::string &)> &cb);
+                       const std::function<void(std::string)> &cb);
 /*!
  * \brief メッセージを送信する
  *

--- a/client/src/c_wcf/client.cc
+++ b/client/src/c_wcf/client.cc
@@ -50,12 +50,12 @@ wcfStatus wcfStart(wcfClient *wcli) {
     wcli_->start();
     return WCF_OK;
 }
-wcfStatus wcfWaitConnection(wcfClient *wcli, int interval) {
+wcfStatus wcfWaitConnection(wcfClient *wcli) {
     auto wcli_ = getWcli(wcli);
     if (!wcli_) {
         return WCF_BAD_WCLI;
     }
-    wcli_->waitConnection(std::chrono::microseconds(interval));
+    wcli_->waitConnection();
     return WCF_OK;
 }
 wcfStatus wcfAutoReconnect(wcfClient *wcli, int enabled) {

--- a/client/src/client_ws.cc
+++ b/client/src/client_ws.cc
@@ -96,7 +96,7 @@ void close(const std::shared_ptr<internal::ClientData> &data) {
     data->current_curl_connected = false;
 }
 bool recv(const std::shared_ptr<internal::ClientData> &data,
-          const std::function<void(const std::string &)> &cb) {
+          const std::function<void(std::string)> &cb) {
     CURL *handle = static_cast<CURL *>(data->current_curl_handle);
     CURLcode ret;
     // data->logger_internal->trace("recv");

--- a/server-store/include/webcface/server/store.h
+++ b/server-store/include/webcface/server/store.h
@@ -47,6 +47,8 @@ struct WEBCFACE_DLL ServerStorage {
                    const spdlog::sink_ptr &sink,
                    spdlog::level::level_enum level);
     void removeClient(const wsConnPtr &con);
+    void
+    removeClient(std::unordered_map<wsConnPtr, MemberDataPtr>::iterator it);
     MemberDataPtr getClient(const wsConnPtr &con);
 
     void clientSendAll();

--- a/server-store/src/store.cc
+++ b/server-store/src/store.cc
@@ -5,8 +5,11 @@
 WEBCFACE_NS_BEGIN
 namespace server {
 void ServerStorage::clear() {
-    clients.clear();
-    clients_by_id.clear();
+    // clients.clear();
+    // clients_by_id.clear();
+    while (!clients.empty()) {
+        removeClient(clients.begin());
+    }
     MemberData::last_member_id = 0;
 }
 void ServerStorage::newClient(const wsConnPtr &con,
@@ -21,13 +24,17 @@ void ServerStorage::newClient(const wsConnPtr &con,
 void ServerStorage::removeClient(const wsConnPtr &con) {
     auto it = clients.find(con);
     if (it != clients.end()) {
-        it->second->onClose();
-        // 名前があるクライアントのデータはclients_by_idに残す
-        if (it->second->name.empty()) {
-            clients_by_id.erase(it->second->member_id);
-        }
-        clients.erase(con);
+        removeClient(it);
     }
+}
+void ServerStorage::removeClient(
+    std::unordered_map<wsConnPtr, MemberDataPtr>::iterator it) {
+    it->second->onClose();
+    // 名前があるクライアントのデータはclients_by_idに残す
+    if (it->second->name.empty()) {
+        clients_by_id.erase(it->second->member_id);
+    }
+    clients.erase(it);
 }
 MemberDataPtr ServerStorage::getClient(const wsConnPtr &con) {
     auto it = clients.find(con);

--- a/tests/c_wcf_test.cc
+++ b/tests/c_wcf_test.cc
@@ -150,6 +150,7 @@ TEST_F(CClientTest, valueReq) {
     dummy_s->send(message::Res<message::Value>{
         1, ""_ss,
         std::make_shared<std::vector<double>>(std::vector<double>{1, 1.5, 2})});
+    EXPECT_EQ(wcfWaitRecv(wcli_), WCF_OK);
     dummy_s->send(message::Res<message::Value>{
         1, "c"_ss,
         std::make_shared<std::vector<double>>(std::vector<double>{1, 1.5, 2})});
@@ -206,6 +207,7 @@ TEST_F(CClientTest, textReq) {
     });
     dummy_s->send(message::Res<message::Text>{
         1, ""_ss, std::make_shared<ValAdaptor>("hello")});
+    EXPECT_EQ(wcfWaitRecv(wcli_), WCF_OK);
     dummy_s->send(message::Res<message::Text>{
         1, "c"_ss, std::make_shared<ValAdaptor>("hello")});
     EXPECT_EQ(wcfWaitRecv(wcli_), WCF_OK);
@@ -561,6 +563,7 @@ TEST_F(CClientTest, viewReq) {
                       .toMessage()},
         });
     dummy_s->send(message::Res<message::View>{1, ""_ss, v, 3});
+    EXPECT_EQ(wcfWaitRecv(wcli_), WCF_OK);
     dummy_s->send(message::Res<message::View>{1, "c"_ss, v, 3});
     EXPECT_EQ(wcfWaitRecv(wcli_), WCF_OK);
     EXPECT_EQ(wcfViewGet(wcli_, "a", "b", &vc, &size), WCF_OK);

--- a/tests/c_wcf_test.cc
+++ b/tests/c_wcf_test.cc
@@ -77,7 +77,7 @@ TEST_F(CClientTest, connectionByWait) {
         std::promise<void> p;
     auto f = p.get_future();
     std::thread t([&] {
-        EXPECT_EQ(wcfWaitConnection(wcli_, 100), WCF_OK);
+        EXPECT_EQ(wcfWaitConnection(wcli_), WCF_OK);
         p.set_value();
     });
     while (!dummy_s->connected() || !wcfIsConnected(wcli_)) {
@@ -92,7 +92,7 @@ TEST_F(CClientTest, connectionByWait) {
     EXPECT_TRUE(dummy_s->connected());
     EXPECT_TRUE(wcfIsConnected(wcli_));
 
-    EXPECT_EQ(wcfWaitConnection(nullptr, 100), WCF_BAD_WCLI);
+    EXPECT_EQ(wcfWaitConnection(nullptr), WCF_BAD_WCLI);
 }
 TEST_F(CClientTest, noConnectionByRecv) {
     EXPECT_FALSE(dummy_s->connected());

--- a/tests/client_test.cc
+++ b/tests/client_test.cc
@@ -532,6 +532,7 @@ TEST_F(ClientTest, textReq) {
     wcli_->member("a").text("b").onChange(callback<Text>());
     dummy_s->send(message::Res<message::Text>{
         1, ""_ss, std::make_shared<ValAdaptor>("z")});
+    wcli_->waitRecv();
     dummy_s->send(message::Res<message::Text>{
         1, "c"_ss, std::make_shared<ValAdaptor>("z")});
     wcli_->waitRecv();
@@ -637,6 +638,7 @@ TEST_F(ClientTest, viewReq) {
                  .toMessage()},
         });
     dummy_s->send(message::Res<message::View>{1, ""_ss, v, 3});
+    wcli_->waitRecv();
     dummy_s->send(message::Res<message::View>{1, "c"_ss, v, 3});
     wcli_->waitRecv();
     EXPECT_EQ(callback_called, 1);
@@ -826,6 +828,7 @@ TEST_F(ClientTest, canvas2DReq) {
                       .toMessage()},
         });
     dummy_s->send(message::Res<message::Canvas2D>{1, ""_ss, 200, 200, v, 3});
+    wcli_->waitRecv();
     dummy_s->send(message::Res<message::Canvas2D>{1, "c"_ss, 200, 200, v, 3});
     wcli_->waitRecv();
     EXPECT_EQ(callback_called, 1);
@@ -1085,6 +1088,7 @@ TEST_F(ClientTest, canvas3DReq) {
                       .toMessage()},
         });
     dummy_s->send(message::Res<message::Canvas3D>{1, ""_ss, v, 3});
+    wcli_->waitRecv();
     dummy_s->send(message::Res<message::Canvas3D>{1, "c"_ss, v, 3});
     wcli_->waitRecv();
     EXPECT_EQ(callback_called, 1);
@@ -1198,6 +1202,7 @@ TEST_F(ClientTest, robotModelReq) {
         std::make_shared<std::vector<message::RobotLink>>(
             std::vector<message::RobotLink>{
                 RobotLink{"a", Geometry{}, ViewColor::black}.toMessage({})})));
+    wcli_->waitRecv();
     dummy_s->send(message::Res<message::RobotModel>(
         1, "c"_ss,
         std::make_shared<std::vector<message::RobotLink>>(
@@ -1249,6 +1254,7 @@ TEST_F(ClientTest, imageReq) {
                    std::make_shared<std::vector<unsigned char>>(100 * 100 * 3),
                    ImageColorMode::bgr);
     dummy_s->send(message::Res<message::Image>{1, ""_ss, img.toMessage()});
+    wcli_->waitRecv();
     dummy_s->send(message::Res<message::Image>{1, "c"_ss, img.toMessage()});
     wcli_->waitRecv();
     EXPECT_EQ(callback_called, 1);

--- a/tests/func_test.cc
+++ b/tests/func_test.cc
@@ -528,9 +528,9 @@ TEST_F(FuncTest, funcSharedFutureRun) {
 TEST_F(FuncTest, funcRunRemote) {
     func("a", "b").runAsync(1.23, true, "abc");
     bool call_msg_found = false;
-    while (!data_->message_queue.empty()) {
-        auto msg = data_->message_queue.front();
-        data_->message_queue.pop();
+    while (!data_->sync_queue.empty()) {
+        auto msg = data_->sync_queue.front();
+        data_->sync_queue.pop();
         if (msg ==
             message::packSingle(message::Call{
                 0,


### PR DESCRIPTION
* 受信処理はws_threadで行い、recv_queueから取り出して処理するのをrecv()で行うようにした
  * sync()とrecv()の順番が変わっても問題なく動作するはず
* waitConnection() のtimeoutを消した
* recv()は未接続でautoReconnectが無効の場合待機せずreturnすることにした
