### PR TITLE
TextとVariantに分離

### DIFF
--- a/client/include/webcface/component_view.h
+++ b/client/include/webcface/component_view.h
@@ -175,11 +175,12 @@ class WEBCFACE_DLL ViewComponent {
      * \brief inputの現在の値を取得
      * \since ver1.10
      *
-     *     * 値の変更はonChange()に新しい値を渡して呼び出す
+     * * 値の変更はonChange()に新しい値を渡して呼び出す
      * (onChange()->runAsync(value) など)
+     * * ver2.0〜 戻り値をText型からVariant型に変更
      *
      */
-    std::optional<Text> bind() const;
+    std::optional<Variant> bind() const;
 
     /*!
      * \brief 文字色を取得

--- a/client/include/webcface/func.h
+++ b/client/include/webcface/func.h
@@ -222,7 +222,7 @@ class WEBCFACE_DLL Func : protected Field {
                         [&] {
                             if constexpr (FuncObjTrait<T>::return_void) {
                                 std::apply(func, args_tuple);
-                                return ValAdaptor{};
+                                return ValAdaptor::emptyVal();
                             } else {
                                 auto ret = std::apply(func, args_tuple);
                                 return ret;
@@ -266,7 +266,7 @@ class WEBCFACE_DLL Func : protected Field {
                                     if constexpr (FuncObjTrait<
                                                       T>::return_void) {
                                         std::apply(*func_p, args_tuple);
-                                        return ValAdaptor{};
+                                        return ValAdaptor::emptyVal();
                                     } else {
                                         auto ret =
                                             std::apply(*func_p, args_tuple);

--- a/client/include/webcface/func_result.h
+++ b/client/include/webcface/func_result.h
@@ -399,7 +399,7 @@ class WEBCFACE_DLL CallHandle : Field {
      * * ver2.0から: respondable() がfalseの場合 std::runtime_error を投げる
      *
      */
-    void respond() const { respond(ValAdaptor()); }
+    void respond() const { respond(ValAdaptor::emptyVal()); }
 
     /*!
      * \brief 関数の結果を例外として送信する

--- a/client/include/webcface/internal/client_internal.h
+++ b/client/include/webcface/internal/client_internal.h
@@ -286,7 +286,7 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
     std::shared_ptr<std::function<void(Member)>> member_entry_event;
 
     StrMap2<std::shared_ptr<std::function<void(Value)>>> value_change_event;
-    StrMap2<std::shared_ptr<std::function<void(Text)>>> text_change_event;
+    StrMap2<std::shared_ptr<std::function<void(Variant)>>> text_change_event;
     StrMap2<std::shared_ptr<std::function<void(Image)>>> image_change_event;
     StrMap2<std::shared_ptr<std::function<void(RobotModel)>>>
         robot_model_change_event;

--- a/client/src/c_wcf/text.cc
+++ b/client/src/c_wcf/text.cc
@@ -47,17 +47,16 @@ static wcfStatus wcfTextGetT(wcfClient *wcli, const CharT *member,
     if (!wcli_) {
         return WCF_BAD_WCLI;
     }
-    auto str = wcli_->member(strOrEmpty(member)).text(field).tryGetV();
+    auto str = wcli_->member(strOrEmpty(member)).text(field).tryGet();
     if (str) {
-        const std::basic_string<CharT> &str2 = *str;
         if (size > 0) {
-            int copy_size = (size - 1) < static_cast<int>(str2.size())
+            int copy_size = (size - 1) < static_cast<int>(str->size())
                                 ? (size - 1)
-                                : static_cast<int>(str2.size());
-            std::memcpy(text, str2.c_str(), copy_size * sizeof(CharT));
+                                : static_cast<int>(str->size());
+            std::memcpy(text, str->c_str(), copy_size * sizeof(CharT));
             text[copy_size] = 0;
         }
-        *recv_size = static_cast<int>(str2.size());
+        *recv_size = static_cast<int>(str->size());
         return WCF_OK;
     } else {
         return WCF_NO_DATA;

--- a/client/src/component_view.cc
+++ b/client/src/component_view.cc
@@ -218,7 +218,7 @@ TemporalViewComponent &TemporalViewComponent::bind(const InputRef &ref) {
     msg_data->text_ref_tmp = ref;
     return *this;
 }
-std::optional<Text> ViewComponent::bind() const {
+std::optional<Variant> ViewComponent::bind() const {
     checkData();
     if (msg_data->text_ref_member && msg_data->text_ref_field) {
         return Field{data_w, *msg_data->text_ref_member,

--- a/client/src/component_view.cc
+++ b/client/src/component_view.cc
@@ -70,10 +70,10 @@ std::unique_ptr<internal::ViewComponentData> TemporalViewComponent::lockTmp(
     }
     if (msg_data->text_ref_tmp) {
         // if (text_ref_tmp->expired()) {
-        Text text_ref{Field{data, data->self_member_name},
-                      SharedString::fromU8String(
-                          "..ir" + view_name.u8String() + "/" +
-                          internalViewId(msg_data->type, idx_for_type))};
+        Variant text_ref{Field{data, data->self_member_name},
+                         SharedString::fromU8String(
+                             "..ir" + view_name.u8String() + "/" +
+                             internalViewId(msg_data->type, idx_for_type))};
         msg_data->text_ref_tmp->lockTo(text_ref);
         if (msg_data->init_ && !text_ref.tryGet()) {
             text_ref.set(*msg_data->init_);

--- a/docs/13_view.md
+++ b/docs/13_view.md
@@ -420,10 +420,11 @@ viewに入力欄を表示します。
 - sliderInput: 数値を指定するスライダー
 - checkInput: チェックボックス
 
+#### InputRef
+
 <div class="tabbed">
 
 - <b class="tab-title">C++</b>
-    InputRef  
     入力された値にアクセスするため webcface::InputRef オブジェクトを作成し、inputにbindします。
     そのInputRefオブジェクトをコピーまたは参照で別の関数などに渡すと、あとから値を取得することができます。
     ```cpp
@@ -434,9 +435,9 @@ viewに入力欄を表示します。
       << std::endl;
     ```
 
-    \warning
+    \note
     上の例ではinput_valをstatic変数にし寿命が切れないようにしていますが、
-    次の例のようにviewの生成ごとにInputRefオブジェクトを生成・破棄しても動作はします。
+    staticにできない場合(複数のviewで使い回す場合など)は次の例のようにviewの生成ごとにInputRefオブジェクトを生成・破棄しても動作はします。
     ```cpp
     while (true){
         auto v = wcli.view("a");
@@ -453,38 +454,18 @@ viewに入力欄を表示します。
     この場合はv.sync()の時に前周期のinput_valの内容が復元されるという挙動になります。
     (したがってv.sync()より前では値が未初期化になります)
 
-    InputRefの値は`get()`で webcface::ValAdaptor 型として取得できます。
-    また std::string, double, bool などの型にキャストすることでも値を得られます。  
     <span class="since-c">1.11</span>
-    `asStringRef()`, `asString()`, `asBool()`, <del>`as<double>()`</del> でも型変換ができます。  
-    <span class="since-c">2.0</span> `asWStringRef()`, `asWString()`, `asDouble()`, `asInt()`, `asLLong()` も使えます。
+    InputRefの値は
+    `asStringRef()`, `asString()`, `asBool()`, <del>`as<double>()`</del> で型を指定して取得できます。  
+    <span class="since-c">2.0</span> `asWStringRef()`, `asWString()`, `asDouble()`, `asInt()`, `asLLong()` も使えます。  
+    (std::string, double, bool などの型にキャストすることでも値を得られます。)  
+    (任意の型に対応したい場合は `get()` で webcface::ValAdaptor 型として取得できます。)
 
     \note
     内部の実装では入力値を受け取りInputRefに値をセットする関数をonChangeにセットしています。
-    また、InputRefの値は[Text](./11_text.md)の1つとしてviewを表示しているクライアントに送信されます。
-
-    onChange  
-    onChange() で値が入力されたときに実行する関数を設定でき、こちらでも値が取得できます。
-    buttonに渡す関数と同様、関数オブジェクト、Funcオブジェクト、AnonymousFuncオブジェクトが使用できます。
-    ```cpp
-    v << webcface::textInput("表示する文字列").onChange([](std::string val) {
-        std::cout << "input changed: " << val << std::endl;
-    });
-    ```
-
-    \note bindとonChangeを両方設定することはできません。
-
-    その他各種inputに指定できるオプションには以下のものがあります。
-    ([Func](./30_func.md)のArgオプションと同様です。)
-
-    `.init(初期値)`  
-    `.min(最小値)`, `.max(最大値)`: decimalInput, numberInput, sliderInputのみ  
-    `.min(最小文字数)`, `.max(最大文字数)`: textInputのみ  
-    `.step(刻み幅)`: numberInput, sliderInputのみ  
-    `.option({ 選択肢, ... })`: selectInput, toggleInput  
+    また、InputRefの値は[Text](./11_text.md)型のデータとしてviewを表示しているクライアントに送信されます。
 
 - <b class="tab-title">JavaScript</b>
-    InputRef  
     入力された値にアクセスするため [InputRef](https://na-trium-144.github.io/webcface-js/classes/InputRef.html) オブジェクトを作成し、inputにbindします。
     そのInputRefオブジェクトを別の関数などに渡すと、あとから値を取得することができます。
     ```ts
@@ -518,9 +499,26 @@ viewに入力欄を表示します。
 
     \note
     内部の実装では入力値を受け取りInputRefに値をセットする関数をonChangeにセットしています。
-    また、InputRefの値は[Text](./11_text.md)の1つとしてviewを表示しているクライアントに送信されます。
+    また、InputRefの値は[Text](./11_text.md)型のデータとしてviewを表示しているクライアントに送信されます。
 
-    onChange  
+</div>
+
+#### onChange
+
+<div class="tabbed">
+
+- <b class="tab-title">C++</b>
+    onChange() で値が入力されたときに実行する関数を設定でき、こちらでも値が取得できます。
+    buttonに渡す関数と同様、関数オブジェクト、Funcオブジェクト、AnonymousFuncオブジェクトが使用できます。
+    ```cpp
+    v << webcface::textInput("表示する文字列").onChange([](std::string val) {
+        std::cout << "input changed: " << val << std::endl;
+    });
+    ```
+
+    \note bindとonChangeを両方設定することはできません。
+
+- <b class="tab-title">JavaScript</b>
     onChange で値が入力されたときに実行する関数を設定でき、こちらでも値が取得できます。
     buttonに渡す関数と同様、関数オブジェクト、Funcオブジェクト、AnonymousFuncオブジェクトが使用できます。
     ```ts
@@ -529,6 +527,23 @@ viewに入力欄を表示します。
     })
     ```
 
+</div>
+
+#### options
+
+<div class="tabbed">
+
+- <b class="tab-title">C++</b>
+    その他各種inputに指定できるオプションには以下のものがあります。
+    ([Func](./30_func.md)のArgオプションと同様です。)
+
+    `.init(初期値)`  
+    `.min(最小値)`, `.max(最大値)`: decimalInput, numberInput, sliderInputのみ  
+    `.min(最小文字数)`, `.max(最大文字数)`: textInputのみ  
+    `.step(刻み幅)`: numberInput, sliderInputのみ  
+    `.option({ 選択肢, ... })`: selectInput, toggleInput  
+
+- <b class="tab-title">JavaScript</b>
     その他各種inputに指定できるオプションには以下のものがあります。
     ([Func](./30_func.md)のArgオプションと同様です。)
 
@@ -537,7 +552,6 @@ viewに入力欄を表示します。
     `min: 最小文字数, max: 最大文字数`: textInputのみ  
     `step: 刻み幅`: numberInput, sliderInputのみ  
     `option: [選択肢, ... ]`: selectInput, toggleInput  
-
 
 </div>
 
@@ -567,9 +581,15 @@ ViewComponent::onClick() でボタン要素のクリック時に実行するべ�
 <span class="since-c">1.10</span>
 <span class="since-js">1.6</span>
 
-各種Input要素の現在の値は ViewComponent::bind() で[Text](./11_text.md)オブジェクトとして取得できます。
+各種Input要素の現在の値は ViewComponent::bind() で
+<del>[Text](./11_text.md)オブジェクトとして</del>
+<span class="since-c">2.0</span> webcface::Variant オブジェクトとして取得できます。
 したがって`bind()`の値をInputの初期値として使用すればよいです。
-bind().get()で得られる webcface::ValAdaptor の値を整数、実数、bool、stringにキャストすることができます。
+
+<span class="since-c">2.0</span> Variant の値は
+`asStringRef()`, `asWStringRef()`, `asString()`, `asWString()`, `asBool()`, `asDouble()`, `asInt()`, `asLLong()` で型を指定して取得できます。  
+(std::string, double, bool などの型にキャストすることでも値を得られます。)  
+(bind().get() で webcface::ValAdaptor 型としても取得できます。)
 
 Inputの値を変更する際は、(view送信側がbindを設定したかonChangeを設定したかに関わらず)
 ViewComponent::onChange() を使います。

--- a/encoding/include/webcface/encoding/val_adaptor.h
+++ b/encoding/include/webcface/encoding/val_adaptor.h
@@ -165,6 +165,8 @@ class WEBCFACE_DLL ValAdaptor {
 
     ValType valType() const { return type; }
 
+    static const ValAdaptor& emptyVal();
+    
     /*!
      * \brief 値が空かどうか調べる
      * \since ver1.11

--- a/encoding/src/val_adaptor.cc
+++ b/encoding/src/val_adaptor.cc
@@ -4,6 +4,11 @@ WEBCFACE_NS_BEGIN
 inline namespace encoding {
 ValAdaptor::ValAdaptor() : type(ValType::none_) {}
 
+const ValAdaptor &ValAdaptor::emptyVal() {
+    static ValAdaptor empty;
+    return empty;
+}
+
 ValAdaptor::ValAdaptor(const SharedString &str)
     : as_str(str), type(ValType::string_) {}
 ValAdaptor &ValAdaptor::operator=(const SharedString &str) {


### PR DESCRIPTION
* TextをTextとVariantに分離
* InputRefのpimplを隠蔽
* InputRef::get()の仕様変更(参照の寿命が短くなった)
* Text::get(), getW() の戻り値を参照にした
* ViewComponent::bind()の戻り値をVariantに