### PR TITLE
debパッケージでインストールした場合にcmakeとpkgconfigで/opt/webcfaceのほうを参照するようにした

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -100,13 +100,14 @@ jobs:
             ln -s $absprefix/bin/$(basename $file) .debpkg/usr/bin/
           done
 
-          mkdir -p .debpkg/usr/include
-          echo $absprefix/include/webcface
-          ln -s $absprefix/include/webcface .debpkg/usr/include/
+          # v2.0.2以降include不要
+          # mkdir -p .debpkg/usr/include
+          # echo $absprefix/include/webcface
+          # ln -s $absprefix/include/webcface .debpkg/usr/include/
 
-          mkdir -p .debpkg/usr/share/doc
-          echo $absprefix/share/doc/webcface
-          ln -s $absprefix/share/doc/webcface .debpkg/usr/share/doc/
+          # mkdir -p .debpkg/usr/share/doc
+          # echo $absprefix/share/doc/webcface
+          # ln -s $absprefix/share/doc/webcface .debpkg/usr/share/doc/
 
           mkdir -p .debpkg/usr/lib/systemd/system
           echo $absprefix/lib/systemd/system/webcface-server.service
@@ -114,8 +115,8 @@ jobs:
 
           libdir=lib/$(basename $prefix/lib/*-linux-*)
           mkdir -p .debpkg/usr/$libdir/cmake
-          echo $absprefix/$libdir/cmake/webcface
-          ln -s $absprefix/$libdir/cmake/webcface .debpkg/usr/$libdir/cmake/
+          echo $absprefix/$libdir/cmake/webcface2
+          ln -s $absprefix/$libdir/cmake/webcface2 .debpkg/usr/$libdir/cmake/
           mkdir -p .debpkg/usr/$libdir/pkgconfig
           echo $absprefix/$libdir/pkgconfig/webcface.pc
           ln -s $absprefix/$libdir/pkgconfig/webcface.pc .debpkg/usr/$libdir/pkgconfig/webcface.pc

--- a/meson.build
+++ b/meson.build
@@ -749,6 +749,11 @@ import('pkgconfig').generate(
   url: webcface_url,
   filebase: 'webcface',
   libraries: [webcface_lib],
+  version: webcface_version_str,
+  # インストール後に webcface.pc へのシンボリックリンクリンクを別の場所に貼った場合、
+  # もとのprefix (/opt/webcface など) も参照するようにする。
+  # (cmakeの場合はwebcface-config.cmake内にシンボリックリンクを展開するコード書いた)
+  extra_cflags: '-I' + (get_option('prefix') / get_option('includedir')),
 )
 meson.override_dependency('webcface', webcface_dep)
 if get_option('default_library') == 'shared'
@@ -796,6 +801,7 @@ if get_option('default_library') == 'shared'
     version: meson.project_version(),
     compatibility: 'SameMajorVersion',
     arch_independent: false,
+    install_dir: get_option('libdir') / 'cmake' / 'webcface' + meson.project_version().split('.')[0],
   )
   conf_data = configuration_data({
     'prefix': get_option('prefix'),
@@ -804,10 +810,12 @@ if get_option('default_library') == 'shared'
     'webcface_lib_debug': webcface_lib_name_debug,
     'webcface_lib_release': webcface_lib_name_release,
     'webcface_abi_major': webcface_abi_major,
+    'webcface_version_str': webcface_version_str,
   })
   cmake.configure_package_config_file(
     name: 'webcface',
     input: 'scripts' / 'webcface-config.cmake.in',
-    configuration: conf_data
+    configuration: conf_data,
+    install_dir: get_option('libdir') / 'cmake' / 'webcface' + meson.project_version().split('.')[0],
   )
 endif

--- a/scripts/webcface-config.cmake.in
+++ b/scripts/webcface-config.cmake.in
@@ -1,4 +1,16 @@
+# /usr/lib/cmake/webcface → /opt/webcface/lib/cmake/webcface
+while(IS_SYMLINK "${CMAKE_CURRENT_LIST_DIR}" AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.14")
+  set(CMAKE_CURRENT_LIST_DIR_BEFORE "${CMAKE_CURRENT_LIST_DIR}")
+  file(READ_SYMLINK "${CMAKE_CURRENT_LIST_DIR}" CMAKE_CURRENT_LIST_DIR)
+  if(NOT IS_ABSOLUTE CMAKE_CURRENT_LIST_DIR)
+    get_filename_component(dir "${CMAKE_CURRENT_LIST_DIR_BEFORE}" DIRECTORY)
+    set(result "${dir}/${CMAKE_CURRENT_LIST_DIR}")
+  endif()
+endwhile()
+
 @PACKAGE_INIT@
+
+message(STATUS "WebCFace @webcface_version_str@: ${PACKAGE_PREFIX_DIR}")
 
 find_library(WEBCFACE_DEBUG_LIB @webcface_lib_debug@ PATHS "${PACKAGE_PREFIX_DIR}/@libdir@")
 find_library(WEBCFACE_RELEASE_LIB @webcface_lib_release@ PATHS "${PACKAGE_PREFIX_DIR}/@libdir@")


### PR DESCRIPTION
* debパッケージでwebcface2.0.0を1.11.4に上書き展開すると/usr/include/webcfaceの上書きに失敗するという問題があるので、
* /usr/include/webcface (とついでに不要な /usr/share/docs/webcface も) をインストールしないようにした
* webcface-config.cmake と webcface.pc がリンク先である /opt/webcface/include のほうも参照するようにした
* ついでに webcface-config.cmake のインストール先を cmake/webcface2 にしてみた


