### PR TITLE
meson.build修正

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,42 +77,30 @@ add_custom_target(webcface-build ALL
     VERBATIM
 )
 
-add_library(webcface INTERFACE)
-add_library(wcf INTERFACE)
-add_dependencies(webcface webcface-build)
-add_dependencies(wcf webcface-build)
+foreach(target webcface wcf)
+    add_library(${target} INTERFACE)
+    add_dependencies(${target} webcface-build)
+    target_compile_definitions(${target} INTERFACE $<BUILD_INTERFACE:WEBCFACE_MESON>)
+    target_include_directories(${target} INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/encoding/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/client/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/meson>
+    )
+    target_link_directories(${target} INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/meson>
+    )
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        target_link_libraries(${target} INTERFACE
+            debug webcfaced.lib
+            optimized webcface.lib
+        )
+    else()
+        target_link_libraries(${target} INTERFACE -lwebcface)
+    endif()
+endforeach()
 target_compile_features(webcface INTERFACE cxx_std_17)
 target_compile_features(wcf INTERFACE c_std_99)
-target_compile_definitions(webcface INTERFACE $<BUILD_INTERFACE:WEBCFACE_MESON>)
-target_compile_definitions(wcf INTERFACE $<BUILD_INTERFACE:WEBCFACE_MESON>)
-target_include_directories(webcface INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/encoding/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/client/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/meson>
-)
-target_include_directories(wcf INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/client/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/meson>
-)
-target_link_directories(webcface INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/meson>
-)
-target_link_directories(wcf INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/meson>
-)
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    target_link_libraries(webcface INTERFACE
-        debug webcfaced.lib
-        optimized webcface.lib
-    )
-    target_link_libraries(wcf INTERFACE
-        debug webcfaced.lib
-        optimized webcface.lib
-    )
-else()
-    target_link_libraries(webcface INTERFACE -lwebcface)
-    target_link_libraries(wcf INTERFACE -lwebcface)
-endif()
+
 add_library(webcface::webcface ALIAS webcface)
 add_library(webcface::wcf ALIAS wcf)
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,11 @@ Web-based IPC &amp; Dashboard-like UI
 > * mainブランチはver2.0.0としてリリース予定の現在開発中のブランチです。
 > ver1は [v1](https://github.com/na-trium-144/webcface/tree/v1) ブランチにあります
 
-WebSocketとMessagePackを使った、ROSのような分散型の通信ライブラリです。
+ROS1のようなプロセス間通信と、GUIによるデータの可視化や関数呼び出しができるシステムです。
 
-C++ (C++17以上), C (C99), Python (3.8以上), JavaScript/TypeScript で相互に数値、文字列、画像などのデータを送受信したり、関数(手続き)を呼び出したりすることができます。
+C++ (C++17以上), C, Python (3.8以上), JavaScript/TypeScript で相互に数値、文字列、画像などのデータを送受信したり、関数を呼び出したりすることができます。
 
 Linux, MacOS, Windows(MSVC, MinGW, MSYS2, Cygwin) で動作します。
-Wi-FiやEtherNet経由で複数のPC間(OS問わず)で通信することも可能です。
-WindowsとWSL1/2の間の相互通信も自動的に接続されます。
-
-さらに同一マシン上やDocker,WSL経由など使用可能な場合はTCPの代わりにUnixドメインソケットを使用するようにし、パフォーマンスが改善しました。
 
 ## Features
 
@@ -38,8 +34,8 @@ pkg-config なら`pkg-config --cflags --libs webcface`
 で簡単に利用できます。  
 またライブラリ本体は
 * Linux: `libwebcface.so.<version>`
-* Mac: `webcface.framework` (または `libwebcface.<version>.dylib`)
-* Windows: `webcface<version>.dll` (MinGWの場合 `libwebcface<version>.dll`)
+* Mac: `libwebcface.<version>.dylib`
+* Windows: `webcface-<version>.dll` (Release) or `webcfaced-<version>.dll` (Debug)
 
 の1つのみであり、手動でこのライブラリにリンクして使うこともできます。  
 WebCFace内部では外部ライブラリを多数使用していますが、それらはシンボルをすべて非公開にしているのでユーザーが使用するライブラリとは干渉しません。
@@ -51,6 +47,13 @@ Python, JavaScript には PyPI / npm に `webcface` パッケージを用意し�
 少し難易度は上がりますが、CのAPIを経由することで他の言語からも使用できると思います。
 
 ### Inter-Process Communication
+
+WebCFaceの通信にはWebSocketとMessagePackを使っています。
+このためプロセス間だけでなくWebブラウザーとの通信が可能になっています。
+さらに同一マシン上やDocker,WSL経由など使用可能な場合はTCPの代わりにUnixドメインソケットを使用します。
+
+Wi-FiやEtherNet経由で複数のPC間(OS問わず)で通信することも可能です。
+WindowsとWSL1/2の間の相互通信も自動的に接続されます。
 
 WebCFaceで送受信できるデータ型として
 * 数値型・数値配列型(Value)
@@ -76,7 +79,7 @@ WebCFaceの通信データ形式はOSやライブラリの言語によらず共�
 WebCFaceではプログラム間でデータの送受信ができるAPIだけでなく、
 WebブラウザーからWebCFaceで通信されているデータを可視化したり関数を呼び出したりできるUI(WebUI)を提供します。
 
-さらにボタンや入力欄などの並べ方をWebCFaceを使ったC++などのプログラムの側で定義してそれをWebUIに表示させることができ、
+さらにボタンや入力欄などの並べ方をWebCFaceを使ったC++,Pythonなどのプログラムの側で定義してそれをWebUIに表示させることができ、
 これによりHTMLやCSSの知識がなくても簡易なUIを作成することができます。
 
 また、同様に2D、3Dの図形もWebCFaceを使ったプログラム側の記述のみでWebUIに描画させることができます。

--- a/client/include/webcface/webcface.h
+++ b/client/include/webcface/webcface.h
@@ -1,9 +1,4 @@
 #pragma once
-#ifdef WEBCFACE_STATIC_DIR
-// clang-format off
-#error "This header file is for WebCFace ver.2 but is used with WebCFace ver.0.x CMake files"
-// clang-format on
-#endif
 
 #ifdef WEBCFACE_MESON
 #include "webcface-config.h"

--- a/docs/00_overview.md
+++ b/docs/00_overview.md
@@ -111,25 +111,22 @@ find_package(webcface CONFIG REQUIRED)
 target_link_libraries(target PRIVATE webcface::webcface)
 ```
 
-* find_packageでwebcfaceが見つからない場合はwebcfaceのインストール場所を`CMAKE_PREFIX_PATH`か`webcface_DIR`に設定してください。
-* FetchContentやsubmoduleでこのリポジトリを追加して使うこともできます。また、ROS2のワークスペースのsrcに追加してcolconでビルドすることもできます。
-    * CMakeのオプション(OpenCVを使用しないようにする、staticライブラリにするなど)はREADMEを参照してください
+* find_packageでwebcfaceが見つからない場合はwebcfaceのインストール場所を`CMAKE_PREFIX_PATH`か`webcface_ROOT`, `webcface_DIR`などに設定してください。
+* FetchContentやsubmoduleでこのリポジトリを追加して使うこともできます。
+* 複数バージョンのWebCFaceがインストールされている可能性がある場合は`find_package(webcface 2.0 CONFIG REQUIRED)`のようにバージョン指定をするとよいかも
+    * 同じメジャーバージョンで、指定したマイナーバージョン以上のものが選ばれます
+    (例えば2.0と書いて2.1が選ばれることはあるが、1.0と書いて2.0や2.1が選ばれることはない)
 
 <details><summary>CMakeを使わない場合は</summary>
 
 * Windows (MSVC)
-    * インクルードディレクトリ: `C:\Program Files\WebCFace\include`, `C:\Program Files\WebCFace\opencv\include`
-    * ライブラリディレクトリ: `C:\Program Files\WebCFace\lib`, `C:\Program Files\WebCFace\opencv\x64\vc16\lib`
-    * リンクするライブラリは
-        * Releaseの場合 webcface10.lib, spdlog.lib, opencv_world490.lib
-        * Debugの場合 webcface10d.lib, spdlogd.lib, opencv_world490d.lib
-    * また、`C:\Program Files\WebCFace\bin` を環境変数のPathに追加するか、その中にあるdllファイルを実行ファイルのディレクトリにコピーして読み込ませてください
-* Linux
+    * インクルードディレクトリ: `C:\Program Files\WebCFace\include`
+    * ライブラリディレクトリ: `C:\Program Files\WebCFace\lib`
+    * リンクするライブラリは、 webcface.lib (Release) / webcfaced.lib (Debug)
+    * また、`C:\Program Files\WebCFace\bin` を環境変数のPathに追加するか、その中にある webcface-20.dll / webcfaced-20.dll ファイルを実行ファイルのディレクトリにコピーして読み込ませてください
+* MSVC以外
     * pkgconfigを使用してコンパイル時の引数に `$(pkg-config --cflags webcface)` 、リンク時に `$(pkg-config --libs webcface)` を渡せばよいです
-    * 手動でリンクするなら lib/libwebcface.so をリンクしてください
-        * Releasesで配布しているdebパッケージの場合はインストール先は /usr です
-* MacOS
-    * Linuxと同様pkgconfigを使ってコンパイル、リンクできると思います
+    * 手動でリンクするなら webcfaceのインストール先/lib/ にあるwebcfaceのライブラリをリンクしてください
 
 </details>
 

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,8 @@ cxx = meson.get_compiler('cpp')
 py = find_program('python3')
 cmake_cmd = find_program('cmake')
 
-webcface_soversion = '20'
+webcface_soversion = '20' # ABIの破壊的変更で1増やす
+webcface_compatibility_version = '0' # ABIの追加で1増やす
 webcface_webui_version = '1.7.0'
 
 webcface_description = 'Web-based IPC & Dashboard-like UI'
@@ -622,6 +623,10 @@ webcface_lib = library(webcface_lib_name,
   ],
   version: meson.project_version(),
   soversion: webcface_soversion,
+  darwin_versions: [
+    webcface_soversion + '.' + webcface_compatibility_version,
+    meson.project_version(),
+  ],
   install: true,
 )
 webcface_dep = declare_dependency(

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,6 @@ fs = import('fs')
 cmake = import('cmake')
 cxx = meson.get_compiler('cpp')
 py = find_program('python3')
-cmake_cmd = find_program('cmake')
 
 webcface_abi_major = '20' # ABIの破壊的変更で1増やす
 webcface_abi_minor = '0' # ABIの追加で1増やす
@@ -683,29 +682,21 @@ install_data(['README.md', 'LICENSE'],
   install_dir: get_option('datadir') / 'doc' / 'webcface',
 )
 if get_option('default_library') == 'shared'
-  run_command(cmake_cmd,
-    '-Dsizeof_void_p=' + (host_machine.cpu_family().endswith('64') ? '8' : '4'),
-    '-Dbuild_dir=' + meson.current_build_dir(),
-    '-Dversion=' + meson.project_version(),
-    '-P', meson.project_source_root() / 'scripts' / 'configure-version.cmake',
-    check: true,
-  )
-  cmake_dir = get_option('libdir') / 'cmake' / 'webcface'
-  install_data(meson.current_build_dir() / 'webcface-config-version.cmake',
-    install_dir: cmake_dir,
+  cmake.write_basic_package_version_file(
+    name: 'webcface',
+    version: meson.project_version(),
+    compatibility: 'SameMajorVersion',
+    arch_independent: false,
   )
   conf_data = configuration_data({
     'libdir': get_option('libdir'),
     'includedir': get_option('includedir'),
-    'cmakedir': cmake_dir,
     'webcface_lib_debug': webcface_lib_name_debug,
     'webcface_lib_release': webcface_lib_name_release,
   })
-  configure_file(
+  cmake.configure_package_config_file(
+    name: 'webcface',
     input: 'scripts' / 'webcface-config.cmake.in',
-    output: 'webcface-config.cmake',
-    configuration: conf_data,
-    install: true,
-    install_dir: cmake_dir,
+    configuration: conf_data
   )
 endif

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,6 @@ project('webcface', 'c', 'cpp',
     # 'c_std=c99', # 指定するとlibjpegのビルドが通らない
     'cpp_std=gnu++17,c++17', # spdlogがgnu++必要、webcfaceは17以上必須
     'wrap_mode=forcefallback',
-    'pkgconfig.relocatable=true',
   ],
 )
 fs = import('fs')
@@ -18,8 +17,8 @@ cxx = meson.get_compiler('cpp')
 py = find_program('python3')
 cmake_cmd = find_program('cmake')
 
-webcface_soversion = '20' # ABIの破壊的変更で1増やす
-webcface_compatibility_version = '0' # ABIの追加で1増やす
+webcface_abi_major = '20' # ABIの破壊的変更で1増やす
+webcface_abi_minor = '0' # ABIの追加で1増やす
 webcface_webui_version = '1.7.0'
 
 webcface_description = 'Web-based IPC & Dashboard-like UI'
@@ -41,7 +40,7 @@ elif get_option('version_suffix') != ''
   webcface_version_str = meson.project_version() + '-' + get_option('version_suffix')
 endif
 summary('Version', webcface_version_str)
-summary('ABI Version', webcface_soversion)
+summary('ABI Version', webcface_abi_major + '.' + webcface_abi_minor)
 
 assert(
   get_option('default_library') == 'shared' or get_option('default_library') == 'static',
@@ -53,6 +52,7 @@ conf_data = configuration_data({
   'WEBCFACE_VERSION_MINOR': meson.project_version().split('.')[1],
   'WEBCFACE_VERSION_REVISION': meson.project_version().split('.')[2],
   'WEBCFACE_VERSION': '"' + webcface_version_str + '"',
+  'WEBCFACE_ABI_MAJOR': webcface_abi_major,
 })
 conf_data.set10('WEBCFACE_SHARED', get_option('default_library') == 'shared')
 
@@ -622,9 +622,9 @@ webcface_lib = library(webcface_lib_name,
     curl_dep,
   ],
   version: meson.project_version(),
-  soversion: webcface_soversion,
+  soversion: webcface_abi_major,
   darwin_versions: [
-    webcface_soversion + '.' + webcface_compatibility_version,
+    webcface_abi_major + '.' + webcface_abi_minor,
     meson.project_version(),
   ],
   install: true,

--- a/meson.build
+++ b/meson.build
@@ -323,6 +323,7 @@ else
       'form-api=disabled',
       'getoptions=disabled',
       'gsasl=disabled',
+      'http2=disabled',
       'ipv6=disabled',
       'libcurl-option=disabled',
       'libz=disabled',

--- a/scripts/config.h.in
+++ b/scripts/config.h.in
@@ -103,7 +103,7 @@ std::function<>の中には要る(ただし型推論ができたりできなか�
 #endif
 #endif
 
-#ifndef WEBCFACE_NS_ABI
+#ifndef WEBCFACE_NS_ABI_2
 #define WEBCFACE_NS_ABI_2(ver) v##ver##_
 #endif
 

--- a/scripts/config.h.in
+++ b/scripts/config.h.in
@@ -1,20 +1,14 @@
 #pragma once
+
 #define WEBCFACE_STR(v) #v
 #define WEBCFACE_DEFAULT_PORT 7530
 #define WEBCFACE_DEFAULT_PORT_SI(port) WEBCFACE_STR(port)
 #define WEBCFACE_DEFAULT_PORT_S WEBCFACE_DEFAULT_PORT_SI(WEBCFACE_DEFAULT_PORT)
 #define WEBCFACE_SERVER_NAME "webcface"
-// clang-format off
 #mesondefine WEBCFACE_VERSION_MAJOR
 #mesondefine WEBCFACE_VERSION_MINOR
 #mesondefine WEBCFACE_VERSION_REVISION
-// clang-format on
-#ifndef WEBCFACE_VERSION_MINOR
-#define WEBCFACE_VERSION_MINOR 0
-#endif
-#ifndef WEBCFACE_VERSION_REVISION
-#define WEBCFACE_VERSION_REVISION 0
-#endif
+#mesondefine WEBCFACE_ABI_MAJOR
 #mesondefine WEBCFACE_VERSION
 #mesondefine WEBCFACE_SHARED
 #mesondefine WEBCFACE_SYSTEM_DLLEXPORT
@@ -31,6 +25,7 @@ WEBCFACE_DLL: 関数の宣言 (msvc, mingw, unix)
 WEBCFACE_DLL_TEMPLATE: テンプレートクラスの定義 (unix)
 WEBCFACE_DLL_INSTANCE_DECL: 明示的実体化の宣言 (msvc_import, mingw) (unixでは消す:gcc-10でエラー)
 WEBCFACE_DLL_INSTANCE_DEF: 明示的実体化の定義 (msvc_export, unix)
+
 */
 // clang-format on
 
@@ -66,10 +61,12 @@ WEBCFACE_DLL_INSTANCE_DEF: 明示的実体化の定義 (msvc_export, unix)
 #undef WEBCFACE_DLL_INSTANCE_DECL
 #define WEBCFACE_DLL_INSTANCE_DEF
 #endif // WEBCFACE_BUILDING
-#else // DLLEXPORT, VISIBILITY
+#else  // DLLEXPORT, VISIBILITY
+// clang-format off
 #error "neither WEBCFACE_SYSTEM_DLLEXPORT nor WEBCFACE_SYSTEM_VISIBILITY is defined"
+// clang-format on
 #endif
-#else  // !WEBCFACE_SHARED
+#else // !WEBCFACE_SHARED
 #define WEBCFACE_DLL
 #define WEBCFACE_DLL_TEMPLATE
 #define WEBCFACE_DLL_INSTANCE_DECL
@@ -102,16 +99,18 @@ std::function<>の中には要る(ただし型推論ができたりできなか�
 
 #if WEBCFACE_SYSTEM_ADD_DEBUG
 #ifdef _DEBUG
-#define WEBCFACE_NS_BEGIN                                                      \
-    namespace webcface {                                                       \
-    inline namespace debug {
-#define WEBCFACE_NS_END                                                        \
-    }                                                                          \
-    }
+#define WEBCFACE_NS_ABI_2(ver) v##ver##_debug
 #endif
 #endif
 
-#ifndef WEBCFACE_NS_BEGIN
-#define WEBCFACE_NS_BEGIN namespace webcface {
-#define WEBCFACE_NS_END }
+#ifndef WEBCFACE_NS_ABI
+#define WEBCFACE_NS_ABI_2(ver) v##ver##_
 #endif
+
+#define WEBCFACE_NS_ABI(ver) WEBCFACE_NS_ABI_2(ver)
+#define WEBCFACE_NS_BEGIN                                                      \
+    namespace webcface {                                                       \
+    inline namespace WEBCFACE_NS_ABI(WEBCFACE_ABI_MAJOR) {
+#define WEBCFACE_NS_END                                                        \
+    }                                                                          \
+    }

--- a/scripts/configure-version.cmake
+++ b/scripts/configure-version.cmake
@@ -1,8 +1,0 @@
-include(CMakePackageConfigHelpers)
-
-set(CMAKE_SIZEOF_VOID_P ${sizeof_void_p})
-write_basic_package_version_file(
-    ${build_dir}/webcface-config-version.cmake
-    VERSION ${version}
-    COMPATIBILITY SameMajorVersion
-)

--- a/scripts/webcface-config.cmake.in
+++ b/scripts/webcface-config.cmake.in
@@ -1,41 +1,14 @@
-# 手書き
-# 動けばヨシ
-
-# Compute the installation prefix relative to this file.
-string(LENGTH "${CMAKE_CURRENT_LIST_FILE}" _CURRENT_LIST_FILE_LEN)
-set(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}")
-while(1)
-  get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
-  if(_IMPORT_PREFIX STREQUAL "/")
-    set(_IMPORT_PREFIX "")
-  endif()
-  string(LENGTH "${_IMPORT_PREFIX}/@cmakedir@/webcface-config.cmake" _REL_LIST_FILE_LEN)
-  if("${_IMPORT_PREFIX}/@cmakedir@/webcface-config.cmake" STREQUAL CMAKE_CURRENT_LIST_FILE)
-    break()
-  elseif(_REL_LIST_FILE_LEN LESS _CURRENT_LIST_FILE_LEN)
-    message(FATAL_ERROR "Failed to compute import prefix")
-  endif()
-endwhile()
+@PACKAGE_INIT@
 
 # Create imported target webcface::webcface
-add_library(webcface::webcface INTERFACE IMPORTED)
-set_target_properties(webcface::webcface PROPERTIES
-  INTERFACE_COMPILE_FEATURES "cxx_std_17"
-  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@includedir@"
-  INTERFACE_LINK_DIRECTORIES "${_IMPORT_PREFIX}/@libdir@"
-)
-target_link_libraries(webcface::webcface INTERFACE
-  debug @webcface_lib_debug@
-  optimized @webcface_lib_release@
-)
-# Create imported target webcface::wcf
-add_library(webcface::wcf INTERFACE IMPORTED)
-set_target_properties(webcface::wcf PROPERTIES
-  INTERFACE_COMPILE_FEATURES "c_std_99"
-  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@includedir@"
-  INTERFACE_LINK_DIRECTORIES "${_IMPORT_PREFIX}/@libdir@"
-)
-target_link_libraries(webcface::wcf INTERFACE
-  debug @webcface_lib_debug@
-  optimized @webcface_lib_release@
-)
+foreach(target webcface wcf)
+    add_library(webcface::${target} INTERFACE IMPORTED)
+    target_include_directories(webcface::${target} INTERFACE "${PACKAGE_PREFIX_DIR}/@includedir@")
+    target_link_directories(webcface::${target} INTERFACE "${PACKAGE_PREFIX_DIR}/@libdir@")
+    target_link_libraries(webcface::${target} INTERFACE
+        debug @webcface_lib_debug@
+        optimized @webcface_lib_release@
+    )
+endforeach()
+target_compile_features(webcface::webcface INTERFACE cxx_std_17)
+target_compile_features(webcface::wcf INTERFACE c_std_99)


### PR DESCRIPTION
* compatibility_versionの設定
* webcface_soversion → webcface_abi_major, abi_minorとか
* namespaceにabi_majorバージョンを追加
* ver0のエラーメッセージ削除
* relocatableはdefault_optionsに指定してもいみない
* http2依存を削除
