### PR TITLE
大半のメンバ関数にconst追加

### DIFF
--- a/client/include/webcface/canvas2d.h
+++ b/client/include/webcface/canvas2d.h
@@ -95,7 +95,8 @@ class WEBCFACE_DLL Canvas2D : protected Field {
      * \param callback Canvas2D型の引数(thisが渡される)を1つ取る関数
      *
      */
-    Canvas2D &onChange(std::function<void WEBCFACE_CALL_FP(Canvas2D)> callback);
+    const Canvas2D &
+    onChange(std::function<void WEBCFACE_CALL_FP(Canvas2D)> callback) const;
     /*!
      * \brief 値が変化したときに呼び出されるコールバックを設定
      * \since ver2.0
@@ -104,7 +105,7 @@ class WEBCFACE_DLL Canvas2D : protected Field {
      */
     template <typename F, typename std::enable_if_t<std::is_invocable_v<F>,
                                                     std::nullptr_t> = nullptr>
-    Canvas2D &onChange(F callback) {
+    const Canvas2D &onChange(F callback) const {
         return onChange(
             [callback = std::move(callback)](const auto &) { callback(); });
     }
@@ -116,7 +117,7 @@ class WEBCFACE_DLL Canvas2D : protected Field {
      *
      */
     template <typename T>
-    [[deprecated]] void appendListener(T &&callback) {
+    [[deprecated]] void appendListener(T &&callback) const {
         onChange(std::forward<T>(callback));
     }
 
@@ -125,7 +126,7 @@ class WEBCFACE_DLL Canvas2D : protected Field {
      * \since ver1.7
      *
      */
-    void request() const;
+    const Canvas2D &request() const;
     /*!
      * \brief Canvasの内容を取得する
      *
@@ -148,7 +149,7 @@ class WEBCFACE_DLL Canvas2D : protected Field {
      * \brief 値やリクエスト状態をクリア
      *
      */
-    Canvas2D &free();
+    const Canvas2D &free() const;
 
     /*!
      * \brief Canvasのサイズを指定 & このCanvas2Dに追加した内容を初期化する
@@ -158,16 +159,16 @@ class WEBCFACE_DLL Canvas2D : protected Field {
      * (init() 後に sync() をすると空のCanvas2Dが送信される)
      *
      */
-    Canvas2D &init(double width, double height);
+    const Canvas2D &init(double width, double height) const;
 
     /*!
      * \brief Componentを追加
      * \since ver1.9
      *
      * * ver2.0〜: move専用
-     * 
+     *
      */
-    Canvas2D &operator<<(TemporalCanvas2DComponent cc);
+    const Canvas2D &operator<<(TemporalCanvas2DComponent cc) const;
 
     /*!
      * \brief コンポーネントなどを追加
@@ -178,17 +179,17 @@ class WEBCFACE_DLL Canvas2D : protected Field {
      *
      */
     template <typename T>
-    Canvas2D &add(T &&cc) {
+    const Canvas2D &add(T &&cc) const {
         *this << std::forward<T>(cc);
         return *this;
     }
     /*!
      * \brief Geometryを追加
      * \since ver1.9
-     * 
+     *
      */
     template <bool V, bool C3>
-    Canvas2D &operator<<(TemporalComponent<V, true, C3> cc) {
+    const Canvas2D &operator<<(TemporalComponent<V, true, C3> cc) const {
         *this << std::move(cc.component_2d);
         return *this;
     }
@@ -199,7 +200,7 @@ class WEBCFACE_DLL Canvas2D : protected Field {
      * (init()も追加もされていなければ) 何もしない。
      *
      */
-    Canvas2D &sync();
+    const Canvas2D &sync() const;
 
     /*!
      * \brief Canvas2Dの参照先を比較

--- a/client/include/webcface/canvas3d.h
+++ b/client/include/webcface/canvas3d.h
@@ -93,7 +93,8 @@ class WEBCFACE_DLL Canvas3D : protected Field {
      * \param callback Canvas3D型の引数(thisが渡される)を1つ取る関数
      *
      */
-    Canvas3D &onChange(std::function<void WEBCFACE_CALL_FP(Canvas3D)> callback);
+    const Canvas3D &
+    onChange(std::function<void WEBCFACE_CALL_FP(Canvas3D)> callback) const;
     /*!
      * \brief 値が変化したときに呼び出されるコールバックを設定
      * \since ver2.0
@@ -102,7 +103,7 @@ class WEBCFACE_DLL Canvas3D : protected Field {
      */
     template <typename F, typename std::enable_if_t<std::is_invocable_v<F>,
                                                     std::nullptr_t> = nullptr>
-    Canvas3D &onChange(F callback) {
+    const Canvas3D &onChange(F callback) const {
         return onChange(
             [callback = std::move(callback)](const auto &) { callback(); });
     }
@@ -114,7 +115,7 @@ class WEBCFACE_DLL Canvas3D : protected Field {
      *
      */
     template <typename T>
-    [[deprecated]] void appendListener(T &&callback) {
+    [[deprecated]] void appendListener(T &&callback) const {
         onChange(std::forward<T>(callback));
     }
 
@@ -123,7 +124,7 @@ class WEBCFACE_DLL Canvas3D : protected Field {
      * \since ver1.7
      *
      */
-    void request() const;
+    const Canvas3D &request() const;
     /*!
      * \brief Canvasの内容を取得する
      *
@@ -146,7 +147,7 @@ class WEBCFACE_DLL Canvas3D : protected Field {
      * \brief 値やリクエスト状態をクリア
      *
      */
-    Canvas3D &free();
+    const Canvas3D &free() const;
 
     /*!
      * \brief このCanvas3Dに追加した内容を初期化する
@@ -156,13 +157,13 @@ class WEBCFACE_DLL Canvas3D : protected Field {
      * (init() 後に sync() をすると空のCanvas3Dが送信される)
      *
      */
-    Canvas3D &init();
+    const Canvas3D &init() const;
 
     /*!
      * \brief Componentを追加
      * \since ver1.9
      */
-    Canvas3D &operator<<(TemporalCanvas3DComponent cc);
+    const Canvas3D &operator<<(TemporalCanvas3DComponent cc) const;
 
     /*!
      * \brief コンポーネントなどを追加
@@ -173,7 +174,7 @@ class WEBCFACE_DLL Canvas3D : protected Field {
      *
      */
     template <typename T>
-    Canvas3D &add(T &&cc) {
+    const Canvas3D &add(T &&cc) const {
         *this << std::forward<T>(cc);
         return *this;
     }
@@ -183,7 +184,7 @@ class WEBCFACE_DLL Canvas3D : protected Field {
      * \since ver1.9
      */
     template <bool V, bool C2>
-    Canvas3D &operator<<(TemporalComponent<V, C2, true> cc) {
+    const Canvas3D &operator<<(TemporalComponent<V, C2, true> cc) const {
         *this << std::move(cc.component_3d);
         return *this;
     }
@@ -195,7 +196,7 @@ class WEBCFACE_DLL Canvas3D : protected Field {
      * (init()も追加もされていなければ) 何もしない。
      *
      */
-    Canvas3D &sync();
+    const Canvas3D &sync() const;
 
     /*!
      * \brief Canvas3Dの参照先を比較

--- a/client/include/webcface/client.h
+++ b/client/include/webcface/client.h
@@ -80,7 +80,7 @@ class WEBCFACE_DLL Client : public Member {
      * \brief 接続を切り、今後再接続しない
      *
      */
-    void close();
+    const Client &close() const;
 
     /*!
      * \brief 通信が切断されたときに自動で再試行するかどうかを設定する。
@@ -90,7 +90,7 @@ class WEBCFACE_DLL Client : public Member {
      *
      * \sa start(), waitConnection()
      */
-    void autoReconnect(bool enabled);
+    const Client &autoReconnect(bool enabled) const;
     /*!
      * \brief 通信が切断されたときに自動で再試行するかどうかを取得する。
      * \since ver1.11.1
@@ -102,7 +102,7 @@ class WEBCFACE_DLL Client : public Member {
      * \since ver1.2
      * \sa waitConnection(), autoReconnect()
      */
-    void start();
+    const Client &start() const;
     /*!
      * \brief サーバーへの接続を別スレッドで開始し、成功するまで待機する。
      * \since ver1.2
@@ -115,10 +115,11 @@ class WEBCFACE_DLL Client : public Member {
      *
      * \sa start(), autoReconnect()
      */
-    void waitConnection();
+    const Client &waitConnection() const;
 
   private:
-    void syncImpl(std::optional<std::chrono::microseconds> timeout);
+    const Client &
+    syncImpl(std::optional<std::chrono::microseconds> timeout) const;
 
   public:
     /*!
@@ -135,7 +136,9 @@ class WEBCFACE_DLL Client : public Member {
      *
      * \sa start(), loopSyncFor(), loopSyncUntil(), loopSync()
      */
-    void sync() { syncImpl(std::chrono::microseconds(0)); }
+    const Client &sync() const {
+        return syncImpl(std::chrono::microseconds(0));
+    }
     /*!
      * \brief
      * 送信用にセットしたデータをすべて送信キューに入れ、受信したデータを処理する。
@@ -149,7 +152,9 @@ class WEBCFACE_DLL Client : public Member {
      *
      * \sa sync(), loopSyncUntil(), loopSync()
      */
-    void loopSyncFor(std::chrono::microseconds timeout) { syncImpl(timeout); }
+    const Client &loopSyncFor(std::chrono::microseconds timeout) const {
+        return syncImpl(timeout);
+    }
     /*!
      * \brief
      * 送信用にセットしたデータをすべて送信キューに入れ、受信したデータを処理する。
@@ -160,8 +165,9 @@ class WEBCFACE_DLL Client : public Member {
      * \sa sync(), loopSyncFor(), loopSync()
      */
     template <typename Clock, typename Duration>
-    void loopSyncUntil(std::chrono::time_point<Clock, Duration> timeout) {
-        syncImpl(std::chrono::duration_cast<std::chrono::microseconds>(
+    const Client &
+    loopSyncUntil(std::chrono::time_point<Clock, Duration> timeout) const {
+        return syncImpl(std::chrono::duration_cast<std::chrono::microseconds>(
             timeout - Clock::now()));
     }
     /*!
@@ -175,14 +181,15 @@ class WEBCFACE_DLL Client : public Member {
      *
      * \sa sync(), loopSyncFor(), loopSyncUntil()
      */
-    void loopSync() { syncImpl(std::nullopt); }
+    const Client &loopSync() const { return syncImpl(std::nullopt); }
 
     // /*!
     //  * \brief 別スレッドでsync()を自動的に呼び出す間隔を設定する。
     //  * \since ver2.0
     //  *
     //  * * start() や waitConnection() より前に設定する必要がある。
-    //  * * autoSyncが有効の場合、別スレッドで一定間隔(100μs)ごとにsync()が呼び出され、
+    //  * *
+    //  autoSyncが有効の場合、別スレッドで一定間隔(100μs)ごとにsync()が呼び出され、
     //  * 各種コールバック (onEntry, onChange, Func::run()など)
     //  * も別のスレッドで呼ばれることになる
     //  * (そのためmutexなどを適切に設定すること)
@@ -238,8 +245,8 @@ class WEBCFACE_DLL Client : public Member {
      *
      * \sa member(), members()
      */
-    Client &
-    onMemberEntry(std::function<void WEBCFACE_CALL_FP(Member)> callback);
+    const Client &
+    onMemberEntry(std::function<void WEBCFACE_CALL_FP(Member)> callback) const;
 
     /*!
      * \brief webcfaceに出力するstreambuf
@@ -256,7 +263,7 @@ class WEBCFACE_DLL Client : public Member {
      *
      * \sa loggerOStream()
      */
-    std::streambuf *loggerStreamBuf();
+    std::streambuf *loggerStreamBuf() const;
     /*!
      * \brief webcfaceに出力するostream
      *
@@ -269,19 +276,19 @@ class WEBCFACE_DLL Client : public Member {
      *
      * \sa loggerStreamBuf()
      */
-    std::ostream &loggerOStream();
+    std::ostream &loggerOStream() const;
     /*!
      * \brief webcfaceに出力するwstreambuf
      * \since ver2.0
      * \sa loggerStreamBuf
      */
-    std::wstreambuf *loggerWStreamBuf();
+    std::wstreambuf *loggerWStreamBuf() const;
     /*!
      * \brief webcfaceに出力するwostream
      * \since ver2.0
      * \sa loggerOStream
      */
-    std::wostream &loggerWOStream();
+    std::wostream &loggerWOStream() const;
 
     /*!
      * \brief WebCFaceサーバーのバージョン情報

--- a/client/include/webcface/func.h
+++ b/client/include/webcface/func.h
@@ -158,35 +158,11 @@ class WEBCFACE_DLL Func : protected Field {
      * set2()で構築された関数の情報(FuncInfo)をclientにセット
      *
      */
-    Func &setImpl(ValType return_type, std::vector<Arg> &&args,
-                  std::function<FuncType> &&func_impl);
-    Func &setImpl(const std::shared_ptr<internal::FuncInfo> &func_info);
+    const Func &setImpl(ValType return_type, std::vector<Arg> &&args,
+                        std::function<FuncType> &&func_impl) const;
+    const Func &
+    setImpl(const std::shared_ptr<internal::FuncInfo> &func_info) const;
 
-    /*!
-     * f_run()を実行し結果をf_ok()に渡すか、例外が発生した場合はf_fail()にエラーを渡す
-     *
-     */
-    template <typename F1, typename F2, typename F3>
-    static void tryRun(F1 &&f_run, F2 &&f_ok, F3 &&f_fail) {
-        ValAdaptor error;
-        try {
-            f_ok(f_run());
-            return;
-        } catch (const std::exception &e) {
-            error = e.what();
-        } catch (const std::string &e) {
-            error = e;
-        } catch (const char *e) {
-            error = e;
-        } catch (const std::wstring &e) {
-            error = e;
-        } catch (const wchar_t *e) {
-            error = e;
-        } catch (...) {
-            error = "unknown exception";
-        }
-        f_fail(error);
-    }
     /*!
      * f_run()を実行し結果をCallHandleに渡す
      *
@@ -234,7 +210,7 @@ class WEBCFACE_DLL Func : protected Field {
                   ReturnTypeSupportedByWebCFaceFunc = TraitOk,
               typename FuncObjTrait<
                   T>::ArgTypesTrait::ArgTypesSupportedByWebCFaceFunc = TraitOk>
-    Func &set(T func) {
+    const Func &set(T func) const {
         return setImpl(
             valTypeOf<typename FuncObjTrait<T>::ReturnType>(),
             FuncObjTrait<T>::argsInfo(),
@@ -274,7 +250,7 @@ class WEBCFACE_DLL Func : protected Field {
                   ReturnTypeSupportedByWebCFaceFunc = TraitOk,
               typename FuncObjTrait<
                   T>::ArgTypesTrait::ArgTypesSupportedByWebCFaceFunc = TraitOk>
-    Func &setAsync(T func) {
+    const Func &setAsync(T func) const {
         return setImpl(
             valTypeOf<typename FuncObjTrait<T>::ReturnType>(),
             FuncObjTrait<T>::argsInfo(),
@@ -315,7 +291,8 @@ class WEBCFACE_DLL Func : protected Field {
      *
      */
     template <typename T>
-    [[deprecated("use set() or setAsync()")]] Func &operator=(T func) {
+    [[deprecated("use set() or setAsync()")]] const Func &
+    operator=(T func) const {
         this->set(std::move(func));
         return *this;
     }
@@ -342,7 +319,8 @@ class WEBCFACE_DLL Func : protected Field {
               typename std::enable_if_t<
                   std::is_same_v<std::invoke_result_t<T, CallHandle>, void>,
                   std::nullptr_t> = nullptr>
-    Func &set(std::vector<Arg> args, ValType return_type, T callback) {
+    const Func &set(std::vector<Arg> args, ValType return_type,
+                    T callback) const {
         auto args_size = args.size();
         return setImpl(return_type, std::move(args),
                        [args_size, callback = std::move(callback)](
@@ -372,7 +350,8 @@ class WEBCFACE_DLL Func : protected Field {
               typename std::enable_if_t<
                   std::is_same_v<std::invoke_result_t<T, CallHandle>, void>,
                   std::nullptr_t> = nullptr>
-    Func &setAsync(std::vector<Arg> args, ValType return_type, T callback) {
+    const Func &setAsync(std::vector<Arg> args, ValType return_type,
+                         T callback) const {
         auto args_size = args.size();
         return setImpl(
             return_type, std::move(args),
@@ -396,7 +375,7 @@ class WEBCFACE_DLL Func : protected Field {
      *
      */
     [[deprecated("Func::hidden() does nothing since ver1.10")]]
-    Func &hidden(bool) {
+    const Func &hidden(bool) const {
         return *this;
     }
 
@@ -404,7 +383,7 @@ class WEBCFACE_DLL Func : protected Field {
      * \brief 関数の設定を削除
      *
      */
-    Func &free();
+    const Func &free() const;
 
     /*!
      * \brief 関数を実行する (同期)
@@ -494,7 +473,7 @@ class WEBCFACE_DLL Func : protected Field {
      * (一致していない場合 std::invalid_argument )
      *
      */
-    Func &setArgs(const std::vector<Arg> &args);
+    const Func &setArgs(const std::vector<Arg> &args) const;
 
     /*!
      * \brief Funcの参照先を比較

--- a/client/include/webcface/image.h
+++ b/client/include/webcface/image.h
@@ -18,10 +18,10 @@ WEBCFACE_NS_BEGIN
  * コンストラクタではなく Member::image() を使って取得してください
  */
 class WEBCFACE_DLL Image : protected Field {
-    Image &request(std::optional<int> rows, std::optional<int> cols,
-                   ImageCompressMode cmp_mode, int quality,
-                   std::optional<ImageColorMode> color_mode,
-                   std::optional<double> frame_rate);
+    const Image &request(std::optional<int> rows, std::optional<int> cols,
+                         ImageCompressMode cmp_mode, int quality,
+                         std::optional<ImageColorMode> color_mode,
+                         std::optional<double> frame_rate) const;
 
   public:
     Image() = default;
@@ -87,7 +87,8 @@ class WEBCFACE_DLL Image : protected Field {
      * \param callback Image型の引数(thisが渡される)を1つ取る関数
      *
      */
-    Image &onChange(std::function<void WEBCFACE_CALL_FP(Image)> callback);
+    const Image &
+    onChange(std::function<void WEBCFACE_CALL_FP(Image)> callback) const;
     /*!
      * \brief 値が変化したときに呼び出されるコールバックを設定
      * \since ver2.0
@@ -96,7 +97,7 @@ class WEBCFACE_DLL Image : protected Field {
      */
     template <typename F, typename std::enable_if_t<std::is_invocable_v<F>,
                                                     std::nullptr_t> = nullptr>
-    Image &onChange(F callback) {
+    const Image &onChange(F callback) const {
         return onChange(
             [callback = std::move(callback)](const auto &) { callback(); });
     }
@@ -108,7 +109,7 @@ class WEBCFACE_DLL Image : protected Field {
      *
      */
     template <typename T>
-    [[deprecated]] void appendListener(T &&callback) {
+    [[deprecated]] void appendListener(T &&callback) const {
         onChange(std::forward<T>(callback));
     }
 
@@ -116,12 +117,12 @@ class WEBCFACE_DLL Image : protected Field {
      * \brief 画像をセットする
      *
      */
-    Image &set(const ImageFrame &img);
+    const Image &set(const ImageFrame &img) const;
     /*!
      * \brief 画像をセットする
      *
      */
-    Image &operator=(const ImageFrame &img) {
+    const Image &operator=(const ImageFrame &img) const {
         this->set(img);
         return *this;
     }
@@ -139,10 +140,11 @@ class WEBCFACE_DLL Image : protected Field {
      * を使ってサイズ指定
      *
      */
-    [[deprecated("Ambiguous image size")]] Image &
+    [[deprecated("Ambiguous image size")]]
+    const Image &
     request(std::optional<int> rows, std::optional<int> cols = std::nullopt,
             std::optional<ImageColorMode> color_mode = std::nullopt,
-            std::optional<double> frame_rate = std::nullopt) {
+            std::optional<double> frame_rate = std::nullopt) const {
         return request(rows, cols, ImageCompressMode::raw, 0, color_mode,
                        frame_rate);
     }
@@ -157,9 +159,10 @@ class WEBCFACE_DLL Image : protected Field {
      * (指定しない場合元画像が更新されるたびに受信する)
      *
      */
-    Image &request(std::optional<SizeOption> size = std::nullopt,
-                   std::optional<ImageColorMode> color_mode = std::nullopt,
-                   std::optional<double> frame_rate = std::nullopt) {
+    const Image &
+    request(std::optional<SizeOption> size = std::nullopt,
+            std::optional<ImageColorMode> color_mode = std::nullopt,
+            std::optional<double> frame_rate = std::nullopt) const {
         return request(size.value_or(SizeOption{}).rows(),
                        size.value_or(SizeOption{}).cols(),
                        ImageCompressMode::raw, 0, color_mode, frame_rate);
@@ -180,10 +183,11 @@ class WEBCFACE_DLL Image : protected Field {
      * を使ってサイズ指定
      *
      */
-    [[deprecated("Ambiguous image size")]] Image &
+    [[deprecated("Ambiguous image size")]]
+    const Image &
     request(std::optional<int> rows, std::optional<int> cols,
             ImageCompressMode cmp_mode, int quality,
-            std::optional<double> frame_rate = std::nullopt) {
+            std::optional<double> frame_rate = std::nullopt) const {
         return request(rows, cols, cmp_mode, quality, std::nullopt, frame_rate);
     }
     /*!
@@ -200,9 +204,10 @@ class WEBCFACE_DLL Image : protected Field {
      * (指定しない場合元画像が更新されるたびに受信する)
      *
      */
-    Image &request(std::optional<SizeOption> size, ImageCompressMode cmp_mode,
-                   int quality,
-                   std::optional<double> frame_rate = std::nullopt) {
+    const Image &
+    request(std::optional<SizeOption> size, ImageCompressMode cmp_mode,
+            int quality,
+            std::optional<double> frame_rate = std::nullopt) const {
         return request(size.value_or(SizeOption{}).rows(),
                        size.value_or(SizeOption{}).cols(), cmp_mode, quality,
                        std::nullopt, frame_rate);
@@ -213,16 +218,16 @@ class WEBCFACE_DLL Image : protected Field {
      * リクエストしていない場合すべてデフォルトで(元画像のフォーマットで)リクエストする
      *
      */
-    std::optional<ImageFrame> tryGet();
+    std::optional<ImageFrame> tryGet() const;
     /*!
      * \brief 画像を返す (データがない場合0x0の画像が返る)
      *
      * リクエストしていない場合すべてデフォルトで(元画像のフォーマットで)リクエストする
      *
      */
-    ImageFrame get() { return tryGet().value_or(ImageFrame{}); }
+    ImageFrame get() const { return tryGet().value_or(ImageFrame{}); }
 
-    operator ImageFrame() { return get(); }
+    // operator ImageFrame() const { return get(); }
 
     /*!
      * \brief syncの時刻を返す
@@ -232,10 +237,10 @@ class WEBCFACE_DLL Image : protected Field {
     [[deprecated]] std::chrono::system_clock::time_point time() const;
 
     //! 値やリクエスト状態をクリア
-    Image &free();
+    const Image &free() const;
 
     //! 画像をクリア (リクエスト状態は解除しない)
-    Image &clear();
+    const Image &clear() const;
 
     /*!
      * \brief Imageの参照先を比較

--- a/client/include/webcface/log.h
+++ b/client/include/webcface/log.h
@@ -73,7 +73,8 @@ class WEBCFACE_DLL Log : protected Field {
      * \param callback Log型の引数(thisが渡される)を1つ取る関数
      *
      */
-    Log &onChange(std::function<void WEBCFACE_CALL_FP(Log)> callback);
+    const Log &
+    onChange(std::function<void WEBCFACE_CALL_FP(Log)> callback) const;
     /*!
      * \brief 値が変化したときに呼び出されるコールバックを設定
      * \since ver2.0
@@ -82,7 +83,7 @@ class WEBCFACE_DLL Log : protected Field {
      */
     template <typename F, typename std::enable_if_t<std::is_invocable_v<F>,
                                                     std::nullptr_t> = nullptr>
-    Log &onChange(F callback) {
+    const Log &onChange(F callback) const {
         return onChange(
             [callback = std::move(callback)](const auto &) { callback(); });
     }
@@ -94,7 +95,7 @@ class WEBCFACE_DLL Log : protected Field {
      *
      */
     template <typename T>
-    [[deprecated]] void appendListener(T &&callback) {
+    [[deprecated]] void appendListener(T &&callback) const {
         onChange(std::forward<T>(callback));
     }
 
@@ -103,7 +104,7 @@ class WEBCFACE_DLL Log : protected Field {
      * \since ver1.7
      *
      */
-    void request() const;
+    const Log &request() const;
     /*!
      * \brief ログを取得する
      *
@@ -135,10 +136,10 @@ class WEBCFACE_DLL Log : protected Field {
      *
      * リクエスト状態は解除しない
      */
-    Log &clear();
+    const Log &clear() const;
 
   private:
-    Log &append(LogLineData &&ll);
+    const Log &append(LogLineData &&ll) const;
 
   public:
     /*!
@@ -148,7 +149,7 @@ class WEBCFACE_DLL Log : protected Field {
      * sync()時にサーバーに送られる。コンソールへの出力などはされない
      *
      */
-    Log &append(int level, std::string_view message) {
+    const Log &append(int level, std::string_view message) const {
         return append({level, std::chrono::system_clock::now(),
                        SharedString::encode(message)});
     }
@@ -159,8 +160,8 @@ class WEBCFACE_DLL Log : protected Field {
      * sync()時にサーバーに送られる。コンソールへの出力などはされない
      *
      */
-    Log &append(int level, std::chrono::system_clock::time_point time,
-                std::string_view message) {
+    const Log &append(int level, std::chrono::system_clock::time_point time,
+                      std::string_view message) const {
         return append({level, time, SharedString::encode(message)});
     }
     /*!
@@ -170,7 +171,7 @@ class WEBCFACE_DLL Log : protected Field {
      * sync()時にサーバーに送られる。コンソールへの出力などはされない
      *
      */
-    Log &append(int level, std::wstring_view message) {
+    const Log &append(int level, std::wstring_view message) const {
         return append({level, std::chrono::system_clock::now(),
                        SharedString::encode(message)});
     }
@@ -181,8 +182,8 @@ class WEBCFACE_DLL Log : protected Field {
      * sync()時にサーバーに送られる。コンソールへの出力などはされない
      *
      */
-    Log &append(int level, std::chrono::system_clock::time_point time,
-                std::wstring_view message) {
+    const Log &append(int level, std::chrono::system_clock::time_point time,
+                      std::wstring_view message) const {
         return append({level, time, SharedString::encode(message)});
     }
 

--- a/client/include/webcface/member.h
+++ b/client/include/webcface/member.h
@@ -110,68 +110,89 @@ class WEBCFACE_DLL Member : protected Field {
 
     /*!
      * \brief valueが追加された時のイベント
-     *
-     * コールバックの型は void(Value)
+     * \since ver2.0
+     * \param callback Value型の引数をとる関数
      *
      */
-    Member &onValueEntry(std::function<void WEBCFACE_CALL_FP(Value)> callback);
+    const Member &
+    onValueEntry(std::function<void WEBCFACE_CALL_FP(Value)> callback) const;
     /*!
      * \brief textが追加された時のイベント
-     *
-     * コールバックの型は void(Text)
+     *\since ver2.0
+     * \param callback Text型の引数をとる関数
      *
      */
-    Member &onTextEntry(std::function<void WEBCFACE_CALL_FP(Text)> callback);
+    const Member &
+    onTextEntry(std::function<void WEBCFACE_CALL_FP(Text)> callback) const;
     /*!
      * \brief robotModelが追加された時のイベント
-     *
-     * コールバックの型は void(RobotModel)
+     *\since ver2.0
+     * \param callback RobotModel型の引数をとる関数
      *
      */
-    Member &onRobotModelEntry(
-        std::function<void WEBCFACE_CALL_FP(RobotModel)> callback);
+    const Member &onRobotModelEntry(
+        std::function<void WEBCFACE_CALL_FP(RobotModel)> callback) const;
     /*!
      * \brief funcが追加された時のイベント
-     *
-     * コールバックの型は void(Func)
+     *\since ver2.0
+     * \param callback Func型の引数をとる関数
      *
      */
-    Member &onFuncEntry(std::function<void WEBCFACE_CALL_FP(Func)> callback);
+    const Member &
+    onFuncEntry(std::function<void WEBCFACE_CALL_FP(Func)> callback) const;
     /*!
      * \brief imageが追加されたときのイベント
-     *
-     * コールバックの型は void(Image)
+     *\since ver2.0
+     * \param callback Image型の引数をとる関数
      *
      */
-    Member &onImageEntry(std::function<void WEBCFACE_CALL_FP(Image)> callback);
+    const Member &
+    onImageEntry(std::function<void WEBCFACE_CALL_FP(Image)> callback) const;
     /*!
      * \brief viewが追加されたときのイベント
-     *
-     * コールバックの型は void(View)
+     *\since ver2.0
+     * \param callback View型の引数をとる関数
      *
      */
-    Member &onViewEntry(std::function<void WEBCFACE_CALL_FP(View)> callback);
+    const Member &
+    onViewEntry(std::function<void WEBCFACE_CALL_FP(View)> callback) const;
     /*!
      * \brief canvas3dが追加されたときのイベント
-     *
-     * コールバックの型は void(Canvas3D)
+     *\since ver2.0
+     * \param callback Canvas3D型の引数をとる関数
      *
      */
-    Member &
-    onCanvas3DEntry(std::function<void WEBCFACE_CALL_FP(Canvas3D)> callback);
+    const Member &onCanvas3DEntry(
+        std::function<void WEBCFACE_CALL_FP(Canvas3D)> callback) const;
     /*!
      * \brief canvas2dが追加されたときのイベント
-     *
-     * コールバックの型は void(Canvas2D)
+     *\since ver2.0
+     * \param callback Canvas2D型の引数をとる関数
      *
      */
-    Member &
-    onCanvas2DEntry(std::function<void WEBCFACE_CALL_FP(Canvas2D)> callback);
+    const Member &onCanvas2DEntry(
+        std::function<void WEBCFACE_CALL_FP(Canvas2D)> callback) const;
+
     /*!
      * \brief Memberがsync()したときのイベント
-     * コールバックの型は void(Member)
+     * \since ver2.0
+     * \param callback Member型の引数をとる関数
+     *
      */
-    Member &onSync(std::function<void WEBCFACE_CALL_FP(Member)> callback);
+    const Member &
+    onSync(std::function<void WEBCFACE_CALL_FP(Member)> callback) const;
+    /*!
+     * \brief Memberがsync()したときのイベント
+     * \since ver2.0
+     * \param callback 引数をとらない関数
+     *
+     */
+    template <typename F, typename std::enable_if_t<std::is_invocable_v<F>,
+                                                    std::nullptr_t> = nullptr>
+    const Member &onSync(F callback) const {
+        return onSync(
+            [callback = std::move(callback)](const auto &) { callback(); });
+    }
 
     /*!
      * \brief 最後のsync()の時刻を返す
@@ -212,15 +233,29 @@ class WEBCFACE_DLL Member : protected Field {
     std::optional<int> pingStatus() const;
     /*!
      * \brief 通信速度が更新された時のイベント
+     * \since ver2.0
      *
-     * * コールバックの型は void(Member)
      * * 通常は約5秒に1回更新される。
      * * pingStatus() と同様、通信速度データのリクエストも行う。
      * * ver2.0〜 Client自身に対しても使用可能
      *
+     * \param callback Member型の引数を取る関数
      * \sa pingStatus()
      */
-    Member &onPing(std::function<void WEBCFACE_CALL_FP(Member)> callback);
+    const Member &
+    onPing(std::function<void WEBCFACE_CALL_FP(Member)> callback) const;
+    /*!
+     * \brief 通信速度が更新された時のイベント
+     * \since ver2.0
+     * \param callback 引数をとらない関数
+     *
+     */
+    template <typename F, typename std::enable_if_t<std::is_invocable_v<F>,
+                                                    std::nullptr_t> = nullptr>
+    const Member &onPing(F callback) const {
+        return onPing(
+            [callback = std::move(callback)](const auto &) { callback(); });
+    }
 
     /*!
      * \brief Memberを比較

--- a/client/include/webcface/robot_model.h
+++ b/client/include/webcface/robot_model.h
@@ -96,8 +96,8 @@ class WEBCFACE_DLL RobotModel : protected Field {
      * \param callback RobotModel型の引数(thisが渡される)を1つ取る関数
      *
      */
-    RobotModel &
-    onChange(std::function<void WEBCFACE_CALL_FP(RobotModel)> callback);
+    const RobotModel &
+    onChange(std::function<void WEBCFACE_CALL_FP(RobotModel)> callback) const;
     /*!
      * \brief 値が変化したときに呼び出されるコールバックを設定
      * \since ver2.0
@@ -106,7 +106,7 @@ class WEBCFACE_DLL RobotModel : protected Field {
      */
     template <typename F, typename std::enable_if_t<std::is_invocable_v<F>,
                                                     std::nullptr_t> = nullptr>
-    RobotModel &onChange(F callback) {
+    const RobotModel &onChange(F callback) const {
         return onChange(
             [callback = std::move(callback)](const auto &) { callback(); });
     }
@@ -118,7 +118,7 @@ class WEBCFACE_DLL RobotModel : protected Field {
      *
      */
     template <typename T>
-    [[deprecated]] void appendListener(T &&callback) {
+    [[deprecated]] void appendListener(T &&callback) const {
         onChange(std::forward<T>(callback));
     }
 
@@ -126,18 +126,18 @@ class WEBCFACE_DLL RobotModel : protected Field {
      * \brief モデルを初期化
      * \since ver1.9
      */
-    RobotModel &init();
+    const RobotModel &init() const;
     /*!
      * \brief モデルにlinkを追加
      * \since ver1.9
      */
-    RobotModel &operator<<(RobotLink rl);
+    const RobotModel &operator<<(RobotLink rl) const;
     /*!
      * \brief モデルにlinkを追加
      * \since ver1.9
      */
     template <typename T>
-    RobotModel &add(T &&rl) {
+    const RobotModel &add(T &&rl) const {
         *this << std::forward<T>(rl);
         return *this;
     }
@@ -145,18 +145,18 @@ class WEBCFACE_DLL RobotModel : protected Field {
      * \brief addで追加したモデルをセットする
      * \since ver1.9
      */
-    RobotModel &sync();
+    const RobotModel &sync() const;
 
     /*!
      * \brief モデルをセットする
      *
      */
-    RobotModel &set(const std::vector<RobotLink> &v);
+    const RobotModel &set(const std::vector<RobotLink> &v) const;
     /*!
      * \brief モデルをセットする
      *
      */
-    RobotModel &operator=(const std::vector<RobotLink> &v) {
+    const RobotModel &operator=(const std::vector<RobotLink> &v) const {
         this->set(v);
         return *this;
     }
@@ -165,7 +165,7 @@ class WEBCFACE_DLL RobotModel : protected Field {
      * \since ver1.7
      *
      */
-    void request() const;
+    const RobotModel &request() const;
     /*!
      * \brief モデルを返す
      *
@@ -189,7 +189,7 @@ class WEBCFACE_DLL RobotModel : protected Field {
      * \brief 値やリクエスト状態をクリア
      *
      */
-    RobotModel &free();
+    const RobotModel &free() const;
 
     /*!
      * \brief これをCanvas3DComponentに変換

--- a/client/include/webcface/text.h
+++ b/client/include/webcface/text.h
@@ -86,18 +86,19 @@ class WEBCFACE_DLL Text : protected Field {
      * \brief 値が変化したときに呼び出されるコールバックを設定
      * \since ver2.0
      * \param callback Text型の引数(thisが渡される)を1つ取る関数
-     * 
+     *
      */
-    Text &onChange(std::function<void WEBCFACE_CALL_FP(Text)> callback);
+    const Text &
+    onChange(std::function<void WEBCFACE_CALL_FP(Text)> callback) const;
     /*!
      * \brief 値が変化したときに呼び出されるコールバックを設定
      * \since ver2.0
      * \param callback 引数をとらない関数
-     * 
+     *
      */
     template <typename F, typename std::enable_if_t<std::is_invocable_v<F>,
                                                     std::nullptr_t> = nullptr>
-    Text &onChange(F callback) {
+    const Text &onChange(F callback) const {
         return onChange(
             [callback = std::move(callback)](const auto &) { callback(); });
     }
@@ -109,7 +110,7 @@ class WEBCFACE_DLL Text : protected Field {
      *
      */
     template <typename T>
-    [[deprecated]] void appendListener(T &&callback) {
+    [[deprecated]] void appendListener(T &&callback) const {
         onChange(std::forward<T>(callback));
     }
 
@@ -119,23 +120,23 @@ class WEBCFACE_DLL Text : protected Field {
      * (ver2.0からstd::stringをstd::string_viewに変更)
      *
      */
-    Text &set(std::string_view v) { return set(ValAdaptor{v}); }
+    const Text &set(std::string_view v) const { return set(ValAdaptor{v}); }
     /*!
      * \brief 文字列をセットする (wstring)
      * \since ver2.0
      */
-    Text &set(std::wstring_view v) { return set(ValAdaptor{v}); }
+    const Text &set(std::wstring_view v) const { return set(ValAdaptor{v}); }
     /*!
      * \brief 文字列以外の型の値もセットする
      * \since ver1.10
      */
-    Text &set(const ValAdaptor &v);
+    const Text &set(const ValAdaptor &v) const;
 
     /*!
      * \brief 文字列をセットする
      *
      */
-    Text &operator=(std::string_view v) {
+    const Text &operator=(std::string_view v) const {
         this->set(v);
         return *this;
     }
@@ -143,7 +144,7 @@ class WEBCFACE_DLL Text : protected Field {
      * \brief 文字列をセットする (wstring)
      * \since ver2.0
      */
-    Text &operator=(std::wstring_view v) {
+    const Text &operator=(std::wstring_view v) const {
         this->set(v);
         return *this;
     }
@@ -153,7 +154,7 @@ class WEBCFACE_DLL Text : protected Field {
      * \since ver1.7
      *
      */
-    void request() const;
+    const Text &request() const;
     /*!
      * \brief 文字列を返す
      *
@@ -201,7 +202,7 @@ class WEBCFACE_DLL Text : protected Field {
      * \brief 値やリクエスト状態をクリア
      *
      */
-    Text &free();
+    const Text &free() const;
 
     bool operator==(std::string_view rhs) const { return this->get() == rhs; }
     bool operator!=(std::string_view rhs) const { return this->get() != rhs; }
@@ -365,8 +366,8 @@ class InputRef {
      *
      */
     template <typename T>
-    [[deprecated("use asDouble(), asInt() or asLLong() instead")]] double
-    as() const {
+    [[deprecated("use asDouble(), asInt() or asLLong() instead")]]
+    double as() const {
         return get().as<T>();
     }
 

--- a/client/include/webcface/value.h
+++ b/client/include/webcface/value.h
@@ -84,7 +84,8 @@ class WEBCFACE_DLL Value : protected Field {
      * \param callback Value型の引数(thisが渡される)を1つ取る関数
      *
      */
-    Value &onChange(std::function<void WEBCFACE_CALL_FP(Value)> callback);
+    const Value &
+    onChange(std::function<void WEBCFACE_CALL_FP(Value)> callback) const;
     /*!
      * \brief 値が変化したときに呼び出されるコールバックを設定
      * \since ver2.0
@@ -93,7 +94,7 @@ class WEBCFACE_DLL Value : protected Field {
      */
     template <typename F, typename std::enable_if_t<std::is_invocable_v<F>,
                                                     std::nullptr_t> = nullptr>
-    Value &onChange(F callback) {
+    const Value &onChange(F callback) const {
         return onChange(
             [callback = std::move(callback)](const auto &) { callback(); });
     }
@@ -105,7 +106,7 @@ class WEBCFACE_DLL Value : protected Field {
      *
      */
     template <typename T>
-    [[deprecated]] void appendListener(T &&callback) {
+    [[deprecated]] void appendListener(T &&callback) const {
         onChange(std::forward<T>(callback));
     }
 
@@ -116,13 +117,13 @@ class WEBCFACE_DLL Value : protected Field {
      * vが配列でなく、parent()の配列データが利用可能ならその要素をセットする
      *
      */
-    Value &set(double v);
+    const Value &set(double v) const;
     /*!
      * \brief vector型配列をセットする
      * \since ver2.0 (set(VectorOpt<double>) を置き換え)
      *
      */
-    Value &set(std::vector<double> v);
+    const Value &set(std::vector<double> v) const;
     /*!
      * \brief 配列型の値をセットする
      * \since ver1.7 (VectorOpt(std::vector<T>) を置き換え)
@@ -134,7 +135,7 @@ class WEBCFACE_DLL Value : protected Field {
               typename std::enable_if_t<
                   std::is_convertible_v<typename R::value_type, double>,
                   std::nullptr_t> = nullptr>
-    Value &set(const R &range) {
+    const Value &set(const R &range) const {
         std::vector<double> vec;
         vec.reserve(std::size(range));
         for (const auto &v : range) {
@@ -150,7 +151,7 @@ class WEBCFACE_DLL Value : protected Field {
     template <typename V, std::size_t N,
               typename std::enable_if_t<std::is_convertible_v<V, double>,
                                         std::nullptr_t> = nullptr>
-    Value &set(const V (&range)[N]) {
+    const Value &set(const V (&range)[N]) const {
         std::vector<double> vec;
         vec.reserve(N);
         for (const auto &v : range) {
@@ -162,18 +163,18 @@ class WEBCFACE_DLL Value : protected Field {
      * \brief 配列をセット、またはすでにsetされていればリサイズする
      * \since ver1.11
      */
-    Value &resize(std::size_t size);
+    const Value &resize(std::size_t size) const;
     /*!
      * \brief 値をセット、またはすでに配列がsetされていれば末尾に追加
      */
-    Value &push_back(double v);
+    const Value &push_back(double v) const;
 
     /*!
      * \brief 数値または配列をセットする
      *
      */
     template <typename T>
-    Value &operator=(T &&v) {
+    const Value &operator=(T &&v) const {
         this->set(std::forward<T>(v));
         return *this;
     }
@@ -182,7 +183,7 @@ class WEBCFACE_DLL Value : protected Field {
      * \since ver1.7
      *
      */
-    void request() const;
+    const Value &request() const;
     /*!
      * \brief 値を返す
      *
@@ -219,46 +220,46 @@ class WEBCFACE_DLL Value : protected Field {
      * \brief 値やリクエスト状態をクリア
      *
      */
-    Value &free();
+    const Value &free() const;
 
-    Value &operator+=(double rhs) {
+    const Value &operator+=(double rhs) const {
         this->set(this->get() + rhs);
         return *this;
     }
-    Value &operator-=(double rhs) {
+    const Value &operator-=(double rhs) const {
         this->set(this->get() - rhs);
         return *this;
     }
-    Value &operator*=(double rhs) {
+    const Value &operator*=(double rhs) const {
         this->set(this->get() * rhs);
         return *this;
     }
-    Value &operator/=(double rhs) {
+    const Value &operator/=(double rhs) const {
         this->set(this->get() / rhs);
         return *this;
     }
-    Value &operator%=(std::int32_t rhs) {
+    const Value &operator%=(std::int32_t rhs) const {
         this->set(static_cast<std::int32_t>(this->get()) % rhs);
         return *this;
     }
-    Value &operator<<=(std::int32_t rhs) {
+    const Value &operator<<=(std::int32_t rhs) const {
         // todo: int64_tかuint64_tにしたほうがいいかもしれない
         this->set(static_cast<std::int32_t>(this->get()) << rhs);
         return *this;
     }
-    Value &operator>>=(std::int32_t rhs) {
+    const Value &operator>>=(std::int32_t rhs) const {
         this->set(static_cast<std::int32_t>(this->get()) >> rhs);
         return *this;
     }
-    Value &operator&=(std::int32_t rhs) {
+    const Value &operator&=(std::int32_t rhs) const {
         this->set(static_cast<std::int32_t>(this->get()) & rhs);
         return *this;
     }
-    Value &operator|=(std::int32_t rhs) {
+    const Value &operator|=(std::int32_t rhs) const {
         this->set(static_cast<std::int32_t>(this->get()) | rhs);
         return *this;
     }
-    Value &operator^=(std::int32_t rhs) {
+    const Value &operator^=(std::int32_t rhs) const {
         this->set(static_cast<std::int32_t>(this->get()) ^ rhs);
         return *this;
     }
@@ -266,7 +267,7 @@ class WEBCFACE_DLL Value : protected Field {
      * \brief 1足したものをsetした後自身を返す
      *
      */
-    Value &operator++() { // ++s
+    const Value &operator++() const { // ++s
         this->set(this->get() + 1);
         return *this;
     }
@@ -274,7 +275,7 @@ class WEBCFACE_DLL Value : protected Field {
      * \brief 1足したものをsetし、足す前の値を返す
      *
      */
-    double operator++(int) { // s++
+    double operator++(int) const { // s++
         auto v = this->get();
         this->set(v + 1);
         return v;
@@ -283,7 +284,7 @@ class WEBCFACE_DLL Value : protected Field {
      * \brief 1引いたものをsetした後自身を返す
      *
      */
-    Value &operator--() { // --s
+    const Value &operator--() const { // --const s
         this->set(this->get() - 1);
         return *this;
     }
@@ -291,7 +292,7 @@ class WEBCFACE_DLL Value : protected Field {
      * \brief 1引いたものをsetし、足す前の値を返す
      *
      */
-    double operator--(int) { // s--
+    double operator--(int) const { // s--
         auto v = this->get();
         this->set(v - 1);
         return v;

--- a/client/include/webcface/view.h
+++ b/client/include/webcface/view.h
@@ -25,7 +25,7 @@ class ViewBuf;
  */
 class WEBCFACE_DLL View : protected Field {
     std::shared_ptr<internal::ViewBuf> sb;
-    std::ostream os;
+    mutable std::ostream os;
 
     static constexpr std::nullptr_t TraitOk = nullptr;
     template <typename T>
@@ -33,7 +33,7 @@ class WEBCFACE_DLL View : protected Field {
         decltype(std::declval<std::ostream>() << std::declval<T>(), TraitOk);
     template <typename T>
     using EnableIfInvocable =
-        decltype(std::declval<T>()(std::declval<View &>()), TraitOk);
+        decltype(std::declval<T>()(std::declval<View>()), TraitOk);
 
   public:
     View();
@@ -106,7 +106,8 @@ class WEBCFACE_DLL View : protected Field {
      * \param callback View型の引数(thisが渡される)を1つ取る関数
      *
      */
-    View &onChange(std::function<void WEBCFACE_CALL_FP(View)> callback);
+    const View &
+    onChange(std::function<void WEBCFACE_CALL_FP(View)> callback) const;
     /*!
      * \brief 値が変化したときに呼び出されるコールバックを設定
      * \since ver2.0
@@ -115,7 +116,7 @@ class WEBCFACE_DLL View : protected Field {
      */
     template <typename F, typename std::enable_if_t<std::is_invocable_v<F>,
                                                     std::nullptr_t> = nullptr>
-    View &onChange(F callback) {
+    const View &onChange(F callback) const {
         return onChange(
             [callback = std::move(callback)](const auto &) { callback(); });
     }
@@ -127,7 +128,7 @@ class WEBCFACE_DLL View : protected Field {
      *
      */
     template <typename T>
-    [[deprecated]] void appendListener(T &&callback) {
+    [[deprecated]] void appendListener(T &&callback) const {
         onChange(std::forward<T>(callback));
     }
 
@@ -136,7 +137,7 @@ class WEBCFACE_DLL View : protected Field {
      * \since ver1.7
      *
      */
-    void request() const;
+    const View &request() const;
     /*!
      * \brief Viewを取得する
      *
@@ -160,7 +161,7 @@ class WEBCFACE_DLL View : protected Field {
      * \brief 値やリクエスト状態をクリア
      *
      */
-    View &free();
+    const View &free() const;
 
     /*!
      * \brief このViewのViewBufの内容を初期化する
@@ -171,7 +172,7 @@ class WEBCFACE_DLL View : protected Field {
      * (init() 後に sync() をするとViewの内容が空になる)
      *
      */
-    View &init();
+    const View &init() const;
     /*!
      * \brief 文字列にフォーマットし、textコンポーネントとして追加
      *
@@ -182,11 +183,11 @@ class WEBCFACE_DLL View : protected Field {
      *
      */
     template <typename T, EnableIfFormattable<T> = TraitOk>
-    View &operator<<(T &&rhs) {
+    const View &operator<<(T &&rhs) const {
         os << std::forward<T>(rhs);
         return *this;
     }
-    View &operator<<(std::ostream &(*os_manip)(std::ostream &)) {
+    const View &operator<<(std::ostream &(*os_manip)(std::ostream &)) const {
         os_manip(os);
         return *this;
     }
@@ -197,7 +198,7 @@ class WEBCFACE_DLL View : protected Field {
      *
      */
     template <bool C2, bool C3>
-    View &operator<<(TemporalComponent<true, C2, C3> vc) {
+    const View &operator<<(TemporalComponent<true, C2, C3> vc) const {
         *this << std::move(vc.component_v);
         return *this;
     }
@@ -207,7 +208,7 @@ class WEBCFACE_DLL View : protected Field {
      * std::flushも呼び出すことで直前に追加した未flashの文字列なども確実に追加する
      *
      */
-    View &operator<<(TemporalViewComponent vc);
+    const View &operator<<(TemporalViewComponent vc) const;
     /*!
      * \brief コンポーネントを追加
      * \since ver1.11
@@ -216,7 +217,7 @@ class WEBCFACE_DLL View : protected Field {
      *
      */
     template <typename F, EnableIfInvocable<F> = TraitOk>
-    View &operator<<(const F &manip) {
+    const View &operator<<(const F &manip) const {
         manip(*this);
         return *this;
     }
@@ -230,7 +231,7 @@ class WEBCFACE_DLL View : protected Field {
      *
      */
     template <typename T>
-    View &add(T &&rhs) {
+    const View &add(T &&rhs) const {
         *this << std::forward<T>(rhs);
         return *this;
     }
@@ -242,7 +243,7 @@ class WEBCFACE_DLL View : protected Field {
      * (init()も追加もされていなければ) 何もしない。
      *
      */
-    View &sync();
+    const View &sync() const;
 
     /*!
      * \brief Viewの参照先を比較

--- a/client/src/canvas2d.cc
+++ b/client/src/canvas2d.cc
@@ -10,15 +10,15 @@ Canvas2D::Canvas2D()
     : Field(), sb(std::make_shared<internal::Canvas2DDataBuf>()) {}
 Canvas2D::Canvas2D(const Field &base)
     : Field(base), sb(std::make_shared<internal::Canvas2DDataBuf>(base)) {}
-Canvas2D &Canvas2D::init(double width, double height) {
+const Canvas2D &Canvas2D::init(double width, double height) const {
     sb->init(width, height);
     return *this;
 }
-Canvas2D &Canvas2D::sync() {
+const Canvas2D &Canvas2D::sync() const {
     sb->sync();
     return *this;
 }
-Canvas2D &Canvas2D::operator<<(TemporalCanvas2DComponent cc) {
+const Canvas2D &Canvas2D::operator<<(TemporalCanvas2DComponent cc) const {
     sb->add(std::move(cc));
     return *this;
 }
@@ -50,7 +50,8 @@ void internal::DataSetBuffer<TemporalCanvas2DComponent>::onSync() {
         change_event->operator()(target_);
     }
 }
-Canvas2D &Canvas2D::onChange(std::function<void(Canvas2D)> callback) {
+const Canvas2D &
+Canvas2D::onChange(std::function<void(Canvas2D)> callback) const {
     this->request();
     auto data = dataLock();
     std::lock_guard lock(data->event_m);
@@ -59,13 +60,14 @@ Canvas2D &Canvas2D::onChange(std::function<void(Canvas2D)> callback) {
     return *this;
 }
 
-void Canvas2D::request() const {
+const Canvas2D &Canvas2D::request() const {
     auto data = dataLock();
     auto req = data->canvas2d_store.addReq(member_, field_);
     if (req) {
         data->messagePushOnline(message::packSingle(
             message::Req<message::Canvas2D>{{}, member_, field_, req}));
     }
+    return *this;
 }
 std::optional<std::vector<Canvas2DComponent>> Canvas2D::tryGet() const {
     request();
@@ -85,7 +87,7 @@ std::optional<std::vector<Canvas2DComponent>> Canvas2D::tryGet() const {
 std::chrono::system_clock::time_point Canvas2D::time() const {
     return member().syncTime();
 }
-Canvas2D &Canvas2D::free() {
+const Canvas2D &Canvas2D::free() const {
     auto req = dataLock()->canvas2d_store.unsetRecv(*this);
     if (req) {
         // todo: リクエスト解除

--- a/client/src/canvas3d.cc
+++ b/client/src/canvas3d.cc
@@ -15,15 +15,15 @@ Canvas3D::Canvas3D(const Field &base)
     : Field(base),
       sb(std::make_shared<internal::DataSetBuffer<TemporalCanvas3DComponent>>(
           base)) {}
-Canvas3D &Canvas3D::init() {
+const Canvas3D &Canvas3D::init() const {
     sb->init();
     return *this;
 }
-Canvas3D &Canvas3D::sync() {
+const Canvas3D &Canvas3D::sync() const {
     sb->sync();
     return *this;
 }
-Canvas3D &Canvas3D::operator<<(TemporalCanvas3DComponent cc) {
+const Canvas3D &Canvas3D::operator<<(TemporalCanvas3DComponent cc) const {
     sb->add(std::move(cc));
     return *this;
 }
@@ -50,7 +50,8 @@ void internal::DataSetBuffer<TemporalCanvas3DComponent>::onSync() {
         change_event->operator()(target_);
     }
 }
-Canvas3D &Canvas3D::onChange(std::function<void(Canvas3D)> callback) {
+const Canvas3D &
+Canvas3D::onChange(std::function<void(Canvas3D)> callback) const {
     this->request();
     auto data = dataLock();
     std::lock_guard lock(data->event_m);
@@ -59,13 +60,14 @@ Canvas3D &Canvas3D::onChange(std::function<void(Canvas3D)> callback) {
     return *this;
 }
 
-void Canvas3D::request() const {
+const Canvas3D &Canvas3D::request() const {
     auto data = dataLock();
     auto req = data->canvas3d_store.addReq(member_, field_);
     if (req) {
         data->messagePushOnline(message::packSingle(
             message::Req<message::Canvas3D>{{}, member_, field_, req}));
     }
+    return *this;
 }
 std::optional<std::vector<Canvas3DComponent>> Canvas3D::tryGet() const {
     auto vb = dataLock()->canvas3d_store.getRecv(*this);
@@ -84,7 +86,7 @@ std::optional<std::vector<Canvas3DComponent>> Canvas3D::tryGet() const {
 std::chrono::system_clock::time_point Canvas3D::time() const {
     return member().syncTime();
 }
-Canvas3D &Canvas3D::free() {
+const Canvas3D &Canvas3D::free() const {
     auto req = dataLock()->canvas3d_store.unsetRecv(*this);
     if (req) {
         // todo: リクエスト解除

--- a/client/src/client_msg_sync.cc
+++ b/client/src/client_msg_sync.cc
@@ -220,16 +220,23 @@ std::vector<Member> Client::members() {
     }
     return ret;
 }
-Client &Client::onMemberEntry(std::function<void(Member)> callback) {
+const Client &
+Client::onMemberEntry(std::function<void(Member)> callback) const {
     std::lock_guard lock(data->event_m);
     data->member_entry_event =
         std::make_shared<std::function<void(Member)>>(std::move(callback));
     return *this;
 }
-std::streambuf *Client::loggerStreamBuf() { return data->logger_buf.get(); }
-std::ostream &Client::loggerOStream() { return *data->logger_os.get(); }
-std::wstreambuf *Client::loggerWStreamBuf() { return data->logger_buf_w.get(); }
-std::wostream &Client::loggerWOStream() { return *data->logger_os_w.get(); }
+std::streambuf *Client::loggerStreamBuf() const {
+    return data->logger_buf.get();
+}
+std::ostream &Client::loggerOStream() const { return *data->logger_os.get(); }
+std::wstreambuf *Client::loggerWStreamBuf() const {
+    return data->logger_buf_w.get();
+}
+std::wostream &Client::loggerWOStream() const {
+    return *data->logger_os_w.get();
+}
 const std::string &Client::serverVersion() const { return data->svr_version; }
 const std::string &Client::serverName() const { return data->svr_name; }
 const std::string &Client::serverHostName() const { return data->svr_hostname; }

--- a/client/src/func.cc
+++ b/client/src/func.cc
@@ -13,17 +13,17 @@
 WEBCFACE_NS_BEGIN
 
 Func::Func(const Field &base) : Field(base) {}
-Func &Func::setImpl(ValType return_type, std::vector<Arg> &&args,
-                    std::function<FuncType> &&func_impl) {
+const Func &Func::setImpl(ValType return_type, std::vector<Arg> &&args,
+                          std::function<FuncType> &&func_impl) const {
     return setImpl(std::make_shared<internal::FuncInfo>(
         static_cast<Field>(*this), return_type, std::move(args),
         std::move(func_impl)));
 }
-Func &Func::setImpl(const std::shared_ptr<internal::FuncInfo> &v) {
+const Func &Func::setImpl(const std::shared_ptr<internal::FuncInfo> &v) const {
     setCheck()->func_store.setSend(*this, v);
     return *this;
 }
-Func &Func::free() {
+const Func &Func::free() const {
     dataLock()->func_store.unsetRecv(*this);
     return *this;
 }
@@ -73,9 +73,9 @@ AsyncFuncResult Func::runAsync(std::vector<ValAdaptor> args_vec) const {
     } else {
         // リモートの場合cli.sync()を待たずに呼び出しメッセージを送る
         auto state = data->func_result_store.addResult(*this);
-        if(!data->messagePushOnline(message::packSingle(message::Call{
-            state->callerId(), 0, data->getMemberIdFromName(member_), field_,
-            args_vec}))){
+        if (!data->messagePushOnline(message::packSingle(message::Call{
+                state->callerId(), 0, data->getMemberIdFromName(member_),
+                field_, args_vec}))) {
             state->setter().reach(false);
         }
         // resultはcli.onRecv内でセットされる。
@@ -98,7 +98,7 @@ std::vector<Arg> Func::args() const {
     return std::vector<Arg>{};
 }
 
-Func &Func::setArgs(const std::vector<Arg> &args) {
+const Func &Func::setArgs(const std::vector<Arg> &args) const {
     auto func_info = setCheck()->func_store.getRecv(*this);
     if (!func_info) {
         throw std::invalid_argument("setArgs failed: Func not set");

--- a/client/src/image.cc
+++ b/client/src/image.cc
@@ -8,10 +8,10 @@ WEBCFACE_NS_BEGIN
 
 Image::Image(const Field &base) : Field(base) {}
 
-Image &Image::request(std::optional<int> rows, std::optional<int> cols,
-                      ImageCompressMode cmp_mode, int quality,
-                      std::optional<ImageColorMode> color_mode,
-                      std::optional<double> frame_rate) {
+const Image &Image::request(std::optional<int> rows, std::optional<int> cols,
+                            ImageCompressMode cmp_mode, int quality,
+                            std::optional<ImageColorMode> color_mode,
+                            std::optional<double> frame_rate) const {
     message::ImageReq req{
         rows,
         cols,
@@ -38,7 +38,7 @@ inline void addImageReq(const std::shared_ptr<internal::ClientData> &data,
     }
 }
 
-Image &Image::set(const ImageFrame &img) {
+const Image &Image::set(const ImageFrame &img) const {
     auto data = setCheck();
     data->image_store.setSend(*this, img);
     std::shared_ptr<std::function<void(Image)>> change_event;
@@ -51,7 +51,7 @@ Image &Image::set(const ImageFrame &img) {
     }
     return *this;
 }
-Image &Image::onChange(std::function<void(Image)> callback) {
+const Image &Image::onChange(std::function<void(Image)> callback) const {
     this->request();
     auto data = dataLock();
     std::lock_guard lock(data->event_m);
@@ -60,7 +60,7 @@ Image &Image::onChange(std::function<void(Image)> callback) {
     return *this;
 }
 
-std::optional<ImageFrame> Image::tryGet() {
+std::optional<ImageFrame> Image::tryGet() const {
     addImageReq(dataLock(), member_, field_);
     return dataLock()->image_store.getRecv(*this);
 }
@@ -68,11 +68,11 @@ std::optional<ImageFrame> Image::tryGet() {
 std::chrono::system_clock::time_point Image::time() const {
     return member().syncTime();
 }
-Image &Image::clear() {
+const Image &Image::clear() const {
     dataLock()->image_store.clearRecv(*this);
     return *this;
 }
-Image &Image::free() {
+const Image &Image::free() const {
     auto req = dataLock()->image_store.unsetRecv(*this);
     if (req) {
         // todo: リクエスト解除

--- a/client/src/log.cc
+++ b/client/src/log.cc
@@ -81,7 +81,7 @@ template class WEBCFACE_DLL_INSTANCE_DEF BasicLoggerBuf<wchar_t>;
 
 Log::Log(const Field &base) : Field(base) {}
 
-Log &Log::onChange(std::function<void(Log)> callback) {
+const Log &Log::onChange(std::function<void(Log)> callback) const {
     this->request();
     std::lock_guard lock(this->dataLock()->event_m);
     this->dataLock()->log_append_event[this->member_] =
@@ -89,12 +89,14 @@ Log &Log::onChange(std::function<void(Log)> callback) {
     return *this;
 }
 
-void Log::request() const {
+const Log &Log::request() const {
     auto data = dataLock();
     auto req = data->log_store.addReq(member_);
     if (req) {
-        data->messagePushOnline(message::packSingle(message::LogReq{{}, member_}));
+        data->messagePushOnline(
+            message::packSingle(message::LogReq{{}, member_}));
     }
+    return *this;
 }
 
 std::optional<std::vector<LogLine>> Log::tryGet() const {
@@ -126,13 +128,13 @@ std::optional<std::vector<LogLineW>> Log::tryGetW() const {
     }
 }
 
-Log &Log::clear() {
+const Log &Log::clear() const {
     dataLock()->log_store.setRecv(member_,
                                   std::make_shared<std::vector<LogLineData>>());
     return *this;
 }
 
-Log &Log::append(LogLineData &&ll) {
+const Log &Log::append(LogLineData &&ll) const {
     writeLog(setCheck().get(), std::move(ll));
     return *this;
 }

--- a/client/src/member.cc
+++ b/client/src/member.cc
@@ -13,55 +13,58 @@ WEBCFACE_NS_BEGIN
 
 Log Member::log() const { return Log{*this}; }
 
-Member &Member::onValueEntry(std::function<void(Value)> callback) {
+const Member &Member::onValueEntry(std::function<void(Value)> callback) const {
     std::lock_guard lock(dataLock()->event_m);
     dataLock()->value_entry_event[member_] =
         std::make_shared<std::function<void(Value)>>(std::move(callback));
     return *this;
 }
-Member &Member::onTextEntry(std::function<void(Text)> callback) {
+const Member &Member::onTextEntry(std::function<void(Text)> callback) const {
     std::lock_guard lock(dataLock()->event_m);
     dataLock()->text_entry_event[member_] =
         std::make_shared<std::function<void(Text)>>(std::move(callback));
     return *this;
 }
-Member &Member::onRobotModelEntry(std::function<void(RobotModel)> callback) {
+const Member &
+Member::onRobotModelEntry(std::function<void(RobotModel)> callback) const {
     std::lock_guard lock(dataLock()->event_m);
     dataLock()->robot_model_entry_event[member_] =
         std::make_shared<std::function<void(RobotModel)>>(std::move(callback));
     return *this;
 }
-Member &Member::onFuncEntry(std::function<void(Func)> callback) {
+const Member &Member::onFuncEntry(std::function<void(Func)> callback) const {
     std::lock_guard lock(dataLock()->event_m);
     dataLock()->func_entry_event[member_] =
         std::make_shared<std::function<void(Func)>>(std::move(callback));
     return *this;
 }
-Member &Member::onViewEntry(std::function<void(View)> callback) {
+const Member &Member::onViewEntry(std::function<void(View)> callback) const {
     std::lock_guard lock(dataLock()->event_m);
     dataLock()->view_entry_event[member_] =
         std::make_shared<std::function<void(View)>>(std::move(callback));
     return *this;
 }
-Member &Member::onCanvas3DEntry(std::function<void(Canvas3D)> callback) {
+const Member &
+Member::onCanvas3DEntry(std::function<void(Canvas3D)> callback) const {
     std::lock_guard lock(dataLock()->event_m);
     dataLock()->canvas3d_entry_event[member_] =
         std::make_shared<std::function<void(Canvas3D)>>(std::move(callback));
     return *this;
 }
-Member &Member::onCanvas2DEntry(std::function<void(Canvas2D)> callback) {
+const Member &
+Member::onCanvas2DEntry(std::function<void(Canvas2D)> callback) const {
     std::lock_guard lock(dataLock()->event_m);
     dataLock()->canvas2d_entry_event[member_] =
         std::make_shared<std::function<void(Canvas2D)>>(std::move(callback));
     return *this;
 }
-Member &Member::onImageEntry(std::function<void(Image)> callback) {
+const Member &Member::onImageEntry(std::function<void(Image)> callback) const {
     std::lock_guard lock(dataLock()->event_m);
     dataLock()->image_entry_event[member_] =
         std::make_shared<std::function<void(Image)>>(std::move(callback));
     return *this;
 }
-Member &Member::onSync(std::function<void(Member)> callback) {
+const Member &Member::onSync(std::function<void(Member)> callback) const {
     std::lock_guard lock(dataLock()->event_m);
     dataLock()->sync_event[member_] =
         std::make_shared<std::function<void(Member)>>(std::move(callback));
@@ -122,7 +125,7 @@ std::optional<int> Member::pingStatus() const {
         return std::nullopt;
     }
 }
-Member &Member::onPing(std::function<void(Member)> callback) {
+const Member &Member::onPing(std::function<void(Member)> callback) const {
     dataLock()->pingStatusReq();
     std::lock_guard lock(dataLock()->event_m);
     dataLock()->ping_event[member_] =

--- a/client/src/robot_model.cc
+++ b/client/src/robot_model.cc
@@ -19,11 +19,11 @@ TemporalCanvas3DComponent RobotModel::toComponent3D() const {
         .robotModel(*this);
 }
 
-RobotModel &RobotModel::init() {
+const RobotModel &RobotModel::init() const {
     sb->init();
     return *this;
 }
-RobotModel &RobotModel::sync() {
+const RobotModel &RobotModel::sync() const {
     sb->sync();
     return *this;
 }
@@ -50,7 +50,8 @@ void internal::DataSetBuffer<RobotLink>::onSync() {
         change_event->operator()(target_);
     }
 }
-RobotModel &RobotModel::onChange(std::function<void(RobotModel)> callback) {
+const RobotModel &
+RobotModel::onChange(std::function<void(RobotModel)> callback) const {
     this->request();
     auto data = dataLock();
     std::lock_guard lock(data->event_m);
@@ -59,21 +60,22 @@ RobotModel &RobotModel::onChange(std::function<void(RobotModel)> callback) {
     return *this;
 }
 
-RobotModel &RobotModel::operator<<(RobotLink vc) {
+const RobotModel &RobotModel::operator<<(RobotLink vc) const {
     sb->add(std::move(vc));
     return *this;
 }
 
-void RobotModel::request() const {
+const RobotModel &RobotModel::request() const {
     auto data = dataLock();
     auto req = data->robot_model_store.addReq(member_, field_);
     if (req) {
         data->messagePushOnline(message::packSingle(
             message::Req<message::RobotModel>{{}, member_, field_, req}));
     }
+    return *this;
 }
 
-RobotModel &RobotModel::set(const std::vector<RobotLink> &v) {
+const RobotModel &RobotModel::set(const std::vector<RobotLink> &v) const {
     sb->set(v); // set()のなかでchange_eventは呼ばれる
     return *this;
 }
@@ -94,7 +96,7 @@ std::optional<std::vector<RobotLink>> RobotModel::tryGet() const {
 std::chrono::system_clock::time_point RobotModel::time() const {
     return member().syncTime();
 }
-RobotModel &RobotModel::free() {
+const RobotModel &RobotModel::free() const {
     auto req = dataLock()->robot_model_store.unsetRecv(*this);
     if (req) {
         // todo: リクエスト解除

--- a/client/src/text.cc
+++ b/client/src/text.cc
@@ -7,16 +7,17 @@ WEBCFACE_NS_BEGIN
 
 Text::Text(const Field &base) : Field(base) {}
 
-void Text::request() const {
+const Text &Text::request() const {
     auto data = dataLock();
     auto req = data->text_store.addReq(member_, field_);
     if (req) {
         data->messagePushOnline(message::packSingle(
             message::Req<message::Text>{{}, member_, field_, req}));
     }
+    return *this;
 }
 
-Text &Text::set(const ValAdaptor &v) {
+const Text &Text::set(const ValAdaptor &v) const {
     auto data = setCheck();
     data->text_store.setSend(*this, std::make_shared<ValAdaptor>(v));
     std::shared_ptr<std::function<void(Text)>> change_event;
@@ -29,7 +30,7 @@ Text &Text::set(const ValAdaptor &v) {
     }
     return *this;
 }
-Text &Text::onChange(std::function<void(Text)> callback) {
+const Text &Text::onChange(std::function<void(Text)> callback) const {
     this->request();
     auto data = dataLock();
     std::lock_guard lock(data->event_m);
@@ -75,7 +76,7 @@ std::optional<std::wstring> Text::tryGetW() const {
 std::chrono::system_clock::time_point Text::time() const {
     return member().syncTime();
 }
-Text &Text::free() {
+const Text &Text::free() const {
     auto req = dataLock()->text_store.unsetRecv(*this);
     if (req) {
         // todo: リクエスト解除

--- a/client/src/value.cc
+++ b/client/src/value.cc
@@ -9,16 +9,17 @@ WEBCFACE_NS_BEGIN
 
 Value::Value(const Field &base) : Field(base) {}
 
-void Value::request() const {
+const Value &Value::request() const {
     auto data = dataLock();
     auto req = data->value_store.addReq(member_, field_);
     if (req) {
         data->messagePushOnline(message::packSingle(
             message::Req<message::Value>{{}, member_, field_, req}));
     }
+    return *this;
 }
 
-Value &Value::set(double v) {
+const Value &Value::set(double v) const {
     auto last_name = this->lastName();
     auto parent = this->parent();
     if (std::all_of(last_name.cbegin(), last_name.cend(),
@@ -38,7 +39,7 @@ Value &Value::set(double v) {
     return *this;
 }
 
-Value &Value::set(std::vector<double> v) {
+const Value &Value::set(std::vector<double> v) const {
     auto data = setCheck();
     data->value_store.setSend(
         *this, std::make_shared<std::vector<double>>(std::move(v)));
@@ -52,7 +53,7 @@ Value &Value::set(std::vector<double> v) {
     }
     return *this;
 }
-Value &Value::onChange(std::function<void(Value)> callback) {
+const Value &Value::onChange(std::function<void(Value)> callback) const {
     this->request();
     auto data = dataLock();
     std::lock_guard lock(data->event_m);
@@ -61,7 +62,7 @@ Value &Value::onChange(std::function<void(Value)> callback) {
     return *this;
 }
 
-Value &Value::resize(std::size_t size) {
+const Value &Value::resize(std::size_t size) const {
     auto pv = this->tryGetVec();
     if (pv) {
         pv->resize(size);
@@ -71,7 +72,7 @@ Value &Value::resize(std::size_t size) {
     this->set(*pv);
     return *this;
 }
-Value &Value::push_back(double v) {
+const Value &Value::push_back(double v) const {
     auto pv = this->tryGetVec();
     if (pv) {
         pv->push_back(v);
@@ -111,7 +112,7 @@ std::optional<std::vector<double>> Value::tryGetVec() const {
 std::chrono::system_clock::time_point Value::time() const {
     return member().syncTime();
 }
-Value &Value::free() {
+const Value &Value::free() const {
     auto req = dataLock()->value_store.unsetRecv(*this);
     if (req) {
         // todo: リクエスト解除

--- a/docs/01_client.md
+++ b/docs/01_client.md
@@ -308,13 +308,25 @@ C++で文字列を返すAPI、およびCのAPI全般ではワイド文字列を�
     ```cpp
     wcli.close();
     ```
-    \note
-    C++ではClientのデストラクタでも自動的に切断します。
+    また、Clientのデストラクタでも自動的にclose()が呼ばれます。
 
+    \note
+    * <span class="since-c">2.0</span>
+    close()を呼んだ時点でサーバーに接続できていた場合は、sync()でキューに入れたメッセージがすべて送信したあとに切断されます。
+        * waitConnection() → sync() → close() とすれば確実にデータを送信することができます。
+        * start()を使ってまだ接続が完了していない場合、または1回接続した後で通信が切断された場合など、サーバーに未接続の状態でclose()が呼ばれたときはメッセージを送信することなく終了してしまいます。
+    * Clientのデストラクタは通信を切断するまで待機します。
+    
 - <b class="tab-title">C</b>
     ```c
     wcfClose(wcli);
     ```
+    \note
+    * <span class="since-c">2.0</span>
+    wcfClose()を呼んだ時点でサーバーに接続できていた場合は、wcfSync()でキューに入れたメッセージがすべて送信したあとに切断されます。
+        * wcfWaitConnection() → wcfSync() → wcfClose() とすれば確実にデータを送信することができます。
+        * wcfStart()を使ってまだ接続が完了していない場合、または1回接続した後で通信が切断された場合など、サーバーに未接続の状態でwcfClose()が呼ばれたときはメッセージを送信することなく終了してしまいます。
+    * wcfClose()は通信を切断するまで待機します。
 
 - <b class="tab-title">JavaScript</b>
     ```ts

--- a/docs/01_client.md
+++ b/docs/01_client.md
@@ -383,6 +383,11 @@ closeしたあと再度start()を呼んで再接続することはできませ�
 
 - <b class="tab-title">C++</b>
     `wcli.serverVersion()`, `wcli.serverName()` で取得できます。
+- <b class="tab-title">C</b>
+    \since <span class="since-c">2.0</span>
+
+    `wcfServerVersion(wcli)`, `wcfServerName(wcli)` で取得できます。
+
 - <b class="tab-title">JavaScript</b>
     `wcli.serverVersion`, `wcli.serverName` で取得できます。
 - <b class="tab-title">Python</b>
@@ -400,6 +405,9 @@ WebUI ver1.7 以降ではWebUIのページタイトルにも表示されてい�
 - <b class="tab-title">C++</b>
     \since <span class="since-c">2.0</span>
     `wcli.serverHostName()` で取得できます。
+- <b class="tab-title">C</b>
+    \since <span class="since-c">2.0</span>
+    `wcfServerHostName(wcli)` で取得できます。
 - <b class="tab-title">JavaScript</b>
     \since <span class="since-js">1.7</span>
     `wcli.serverHostName` で取得できます。

--- a/docs/02_member.md
+++ b/docs/02_member.md
@@ -56,6 +56,17 @@ Client::members() で現在接続されているメンバーのリストが得�
         // ...
     }
     ```
+- <b class="tab-title">C</b>
+    \since <span class="since-c">2.0</span>
+
+    `wcfMemberList`, `wcfMemberListW` にchar\*の配列とサイズを渡すと、メンバーの一覧を取得できます。
+    ```c
+    const char *member_list[10];
+    int actual_member_num;
+    wcfMemberList(wcli, member_list, 10, &actual_member_num);
+    ```
+    それぞれのメンバー名の文字列は、 wcfClose() するまではfreeされません。
+
 - <b class="tab-title">JavaScript</b>
     ```js
     for(const m of wcli.members()){
@@ -97,9 +108,22 @@ Client::onMemberEntry() で新しいメンバーが接続されたときのイ�
     Client::waitConnection()はこのクライアントが接続する前から存在したメンバーすべてについてコールバックを呼んでからreturnします。
 
     \note
-    onMemberEntryに限らず、
-    * <span class="since-c">2.0</span> webcfaceが受け取る関数オブジェクトは基本的にコピーではなくムーブされます。
-    * <span class="since-c">2.0</span> nullptrを渡すとイベントのコールバックを解除します。
+    <span class="since-c">2.0</span>
+    onMemberEntryに限らず、webcfaceが受け取る関数オブジェクトは基本的にコピーではなくムーブされます。
+
+- <b class="tab-title">C</b>
+    \since <span class="since-c">2.0</span>
+
+    `wcfMemberEntryEvent`, `wcfMemberEntryEventW` で引数に const char \* と void \* をとる関数ポインタをコールバックとして設定できます。
+    void\*引数には登録時に任意のデータのポインタを渡すことができます。(使用しない場合はNULLでよいです。)
+    ```c
+    void callback_member_entry(const char *name, void *user_data_p) {
+        struct UserData *user_data = (struct UserData *)user_data_p;
+        // ...
+    }
+    struct UserData user_data = {...};
+    wcfMemberEntryEvent(wcli, callback_member_entry, &user_data);
+    ```
 
 - <b class="tab-title">JavaScript</b>
     ```ts
@@ -176,17 +200,22 @@ C++のライブラリは `"cpp"`, Pythonのライブラリ(webcface-python)は`"
 <div class="tabbed">
 
 - <b class="tab-title">C++</b>
-    `wcli.libVersion()`, `wcli.libName()`, `wcli.remoteAddr()` で取得できます。
+    `member.libVersion()`, `member.libName()`, `member.remoteAddr()` で取得できます。
+- <b class="tab-title">C</b>
+    \since <span class="since-c">2.0</span>
+
+    `wcfMemberLibVersion(wcli, name)`, `wcfMemberLibName(wcli, name)`, `wcfMemberRemoteAddr(wcli, name)` で取得できます。
+
 - <b class="tab-title">JavaScript</b>
-    `wcli.libVersion`, `wcli.libName`, `wcli.remoteAddr` で取得できます。
+    `member.libVersion`, `member.libName`, `member.remoteAddr` で取得できます。
 - <b class="tab-title">Python</b>
-    `wcli.lib_version`, `wcli.lib_name`, `wcli.remote_addr` で取得できます。
+    `member.lib_version`, `member.lib_name`, `member.remote_addr` で取得できます。
     
 </div>
 
 ## ping
 
-Member::pingStatus() でそのクライアントの通信速度を取得できます。(int型で、単位はms)
+クライアントの通信速度を取得できます。(単位はms)
 ここでは通信速度とはサーバーとクライアントの間で1往復データを送受信するのにかかる遅延です。
 
 通信速度の情報は5秒に1回更新され、更新されたときにonPingイベントが発生します
@@ -196,6 +225,9 @@ Member::pingStatus() でそのクライアントの通信速度を取得でき�
 <div class="tabbed">
 
 - <b class="tab-title">C++</b>
+    Member::pingStatus() でmemberの通信速度(int型)を取得できます。
+    また、 Member::onPing() でpingの情報が更新された時に実行するコールバックを設定できます。
+
     <span class="since-c">2.0</span>
     ```cpp
     wcli.member("foo").onPing([](webcface::Member m){
@@ -209,6 +241,26 @@ Member::pingStatus() でそのクライアントの通信速度を取得でき�
     <del>onMemberEntry() と同様、 callbackList() でCallbackListにアクセスできます。</del>
     * <span class="since-c">2.0</span>
     自分自身のping値も取得できるようになりました。(`wcli.pingStatus()`, `wcli.onPing(...)`)
+
+- <b class="tab-title">C</b>
+    \since <span class="since-c">2.0</span>
+
+    `wcfMemberPingStatus`, `wcfMemberPingStatusW` でmemberの通信速度を取得できます。
+    ```c
+    int ping_status;
+    wcfMemberPingStatus(wcli, name, &ping_status);
+    ```
+
+    また、 `wcfMemberPingEvent`, `wcfMemberPingEventW` で引数に const char \* と void \* をとる関数ポインタをコールバックとして設定できます。
+    void\*引数には登録時に任意のデータのポインタを渡すことができます。(使用しない場合はNULLでよいです。)
+    ```c
+    void callback_ping(const char *name, void *user_data_p) {
+        struct UserData *user_data = (struct UserData *)user_data_p;
+        // ...
+    }
+    struct UserData user_data = {...};
+    wcfMemberPingEvent(wcli, callback_ping, &user_data);
+    ```
 
 - <b class="tab-title">JavaScript</b>
     ```ts

--- a/docs/02_member.md
+++ b/docs/02_member.md
@@ -93,11 +93,13 @@ Client::onMemberEntry() で新しいメンバーが接続されたときのイ�
     ```cpp
     wcli.onMemberEntry([](webcface::Member m){/* ... */});
     ```
-
-    <span class="since-c">2.0</span>
+    * <span class="since-c">2.0</span>
     Client::waitConnection()はこのクライアントが接続する前から存在したメンバーすべてについてコールバックを呼んでからreturnします。
 
-    \note webcfaceが受け取る関数オブジェクトは基本的にコピーではなくムーブされます。
+    \note
+    onMemberEntryに限らず、
+    * <span class="since-c">2.0</span> webcfaceが受け取る関数オブジェクトは基本的にコピーではなくムーブされます。
+    * <span class="since-c">2.0</span> nullptrを渡すとイベントのコールバックを解除します。
 
 - <b class="tab-title">JavaScript</b>
     ```ts

--- a/docs/10_value.md
+++ b/docs/10_value.md
@@ -436,6 +436,17 @@ Member::valueEntries() に変更
     // pos.x, pos.y などのvalueが得られる
     ```
 
+- <b class="tab-title">C</b>
+    \since <span class="since-c">2.0</span>
+
+    `wcfValueEntryList`, `wcfValueEntryListW` にchar\*の配列とサイズを渡すと、valueの一覧を取得できます。
+    ```c
+    const char *value_list[10];
+    int actual_value_num;
+    wcfMemberList(wcli, "foo", value_list, 10, &actual_value_num);
+    ```
+    それぞれのvalue名の文字列は、 wcfClose() するまではfreeされません。
+
 - <b class="tab-title">JavaScript</b>
     ```js
     for(const v of wcli.member("foo").values()){
@@ -471,6 +482,23 @@ Member名がわかっていれば<del>初回の Client::sync()</del> Client::sta
 
     <span class="since-c">2.0</span>
     Client::waitConnection()はこのクライアントが接続する前から存在したデータすべてについてコールバックを呼んでからreturnします。
+
+- <b class="tab-title">C</b>
+    \since <span class="since-c">2.0</span>
+
+    `wcfValueEntryEvent`, `wcfValueEntryEventW` で引数に const char \* 2つと void \* をとる関数ポインタをコールバックとして設定できます。
+    void\*引数には登録時に任意のデータのポインタを渡すことができます。(使用しない場合はNULLでよいです。)
+    ```c
+    void callback_value_entry(const char *member_name, const char *value_name, void *user_data_p) {
+        // member_name is "foo"
+
+        struct UserData *user_data = (struct UserData *)user_data_p;
+        // ...
+    }
+    struct UserData user_data = {...};
+    wcfValueEntryEvent(wcli, "foo", callback_value_entry, &user_data);
+    ```
+
 
 - <b class="tab-title">JavaScript</b>
     ```ts
@@ -522,6 +550,27 @@ Member名がわかっていれば<del>初回の Client::sync()</del> Client::sta
     ```
 
     ver1.11以前は `value("hoge").appendListener(...)`, `member("foo").onSync().appendListener(...)` です
+
+- <b class="tab-title">C</b>
+    \since <span class="since-c">2.0</span>
+
+    `wcfValueChangeEvent`, `wcfValueChangeEventW` で引数に const char \* 2つと void \* をとる関数ポインタをコールバックとして設定できます。
+    void\*引数には登録時に任意のデータのポインタを渡すことができます。(使用しない場合はNULLでよいです。)
+    ```c
+    void callback_value_change(const char *member_name, const char *value_name, void *user_data_p) {
+        // member_name is "foo", value_name is "hoge"
+        
+        // struct UserData *user_data = (struct UserData *)user_data_p;
+        // ...
+
+        double value[5];
+        int size;
+        wcfValueGetVecD(wcli, member_name, value_name, value, 5, &size);
+
+    }
+    struct UserData user_data = {...};
+    wcfValueChangeEvent(wcli, "foo", "hoge", callback_value_change, &user_data);
+    ```
 
 - <b class="tab-title">JavaScript</b>
     ```ts

--- a/docs/10_value.md
+++ b/docs/10_value.md
@@ -517,12 +517,11 @@ Member名がわかっていれば<del>初回の Client::sync()</del> Client::sta
     <span class="since-c">1.7</span>
     引数を持たない関数もイベントのコールバックに設定可能です。
     ```cpp
-    wcli.member("foo").value("hoge").onChange([]() {
-        std::cout << "foo.hoge changed" << std::endl;
-    });
+    wcli.member("foo").value("hoge").onChange([](){ /* ... */ });
+    wcli.member("foo").onSync([](){ /* ... */ });
     ```
 
-    ver1.11以前は `value("hoge").appendListener(...)` です
+    ver1.11以前は `value("hoge").appendListener(...)`, `member("foo").onSync().appendListener(...)` です
 
 - <b class="tab-title">JavaScript</b>
     ```ts

--- a/docs/13_view.md
+++ b/docs/13_view.md
@@ -144,11 +144,11 @@ Viewに追加する各種要素をViewComponentといいます。
     `button(...).textColor(...)` などのようにメソッドチェーンすることで各要素にオプションを設定できます。
 
     <span class="since-c">1.11</span>
-    引数にViewを取る関数オブジェクトをViewに渡すと、その場でその関数が呼び出されます。
+    引数にView(コピーまたはconst参照)を取る関数オブジェクトをViewに渡すと、その場でその関数が呼び出されます。
     複数のViewComponentを出力する処理をまとめて使いまわしたい場合に便利です。
     ```cpp
     auto showNameAndValue(const std::string &name, int value) {
-        return [=](webcface::View &view) {
+        return [=](const webcface::View &view) {
             view << name << " = " << value;
         };
     }

--- a/docs/15_image.md
+++ b/docs/15_image.md
@@ -74,11 +74,11 @@ Client::image からImageオブジェクトを作り、 Image::set() で画像�
 
 </div>
 
-### OpenCV
+### 外部ライブラリの利用
 
 <div class="tabbed">
 
-- <b class="tab-title">C++</b>
+- <b class="tab-title">OpenCV (C++)</b>
     ImageFrame → cv::Mat
     ```cpp
     cv::Mat img_mat(img_frame.rows(), img_frame.cols(), CV_8UC3, img_frame.data().data());

--- a/docs/40_log.md
+++ b/docs/40_log.md
@@ -38,7 +38,7 @@ webcface-send -t log
     wcli.log().append(webcface::level::error, "this is error");
     ```
 
-    ostream, (<span class="since-c">2.0</span>wostream) を使いたい場合は
+    std::ostreamを使いたい場合は
     ```cpp
     wcli.loggerOStream() << "hello" << std::endl;
     ```
@@ -49,7 +49,7 @@ webcface-send -t log
     ```
     のようにcoutやcerrの出力先を置き換えることができます。
     これらはWebCFaceに出力すると同時に標準エラー出力にも出力します。
-    (ver1.11以前はspdlogのstderr_sink、 ver2.0以降はfputs,fputcを使って直接stderrに出力されます)
+    (<del>spdlogのstderr_sinkを使って</del> <span class="since-c">2.0</span>fputs,fputcを使って 直接stderrに出力されます)
     またこの場合はログレベルが設定できず、常にinfoになります。
     
     <span class="since-c">2.0</span>

--- a/docs/40_log.md
+++ b/docs/40_log.md
@@ -92,7 +92,7 @@ webcface-send -t log
   spdlog→webcfaceにログを送信するsinkの例(ver1.11までwebcfaceに含まれていた実装):
   ```cpp
   class LoggerSink final : public spdlog::sinks::base_sink<std::mutex> {
-      webcface::Log *wcli_log;
+      webcface::Log wcli_log;
 
     protected:
       void sink_it_(const spdlog::details::log_msg &msg) override {
@@ -104,14 +104,14 @@ webcface-send -t log
               if (log_text.size() > 0 && log_text.back() == '\r') {
                   log_text.pop_back();
               }
-              wcli_log->append(msg.level, msg.time, log_text);
+              wcli_log.append(msg.level, msg.time, log_text);
           }
       }
       void flush_() override {}
 
     public:
       explicit LoggerSink(webcface::Client &wcli)
-      : spdlog::sinks::base_sink<std::mutex>(), wcli_log(wcli.log()) {}
+          : spdlog::sinks::base_sink<std::mutex>(), wcli_log(wcli.log()) {}
       void set_pattern_(const std::string &) override {}
       void set_formatter_(std::unique_ptr<spdlog::formatter>) override {}
   };

--- a/examples/cv-recv.cc
+++ b/examples/cv-recv.cc
@@ -8,24 +8,24 @@
 
 webcface::Client wcli;
 
-void img_update1(webcface::Image img);
-void img_update2(webcface::Image img);
-void img_update3(webcface::Image img);
-void img_update4(webcface::Image img);
-void img_update5(webcface::Image img);
+void img_update1(const webcface::Image &img);
+void img_update2(const webcface::Image &img);
+void img_update3(const webcface::Image &img);
+void img_update4(const webcface::Image &img);
+void img_update5(const webcface::Image &img);
 
 int main() {
     wcli.waitConnection();
 
     // image_sendを5回起動して終了すると5通りのリクエストをして表示するサンプル
 
-    webcface::Image img = wcli.member("example_image_send").image("sample");
+    const webcface::Image &img = wcli.member("example_image_send").image("sample");
     img.request();
     img.onChange(img_update1);
     wcli.loopSync();
 }
 
-void img_update1(webcface::Image img) {
+void img_update1(const webcface::Image &img) {
     std::cout << "image updated" << std::endl;
     auto img_frame = img.get();
     if (!img_frame.empty()) {
@@ -41,7 +41,7 @@ void img_update1(webcface::Image img) {
         img.onChange(img_update2);
     }
 }
-void img_update2(webcface::Image img) {
+void img_update2(const webcface::Image &img) {
     auto img_frame = img.get();
     if (!img_frame.empty()) {
         cv::Mat mat2(img_frame.rows(), img_frame.cols(), CV_8UC3,
@@ -57,7 +57,7 @@ void img_update2(webcface::Image img) {
         img.onChange(img_update3);
     }
 }
-void img_update3(webcface::Image img) {
+void img_update3(const webcface::Image &img) {
     auto img_frame = img.get();
     if (!img_frame.empty()) {
         assert(img_frame.channels() == 1);
@@ -71,7 +71,7 @@ void img_update3(webcface::Image img) {
         img.onChange(img_update4);
     }
 }
-void img_update4(webcface::Image img) {
+void img_update4(const webcface::Image &img) {
     auto img_frame = img.get();
     if (!img_frame.empty()) {
         cv::Mat mat2 = cv::imdecode(img_frame.data(), cv::IMREAD_COLOR);
@@ -82,7 +82,7 @@ void img_update4(webcface::Image img) {
         img.onChange(img_update5);
     }
 }
-void img_update5(webcface::Image img) {
+void img_update5(const webcface::Image &img) {
     auto img_frame = img.get();
     if (!img_frame.empty()) {
         cv::Mat mat2 = cv::imdecode(img_frame.data(), cv::IMREAD_COLOR);

--- a/examples/image-recv.cc
+++ b/examples/image-recv.cc
@@ -8,11 +8,11 @@
 
 webcface::Client wcli;
 
-void img_update1(webcface::Image img);
-void img_update2(webcface::Image img);
-void img_update3(webcface::Image img);
-void img_update4(webcface::Image img);
-void img_update5(webcface::Image img);
+void img_update1(const webcface::Image &img);
+void img_update2(const webcface::Image &img);
+void img_update3(const webcface::Image &img);
+void img_update4(const webcface::Image &img);
+void img_update5(const webcface::Image &img);
 
 int main() {
     Magick::InitializeMagick(nullptr);
@@ -26,7 +26,7 @@ int main() {
     wcli.loopSync();
 }
 
-void img_update1(webcface::Image img) {
+void img_update1(const webcface::Image &img) {
     auto img_frame = img.get();
     if (!img_frame.empty()) {
         std::cout << "1. Normal" << std::endl;
@@ -41,7 +41,7 @@ void img_update1(webcface::Image img) {
         img.onChange(img_update2);
     }
 }
-void img_update2(webcface::Image img) {
+void img_update2(const webcface::Image &img) {
     auto img_frame = img.get();
     if (!img_frame.empty()) {
         std::cout << "2. Resized to 300x300" << std::endl;
@@ -59,7 +59,7 @@ void img_update2(webcface::Image img) {
     }
 }
 
-void img_update3(webcface::Image img) {
+void img_update3(const webcface::Image &img) {
     auto img_frame = img.get();
     if (!img_frame.empty()) {
         std::cout << "3. Grayscale" << std::endl;
@@ -76,7 +76,7 @@ void img_update3(webcface::Image img) {
         img.onChange(img_update4);
     }
 }
-void img_update4(webcface::Image img) {
+void img_update4(const webcface::Image &img) {
     auto img_frame = img.get();
     if (!img_frame.empty()) {
         std::cout << "4. JPEG" << std::endl;
@@ -92,7 +92,7 @@ void img_update4(webcface::Image img) {
         img.onChange(img_update5);
     }
 }
-void img_update5(webcface::Image img) {
+void img_update5(const webcface::Image &img) {
     auto img_frame = img.get();
     if (!img_frame.empty()) {
         std::cout << "5. PNG" << std::endl;

--- a/examples/recv.cc
+++ b/examples/recv.cc
@@ -9,7 +9,7 @@
 int main() {
     // webcface::logger_internal_level = spdlog::level::trace;
     webcface::Client c("example_recv");
-    c.onMemberEntry([](webcface::Member m) {
+    c.onMemberEntry([](const webcface::Member &m) {
         std::cout << "member entry " << m.name() << std::endl;
         m.onValueEntry([](const webcface::Value &v) {
             std::cout << "value entry " << v.name() << std::endl;
@@ -28,7 +28,7 @@ int main() {
             }
             std::cout << " ret: " << f.returnType() << std::endl;
         });
-        m.log().onChange([](webcface::Log l) {
+        m.log().onChange([](const webcface::Log &l) {
             for (const auto &ll : l.get()) {
                 std::cout << "log [" << ll.level() << "] " << ll.message()
                           << std::endl;

--- a/tests/dummy_server.cc
+++ b/tests/dummy_server.cc
@@ -43,8 +43,12 @@ class CustomLogger : public crow::ILogHandler {
 };
 
 DummyServer::~DummyServer() {
-    static_cast<crow::SimpleApp *>(server_)->stop();
-    t.join();
+    try {
+        static_cast<crow::SimpleApp *>(server_)->stop();
+        t.join();
+    } catch (...) {
+        // ignore exception
+    }
 }
 DummyServer::DummyServer(bool use_unix)
     : t([this, use_unix] {

--- a/tests/view_test.cc
+++ b/tests/view_test.cc
@@ -105,7 +105,7 @@ TEST_F(ViewTest, viewSet) {
         EXPECT_EQ(v, v2);
     };
     v << manip2;
-    EXPECT_EQ(manip_called, 2);
+    EXPECT_EQ(manip_called, 1);
     v.sync();
     EXPECT_EQ(callback_called, 1);
     auto &view_data = **data_->view_store.getRecv(self_name, "b"_ss);

--- a/tests/view_test.cc
+++ b/tests/view_test.cc
@@ -100,15 +100,11 @@ TEST_F(ViewTest, viewSet) {
         EXPECT_EQ(val, "aaa");
     });
     int manip_called = 0;
-    auto manip = [&](webcface::View &v2) {
-        manip_called++;
-        EXPECT_EQ(&v, &v2);
-    };
     auto manip2 = [&](const webcface::View &v2) {
         manip_called++;
         EXPECT_EQ(v, v2);
     };
-    v << manip << manip2;
+    v << manip2;
     EXPECT_EQ(manip_called, 2);
     v.sync();
     EXPECT_EQ(callback_called, 1);


### PR DESCRIPTION
* 大半のメンバ関数にconst追加
  * View << callback のときcallbackの引数にView&が使えなくなった
* Member::onSync, onPing に引数なしコールバック設定可能にした
* イベント周りドキュメント

