### PR TITLE
std::anyをstd::shared_ptr<void>に変更 (v2.0.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [2.0.4] - 2024-08-30
 ### Fixed
-* macosのuniversalビルドでstd::bad_any_castになることがあるので、std::anyをやめてvariantに変更 (#392)
+* macosのuniversalビルドでstd::bad_any_castになることがあるので、std::anyをやめてshared_ptr\<void\>に変更 (#392)
 
 ## [2.0.3] - 2024-08-29
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.4] - 2024-08-30
+### Fixed
+* macosのuniversalビルドでstd::bad_any_castになることがあるので、std::anyをやめてvariantに変更 (#392)
+
 ## [2.0.3] - 2024-08-29
 ### Fixed
 * v2.0.2の変更でwebcface-config.cmakeのパスの展開にバグがあったのを修正 (#390)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(webcface VERSION 2.0.3)
+project(webcface VERSION 2.0.4)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     set(IS_MAIN on)

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "WebCFace"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "2.0.3"
+PROJECT_NUMBER         = "2.0.4"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/client/src/client_msg_recv.cc
+++ b/client/src/client_msg_recv.cc
@@ -75,7 +75,7 @@ void internal::ClientData::onRecv(const std::string &message) {
         const auto &[kind, obj] = m;
         switch (kind) {
         case MessageKind::sync_init_end: {
-            auto r = std::any_cast<webcface::message::SyncInitEnd>(obj);
+            auto r = std::get<webcface::message::SyncInitEnd>(obj);
             this->svr_name = r.svr_name;
             this->svr_version = r.ver;
             this->self_member_id.emplace(r.member_id);
@@ -93,7 +93,7 @@ void internal::ClientData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::ping_status: {
-            auto r = std::any_cast<webcface::message::PingStatus>(obj);
+            auto r = std::get<webcface::message::PingStatus>(obj);
             this->ping_status = r.status;
             StrSet1 members;
             {
@@ -121,7 +121,7 @@ void internal::ClientData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::sync: {
-            auto r = std::any_cast<webcface::message::Sync>(obj);
+            auto r = std::get<webcface::message::Sync>(obj);
             const auto &member = this->getMemberNameFromId(r.member_id);
             this->sync_time_store.setRecv(member, r.getTime());
             sync_members.push_back(member);
@@ -129,22 +129,20 @@ void internal::ClientData::onRecv(const std::string &message) {
         }
         case MessageKind::value + MessageKind::res: {
             auto r =
-                std::any_cast<webcface::message::Res<webcface::message::Value>>(
-                    obj);
+                std::get<webcface::message::Res<webcface::message::Value>>(obj);
             onRecvRes(this, r, r.data, this->value_store,
                       this->value_change_event);
             break;
         }
         case MessageKind::text + MessageKind::res: {
             auto r =
-                std::any_cast<webcface::message::Res<webcface::message::Text>>(
-                    obj);
+                std::get<webcface::message::Res<webcface::message::Text>>(obj);
             onRecvRes(this, r, r.data, this->text_store,
                       this->text_change_event);
             break;
         }
         case MessageKind::robot_model + MessageKind::res: {
-            auto r = std::any_cast<message::Res<message::RobotModel>>(obj);
+            auto r = std::get<message::Res<message::RobotModel>>(obj);
             auto links_data = std::make_shared<
                 std::vector<std::shared_ptr<internal::RobotLinkData>>>();
             links_data->reserve(r.data.size());
@@ -158,8 +156,7 @@ void internal::ClientData::onRecv(const std::string &message) {
         }
         case MessageKind::view + MessageKind::res: {
             auto r =
-                std::any_cast<webcface::message::Res<webcface::message::View>>(
-                    obj);
+                std::get<webcface::message::Res<webcface::message::View>>(obj);
             std::lock_guard lock_s(this->view_store.mtx);
             auto [member, field] =
                 this->view_store.getReq(r.req_id, r.sub_field);
@@ -193,8 +190,9 @@ void internal::ClientData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::canvas3d + MessageKind::res: {
-            auto r = std::any_cast<
-                webcface::message::Res<webcface::message::Canvas3D>>(obj);
+            auto r =
+                std::get<webcface::message::Res<webcface::message::Canvas3D>>(
+                    obj);
             std::lock_guard lock_s(this->canvas3d_store.mtx);
             auto [member, field] =
                 this->canvas3d_store.getReq(r.req_id, r.sub_field);
@@ -229,8 +227,9 @@ void internal::ClientData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::canvas2d + MessageKind::res: {
-            auto r = std::any_cast<
-                webcface::message::Res<webcface::message::Canvas2D>>(obj);
+            auto r =
+                std::get<webcface::message::Res<webcface::message::Canvas2D>>(
+                    obj);
             std::lock_guard lock_s(this->canvas2d_store.mtx);
             auto [member, field] =
                 this->canvas2d_store.getReq(r.req_id, r.sub_field);
@@ -264,13 +263,12 @@ void internal::ClientData::onRecv(const std::string &message) {
         }
         case MessageKind::image + MessageKind::res: {
             auto r =
-                std::any_cast<webcface::message::Res<webcface::message::Image>>(
-                    obj);
+                std::get<webcface::message::Res<webcface::message::Image>>(obj);
             onRecvRes(this, r, r, this->image_store, this->image_change_event);
             break;
         }
         case MessageKind::log: {
-            auto r = std::any_cast<webcface::message::Log>(obj);
+            auto r = std::get<webcface::message::Log>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             std::lock_guard lock_s(this->log_store.mtx);
             auto log_s = this->log_store.getRecv(member);
@@ -293,7 +291,7 @@ void internal::ClientData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::call: {
-            auto r = std::any_cast<webcface::message::Call>(obj);
+            auto r = std::get<webcface::message::Call>(obj);
             auto func_info =
                 this->func_store.getRecv(this->self_member_name, r.field);
             if (func_info) {
@@ -309,7 +307,7 @@ void internal::ClientData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::call_response: {
-            auto r = std::any_cast<webcface::message::CallResponse>(obj);
+            auto r = std::get<webcface::message::CallResponse>(obj);
             try {
                 this->func_result_store.getResult(r.caller_id)
                     ->setter()
@@ -329,7 +327,7 @@ void internal::ClientData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::call_result: {
-            auto r = std::any_cast<webcface::message::CallResult>(obj);
+            auto r = std::get<webcface::message::CallResult>(obj);
             try {
                 if (r.is_error) {
                     this->func_result_store.getResult(r.caller_id)
@@ -354,7 +352,7 @@ void internal::ClientData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::sync_init: {
-            auto r = std::any_cast<webcface::message::SyncInit>(obj);
+            auto r = std::get<webcface::message::SyncInit>(obj);
             {
                 std::lock_guard lock(this->entry_m);
                 this->member_entry.emplace(r.member_name);
@@ -382,52 +380,58 @@ void internal::ClientData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::entry + MessageKind::value: {
-            auto r = std::any_cast<
-                webcface::message::Entry<webcface::message::Value>>(obj);
+            auto r =
+                std::get<webcface::message::Entry<webcface::message::Value>>(
+                    obj);
             onRecvEntry(this, r, this->value_store, this->value_entry_event);
             break;
         }
         case MessageKind::entry + MessageKind::text: {
-            auto r = std::any_cast<
-                webcface::message::Entry<webcface::message::Text>>(obj);
+            auto r =
+                std::get<webcface::message::Entry<webcface::message::Text>>(
+                    obj);
             onRecvEntry(this, r, this->text_store, this->text_entry_event);
             break;
         }
         case MessageKind::entry + MessageKind::view: {
-            auto r = std::any_cast<
-                webcface::message::Entry<webcface::message::View>>(obj);
+            auto r =
+                std::get<webcface::message::Entry<webcface::message::View>>(
+                    obj);
             onRecvEntry(this, r, this->view_store, this->view_entry_event);
             break;
         }
         case MessageKind::entry + MessageKind::canvas3d: {
-            auto r = std::any_cast<
-                webcface::message::Entry<webcface::message::Canvas3D>>(obj);
+            auto r =
+                std::get<webcface::message::Entry<webcface::message::Canvas3D>>(
+                    obj);
             onRecvEntry(this, r, this->canvas3d_store,
                         this->canvas3d_entry_event);
             break;
         }
         case MessageKind::entry + MessageKind::canvas2d: {
-            auto r = std::any_cast<
-                webcface::message::Entry<webcface::message::Canvas2D>>(obj);
+            auto r =
+                std::get<webcface::message::Entry<webcface::message::Canvas2D>>(
+                    obj);
             onRecvEntry(this, r, this->canvas2d_store,
                         this->canvas2d_entry_event);
             break;
         }
         case MessageKind::entry + MessageKind::robot_model: {
-            auto r = std::any_cast<
+            auto r = std::get<
                 webcface::message::Entry<webcface::message::RobotModel>>(obj);
             onRecvEntry(this, r, this->robot_model_store,
                         this->robot_model_entry_event);
             break;
         }
         case MessageKind::entry + MessageKind::image: {
-            auto r = std::any_cast<
-                webcface::message::Entry<webcface::message::Image>>(obj);
+            auto r =
+                std::get<webcface::message::Entry<webcface::message::Image>>(
+                    obj);
             onRecvEntry(this, r, this->image_store, this->image_entry_event);
             break;
         }
         case MessageKind::func_info: {
-            auto r = std::any_cast<webcface::message::FuncInfo>(obj);
+            auto r = std::get<webcface::message::FuncInfo>(obj);
             auto member = this->getMemberNameFromId(r.member_id);
             this->func_store.setEntry(member, r.field);
             this->func_store.setRecv(member, r.field,

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('webcface', 'c', 'cpp',
-  version: '2.0.3',
+  version: '2.0.4',
   license: 'MIT',
   meson_version: '>=1.3.0',
   default_options: [

--- a/meson.build
+++ b/meson.build
@@ -92,6 +92,9 @@ elif host_machine.system() == 'windows'
   endif
 elif host_machine.system() == 'cygwin'
   summary('System', 'cygwin')
+  if get_option('buildtype') == 'debug'
+    add_project_arguments('-Wa,-mbig-obj', language: ['cpp'])
+  endif
   webcface_system_dllexport = true
   webcface_system_wchar_windows = true
   webcface_system_version_rc = true

--- a/message/include/webcface/message/message.h
+++ b/message/include/webcface/message/message.h
@@ -737,20 +737,11 @@ struct Res<Image> : public MessageBase<MessageKind::image + MessageKind::res>,
                        MSGPACK_NVP("p", cmp_mode_))
 };
 
-using MessageVariant =
-    std::variant<SyncInit, SyncInitEnd, Ping, PingStatus, PingStatusReq, Sync,
-                 Call, CallResponse, CallResult, Value, Text, RobotModel, View,
-                 Canvas3D, Canvas2D, Image, Log, LogReq, FuncInfo, Req<Value>,
-                 Req<Text>, Req<View>, Req<Canvas2D>, Req<Canvas3D>,
-                 Req<RobotModel>, Req<Image>, Entry<Value>, Entry<Text>,
-                 Entry<View>, Entry<Canvas2D>, Entry<Image>, Entry<Canvas3D>,
-                 Entry<RobotModel>, Res<Value>, Res<Text>, Res<RobotModel>,
-                 Res<View>, Res<Canvas3D>, Res<Canvas2D>, Res<Image>>;
 /*!
- * \brief msgpackのメッセージをパースしstd::anyで返す
+ * \brief msgpackのメッセージをパースし返す
  *
  */
-std::vector<std::pair<int, MessageVariant>>
+std::vector<std::pair<int, std::shared_ptr<void>>>
 unpack(const std::string &message,
        const std::shared_ptr<spdlog::logger> &logger);
 

--- a/message/include/webcface/message/message.h
+++ b/message/include/webcface/message/message.h
@@ -16,7 +16,6 @@
 #include <utility>
 #include <vector>
 #include <deque>
-#include <any>
 #include <cstdint>
 #include <spdlog/logger.h>
 #include "webcface/message/u8string.h"
@@ -576,14 +575,6 @@ struct Req : public MessageBase<T::kind + MessageKind::req> {
     MSGPACK_DEFINE_MAP(MSGPACK_NVP("i", req_id), MSGPACK_NVP("M", member),
                        MSGPACK_NVP("f", field))
 };
-#if WEBCFACE_SYSTEM_DLLEXPORT
-extern template struct Req<Value>;
-extern template struct Req<Text>;
-extern template struct Req<View>;
-extern template struct Req<Canvas2D>;
-extern template struct Req<Canvas3D>;
-extern template struct Req<RobotModel>;
-#endif
 struct ImageReq {
     std::optional<int> rows = std::nullopt, cols = std::nullopt;
     std::optional<ImageColorMode> color_mode = std::nullopt;
@@ -628,15 +619,6 @@ struct Entry : public MessageBase<T::kind + MessageKind::entry> {
     SharedString field;
     MSGPACK_DEFINE_MAP(MSGPACK_NVP("m", member_id), MSGPACK_NVP("f", field))
 };
-#if WEBCFACE_SYSTEM_DLLEXPORT
-extern template struct Entry<Value>;
-extern template struct Entry<Text>;
-extern template struct Entry<View>;
-extern template struct Entry<Canvas2D>;
-extern template struct Entry<Image>;
-extern template struct Entry<Canvas3D>;
-extern template struct Entry<RobotModel>;
-#endif
 template <typename T>
 struct Res {};
 /*!
@@ -754,11 +736,21 @@ struct Res<Image> : public MessageBase<MessageKind::image + MessageKind::res>,
                        MSGPACK_NVP("h", height_), MSGPACK_NVP("l", color_mode_),
                        MSGPACK_NVP("p", cmp_mode_))
 };
+
+using MessageVariant =
+    std::variant<SyncInit, SyncInitEnd, Ping, PingStatus, PingStatusReq, Sync,
+                 Call, CallResponse, CallResult, Value, Text, RobotModel, View,
+                 Canvas3D, Canvas2D, Image, Log, LogReq, FuncInfo, Req<Value>,
+                 Req<Text>, Req<View>, Req<Canvas2D>, Req<Canvas3D>,
+                 Req<RobotModel>, Req<Image>, Entry<Value>, Entry<Text>,
+                 Entry<View>, Entry<Canvas2D>, Entry<Image>, Entry<Canvas3D>,
+                 Entry<RobotModel>, Res<Value>, Res<Text>, Res<RobotModel>,
+                 Res<View>, Res<Canvas3D>, Res<Canvas2D>, Res<Image>>;
 /*!
  * \brief msgpackのメッセージをパースしstd::anyで返す
  *
  */
-std::vector<std::pair<int, std::any>>
+std::vector<std::pair<int, MessageVariant>>
 unpack(const std::string &message,
        const std::shared_ptr<spdlog::logger> &logger);
 

--- a/message/src/message.cc
+++ b/message/src/message.cc
@@ -3,20 +3,6 @@
 
 WEBCFACE_NS_BEGIN
 namespace message {
-template struct WEBCFACE_DLL_INSTANCE_DEF Req<Value>;
-template struct WEBCFACE_DLL_INSTANCE_DEF Req<Text>;
-template struct WEBCFACE_DLL_INSTANCE_DEF Req<View>;
-template struct WEBCFACE_DLL_INSTANCE_DEF Req<Canvas2D>;
-template struct WEBCFACE_DLL_INSTANCE_DEF Req<Canvas3D>;
-template struct WEBCFACE_DLL_INSTANCE_DEF Req<RobotModel>;
-template struct WEBCFACE_DLL_INSTANCE_DEF Entry<Value>;
-template struct WEBCFACE_DLL_INSTANCE_DEF Entry<Text>;
-template struct WEBCFACE_DLL_INSTANCE_DEF Entry<View>;
-template struct WEBCFACE_DLL_INSTANCE_DEF Entry<Canvas2D>;
-template struct WEBCFACE_DLL_INSTANCE_DEF Entry<Image>;
-template struct WEBCFACE_DLL_INSTANCE_DEF Entry<Canvas3D>;
-template struct WEBCFACE_DLL_INSTANCE_DEF Entry<RobotModel>;
-
 static void printMsg(const std::shared_ptr<spdlog::logger> &logger,
                      const std::string &message) {
     std::stringstream ss;
@@ -30,11 +16,11 @@ static void printMsg(const std::shared_ptr<spdlog::logger> &logger,
     // }
     // std::cerr << std::endl;
 }
-std::vector<std::pair<int, std::any>>
+std::vector<std::pair<int, MessageVariant>>
 unpack(const std::string &message,
        const std::shared_ptr<spdlog::logger> &logger) {
     if (message.size() == 0) {
-        return std::vector<std::pair<int, std::any>>{};
+        return std::vector<std::pair<int, MessageVariant>>{};
     }
     try {
         msgpack::object_handle result;
@@ -44,12 +30,12 @@ unpack(const std::string &message,
 
         if (obj.type != msgpack::type::ARRAY || obj.via.array.size % 2 != 0) {
             logger->error("unpack error: invalid array length");
-            return std::vector<std::pair<int, std::any>>{};
+            return std::vector<std::pair<int, MessageVariant>>{};
         }
-        std::vector<std::pair<int, std::any>> ret;
+        std::vector<std::pair<int, MessageVariant>> ret;
         for (std::size_t i = 0; i < obj.via.array.size; i += 2) {
             auto kind = obj.via.array.ptr[i].as<int>();
-            std::any obj_u;
+            MessageVariant obj_u;
             switch (kind) {
 
 #define MSG_PARSE(type)                                                        \
@@ -106,7 +92,7 @@ unpack(const std::string &message,
     } catch (const std::exception &e) {
         logger->error("unpack error: {}", e.what());
         printMsg(logger, message);
-        return std::vector<std::pair<int, std::any>>{};
+        return std::vector<std::pair<int, MessageVariant>>{};
     }
 }
 } // namespace message

--- a/server-store/src/member_data.cc
+++ b/server-store/src/member_data.cc
@@ -155,7 +155,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::sync_init: {
-            auto v = std::any_cast<webcface::message::SyncInit>(obj);
+            auto v = std::get<webcface::message::SyncInit>(obj);
             this->name = v.member_name;
             auto member_id_before = this->member_id;
             auto prev_cli_it = std::find_if(
@@ -181,8 +181,8 @@ void MemberData::onRecv(const std::string &message) {
                     this->sink);
                 this->logger->set_level(this->logger_level);
                 this->logger->debug(
-                    "sync_init name={}, member_id={} (before {})", this->name.decode(),
-                    this->member_id, member_id_before);
+                    "sync_init name={}, member_id={} (before {})",
+                    this->name.decode(), this->member_id, member_id_before);
                 this->logger->info("successfully connected and initialized.");
                 // 全クライアントに新しいMemberを通知
                 store->forEach([&](auto cd) {
@@ -283,7 +283,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::sync: {
-            auto v = std::any_cast<webcface::message::Sync>(obj);
+            auto v = std::get<webcface::message::Sync>(obj);
             v.member_id = this->member_id;
             logger->debug("sync");
             // 1つ以上リクエストしているクライアントにはsyncの情報を流す
@@ -296,7 +296,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::call: {
-            auto v = std::any_cast<webcface::message::Call>(obj);
+            auto v = std::get<webcface::message::Call>(obj);
             v.caller_member_id = this->member_id;
             logger->debug(
                 "call caller_id={}, target_id={}, field={}, with {} args",
@@ -322,7 +322,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::call_response: {
-            auto v = std::any_cast<webcface::message::CallResponse>(obj);
+            auto v = std::get<webcface::message::CallResponse>(obj);
             logger->debug("call_response to (member_id {}, caller_id {}), {}",
                           v.caller_member_id, v.caller_id, v.started);
             this->pending_calls[v.caller_member_id][v.caller_id] = 1;
@@ -336,7 +336,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::call_result: {
-            auto v = std::any_cast<webcface::message::CallResult>(obj);
+            auto v = std::get<webcface::message::CallResult>(obj);
             logger->debug(
                 "call_result to (member_id {}, caller_id {}), {} as {}",
                 v.caller_member_id, v.caller_id,
@@ -355,7 +355,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::value: {
-            auto v = std::any_cast<webcface::message::Value>(obj);
+            auto v = std::get<webcface::message::Value>(obj);
             if (v.data->size() == 1) {
                 logger->debug("value {} = {}", v.field.decode(), (*v.data)[0]);
             } else {
@@ -391,7 +391,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::text: {
-            auto v = std::any_cast<webcface::message::Text>(obj);
+            auto v = std::get<webcface::message::Text>(obj);
             logger->debug("text {} = {}", v.field.decode(),
                           static_cast<std::string>(*v.data));
             if (!this->text.count(v.field) &&
@@ -424,7 +424,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::robot_model: {
-            auto v = std::any_cast<webcface::message::RobotModel>(obj);
+            auto v = std::get<webcface::message::RobotModel>(obj);
             logger->debug("robot model {}", v.field.decode());
             if (!this->robot_model.count(v.field) &&
                 !v.field.startsWith(field_separator)) {
@@ -457,7 +457,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::view: {
-            auto v = std::any_cast<webcface::message::View>(obj);
+            auto v = std::get<webcface::message::View>(obj);
             logger->debug("view {} diff={}, length={}", v.field.decode(),
                           v.data_diff.size(), v.length);
             if (!this->view.count(v.field) &&
@@ -492,7 +492,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::canvas3d: {
-            auto v = std::any_cast<webcface::message::Canvas3D>(obj);
+            auto v = std::get<webcface::message::Canvas3D>(obj);
             logger->debug("canvas3d {} diff={}, length={}", v.field.decode(),
                           v.data_diff.size(), v.length);
             if (!this->canvas3d.count(v.field) &&
@@ -528,7 +528,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::canvas2d: {
-            auto v = std::any_cast<webcface::message::Canvas2D>(obj);
+            auto v = std::get<webcface::message::Canvas2D>(obj);
             logger->debug("canvas2d {} diff={}, length={}", v.field.decode(),
                           v.data_diff.size(), v.length);
             if (!this->canvas2d.count(v.field) &&
@@ -568,7 +568,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::image: {
-            auto v = std::any_cast<webcface::message::Image>(obj);
+            auto v = std::get<webcface::message::Image>(obj);
             logger->debug("image {} ({} x {})", v.field.decode(), v.width_,
                           v.height_);
             if (!this->image.count(v.field) &&
@@ -602,7 +602,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::log: {
-            auto v = std::any_cast<webcface::message::Log>(obj);
+            auto v = std::get<webcface::message::Log>(obj);
             v.member_id = this->member_id;
             logger->debug("log {} lines", v.log->size());
             if (store->keep_log >= 0 &&
@@ -632,7 +632,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::func_info: {
-            auto v = std::any_cast<webcface::message::FuncInfo>(obj);
+            auto v = std::get<webcface::message::FuncInfo>(obj);
             v.member_id = this->member_id;
             logger->debug("func_info {}", v.field.decode());
             if (!this->func.count(v.field) &&
@@ -650,8 +650,7 @@ void MemberData::onRecv(const std::string &message) {
         }
         case MessageKind::req + MessageKind::value: {
             auto s =
-                std::any_cast<webcface::message::Req<webcface::message::Value>>(
-                    obj);
+                std::get<webcface::message::Req<webcface::message::Value>>(obj);
             logger->debug("request value ({}): {} from {}", s.req_id,
                           s.field.decode(), s.member.decode());
             // 指定した値を返す
@@ -685,8 +684,7 @@ void MemberData::onRecv(const std::string &message) {
         }
         case MessageKind::req + MessageKind::text: {
             auto s =
-                std::any_cast<webcface::message::Req<webcface::message::Text>>(
-                    obj);
+                std::get<webcface::message::Req<webcface::message::Text>>(obj);
             logger->debug("request text ({}): {} from {}", s.req_id,
                           s.field.decode(), s.member.decode());
             // 指定した値を返す
@@ -720,8 +718,9 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::req + MessageKind::robot_model: {
-            auto s = std::any_cast<
-                webcface::message::Req<webcface::message::RobotModel>>(obj);
+            auto s =
+                std::get<webcface::message::Req<webcface::message::RobotModel>>(
+                    obj);
             logger->debug("request robot_model ({}): {} from {}", s.req_id,
                           s.field.decode(), s.member.decode());
             // 指定した値を返す
@@ -755,8 +754,7 @@ void MemberData::onRecv(const std::string &message) {
         }
         case MessageKind::req + MessageKind::view: {
             auto s =
-                std::any_cast<webcface::message::Req<webcface::message::View>>(
-                    obj);
+                std::get<webcface::message::Req<webcface::message::View>>(obj);
             logger->debug("request view ({}): {} from {}", s.req_id,
                           s.field.decode(), s.member.decode());
             // 指定した値を返す
@@ -796,8 +794,9 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::req + MessageKind::canvas3d: {
-            auto s = std::any_cast<
-                webcface::message::Req<webcface::message::Canvas3D>>(obj);
+            auto s =
+                std::get<webcface::message::Req<webcface::message::Canvas3D>>(
+                    obj);
             logger->debug("request canvas3d ({}): {} from {}", s.req_id,
                           s.field.decode(), s.member.decode());
             // 指定した値を返す
@@ -837,8 +836,9 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::req + MessageKind::canvas2d: {
-            auto s = std::any_cast<
-                webcface::message::Req<webcface::message::Canvas2D>>(obj);
+            auto s =
+                std::get<webcface::message::Req<webcface::message::Canvas2D>>(
+                    obj);
             logger->debug("request canvas2d ({}): {} from {}", s.req_id,
                           s.field.decode(), s.member.decode());
             // 指定した値を返す
@@ -883,8 +883,7 @@ void MemberData::onRecv(const std::string &message) {
         }
         case MessageKind::req + MessageKind::image: {
             auto s =
-                std::any_cast<webcface::message::Req<webcface::message::Image>>(
-                    obj);
+                std::get<webcface::message::Req<webcface::message::Image>>(obj);
             logger->debug("request image ({}): {} from {}, {} x {}, color={}, "
                           "mode={}, q={}, fps={}",
                           s.req_id, s.field.decode(), s.member.decode(),
@@ -909,7 +908,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::log_req: {
-            auto s = std::any_cast<webcface::message::LogReq>(obj);
+            auto s = std::get<webcface::message::LogReq>(obj);
             logger->debug("request log from {}", s.member.decode());
             log_req.insert(s.member);
             // 指定した値を返す

--- a/server-store/src/member_data.cc
+++ b/server-store/src/member_data.cc
@@ -155,7 +155,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::sync_init: {
-            auto v = std::get<webcface::message::SyncInit>(obj);
+            auto &v = *static_cast<webcface::message::SyncInit *>(obj.get());
             this->name = v.member_name;
             auto member_id_before = this->member_id;
             auto prev_cli_it = std::find_if(
@@ -283,7 +283,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::sync: {
-            auto v = std::get<webcface::message::Sync>(obj);
+            auto &v = *static_cast<webcface::message::Sync *>(obj.get());
             v.member_id = this->member_id;
             logger->debug("sync");
             // 1つ以上リクエストしているクライアントにはsyncの情報を流す
@@ -296,7 +296,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::call: {
-            auto v = std::get<webcface::message::Call>(obj);
+            auto &v = *static_cast<webcface::message::Call *>(obj.get());
             v.caller_member_id = this->member_id;
             logger->debug(
                 "call caller_id={}, target_id={}, field={}, with {} args",
@@ -322,7 +322,8 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::call_response: {
-            auto v = std::get<webcface::message::CallResponse>(obj);
+            auto &v =
+                *static_cast<webcface::message::CallResponse *>(obj.get());
             logger->debug("call_response to (member_id {}, caller_id {}), {}",
                           v.caller_member_id, v.caller_id, v.started);
             this->pending_calls[v.caller_member_id][v.caller_id] = 1;
@@ -336,7 +337,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::call_result: {
-            auto v = std::get<webcface::message::CallResult>(obj);
+            auto &v = *static_cast<webcface::message::CallResult *>(obj.get());
             logger->debug(
                 "call_result to (member_id {}, caller_id {}), {} as {}",
                 v.caller_member_id, v.caller_id,
@@ -355,7 +356,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::value: {
-            auto v = std::get<webcface::message::Value>(obj);
+            auto &v = *static_cast<webcface::message::Value *>(obj.get());
             if (v.data->size() == 1) {
                 logger->debug("value {} = {}", v.field.decode(), (*v.data)[0]);
             } else {
@@ -391,7 +392,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::text: {
-            auto v = std::get<webcface::message::Text>(obj);
+            auto &v = *static_cast<webcface::message::Text *>(obj.get());
             logger->debug("text {} = {}", v.field.decode(),
                           static_cast<std::string>(*v.data));
             if (!this->text.count(v.field) &&
@@ -424,7 +425,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::robot_model: {
-            auto v = std::get<webcface::message::RobotModel>(obj);
+            auto &v = *static_cast<webcface::message::RobotModel *>(obj.get());
             logger->debug("robot model {}", v.field.decode());
             if (!this->robot_model.count(v.field) &&
                 !v.field.startsWith(field_separator)) {
@@ -457,7 +458,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::view: {
-            auto v = std::get<webcface::message::View>(obj);
+            auto &v = *static_cast<webcface::message::View *>(obj.get());
             logger->debug("view {} diff={}, length={}", v.field.decode(),
                           v.data_diff.size(), v.length);
             if (!this->view.count(v.field) &&
@@ -492,7 +493,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::canvas3d: {
-            auto v = std::get<webcface::message::Canvas3D>(obj);
+            auto &v = *static_cast<webcface::message::Canvas3D *>(obj.get());
             logger->debug("canvas3d {} diff={}, length={}", v.field.decode(),
                           v.data_diff.size(), v.length);
             if (!this->canvas3d.count(v.field) &&
@@ -528,7 +529,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::canvas2d: {
-            auto v = std::get<webcface::message::Canvas2D>(obj);
+            auto &v = *static_cast<webcface::message::Canvas2D *>(obj.get());
             logger->debug("canvas2d {} diff={}, length={}", v.field.decode(),
                           v.data_diff.size(), v.length);
             if (!this->canvas2d.count(v.field) &&
@@ -568,7 +569,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::image: {
-            auto v = std::get<webcface::message::Image>(obj);
+            auto &v = *static_cast<webcface::message::Image *>(obj.get());
             logger->debug("image {} ({} x {})", v.field.decode(), v.width_,
                           v.height_);
             if (!this->image.count(v.field) &&
@@ -602,7 +603,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::log: {
-            auto v = std::get<webcface::message::Log>(obj);
+            auto &v = *static_cast<webcface::message::Log *>(obj.get());
             v.member_id = this->member_id;
             logger->debug("log {} lines", v.log->size());
             if (store->keep_log >= 0 &&
@@ -632,7 +633,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::func_info: {
-            auto v = std::get<webcface::message::FuncInfo>(obj);
+            auto &v = *static_cast<webcface::message::FuncInfo *>(obj.get());
             v.member_id = this->member_id;
             logger->debug("func_info {}", v.field.decode());
             if (!this->func.count(v.field) &&
@@ -649,8 +650,8 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::req + MessageKind::value: {
-            auto s =
-                std::get<webcface::message::Req<webcface::message::Value>>(obj);
+            auto &s = *static_cast<
+                webcface::message::Req<webcface::message::Value> *>(obj.get());
             logger->debug("request value ({}): {} from {}", s.req_id,
                           s.field.decode(), s.member.decode());
             // 指定した値を返す
@@ -683,8 +684,9 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::req + MessageKind::text: {
-            auto s =
-                std::get<webcface::message::Req<webcface::message::Text>>(obj);
+            auto &s =
+                *static_cast<webcface::message::Req<webcface::message::Text> *>(
+                    obj.get());
             logger->debug("request text ({}): {} from {}", s.req_id,
                           s.field.decode(), s.member.decode());
             // 指定した値を返す
@@ -718,9 +720,9 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::req + MessageKind::robot_model: {
-            auto s =
-                std::get<webcface::message::Req<webcface::message::RobotModel>>(
-                    obj);
+            auto &s = *static_cast<
+                webcface::message::Req<webcface::message::RobotModel> *>(
+                obj.get());
             logger->debug("request robot_model ({}): {} from {}", s.req_id,
                           s.field.decode(), s.member.decode());
             // 指定した値を返す
@@ -753,8 +755,9 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::req + MessageKind::view: {
-            auto s =
-                std::get<webcface::message::Req<webcface::message::View>>(obj);
+            auto &s =
+                *static_cast<webcface::message::Req<webcface::message::View> *>(
+                    obj.get());
             logger->debug("request view ({}): {} from {}", s.req_id,
                           s.field.decode(), s.member.decode());
             // 指定した値を返す
@@ -794,9 +797,9 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::req + MessageKind::canvas3d: {
-            auto s =
-                std::get<webcface::message::Req<webcface::message::Canvas3D>>(
-                    obj);
+            auto &s = *static_cast<
+                webcface::message::Req<webcface::message::Canvas3D> *>(
+                obj.get());
             logger->debug("request canvas3d ({}): {} from {}", s.req_id,
                           s.field.decode(), s.member.decode());
             // 指定した値を返す
@@ -836,9 +839,9 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::req + MessageKind::canvas2d: {
-            auto s =
-                std::get<webcface::message::Req<webcface::message::Canvas2D>>(
-                    obj);
+            auto &s = *static_cast<
+                webcface::message::Req<webcface::message::Canvas2D> *>(
+                obj.get());
             logger->debug("request canvas2d ({}): {} from {}", s.req_id,
                           s.field.decode(), s.member.decode());
             // 指定した値を返す
@@ -882,8 +885,8 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::req + MessageKind::image: {
-            auto s =
-                std::get<webcface::message::Req<webcface::message::Image>>(obj);
+            auto &s = *static_cast<
+                webcface::message::Req<webcface::message::Image> *>(obj.get());
             logger->debug("request image ({}): {} from {}, {} x {}, color={}, "
                           "mode={}, q={}, fps={}",
                           s.req_id, s.field.decode(), s.member.decode(),
@@ -908,7 +911,7 @@ void MemberData::onRecv(const std::string &message) {
             break;
         }
         case MessageKind::log_req: {
-            auto s = std::get<webcface::message::LogReq>(obj);
+            auto &s = *static_cast<webcface::message::LogReq *>(obj.get());
             logger->debug("request log from {}", s.member.decode());
             log_req.insert(s.member);
             // 指定した値を返す

--- a/tests/dummy_client.h
+++ b/tests/dummy_client.h
@@ -1,5 +1,4 @@
 #include "webcface/message/message.h"
-#include <any>
 #include <vector>
 #include <utility>
 #include <thread>
@@ -7,7 +6,7 @@
 
 using namespace webcface;
 struct DummyClient {
-    std::vector<std::pair<int, std::any>> recv_data;
+    std::vector<std::pair<int, message::MessageVariant>> recv_data;
 
     // clientからT型のメッセージを受信していればf1, そうでなければf2を実行する
     template <typename T, typename F1, typename F2>
@@ -15,7 +14,7 @@ struct DummyClient {
         std::lock_guard lock(client_m);
         for (const auto &m : recv_data) {
             if (m.first == T::kind) {
-                on_ok(std::any_cast<T>(m.second));
+                on_ok(std::get<T>(m.second));
                 return;
             }
         }
@@ -29,7 +28,7 @@ struct DummyClient {
                 std::lock_guard lock(client_m);
                 for (const auto &m : recv_data) {
                     if (m.first == T::kind) {
-                        on_ok(std::any_cast<T>(m.second));
+                        on_ok(std::get<T>(m.second));
                         return;
                     }
                 }

--- a/tests/dummy_client.h
+++ b/tests/dummy_client.h
@@ -6,7 +6,7 @@
 
 using namespace webcface;
 struct DummyClient {
-    std::vector<std::pair<int, message::MessageVariant>> recv_data;
+    std::vector<std::pair<int, std::shared_ptr<void>>> recv_data;
 
     // clientからT型のメッセージを受信していればf1, そうでなければf2を実行する
     template <typename T, typename F1, typename F2>
@@ -14,7 +14,7 @@ struct DummyClient {
         std::lock_guard lock(client_m);
         for (const auto &m : recv_data) {
             if (m.first == T::kind) {
-                on_ok(std::get<T>(m.second));
+                on_ok(*static_cast<T*>(m.second.get()));
                 return;
             }
         }
@@ -28,7 +28,7 @@ struct DummyClient {
                 std::lock_guard lock(client_m);
                 for (const auto &m : recv_data) {
                     if (m.first == T::kind) {
-                        on_ok(std::get<T>(m.second));
+                        on_ok(*static_cast<T*>(m.second.get()));
                         return;
                     }
                 }

--- a/tests/dummy_server.h
+++ b/tests/dummy_server.h
@@ -1,5 +1,4 @@
 #include "webcface/message/message.h"
-#include <any>
 #include <vector>
 #include <utility>
 #include <thread>
@@ -7,7 +6,7 @@
 
 using namespace webcface;
 struct DummyServer {
-    std::vector<std::pair<int, std::any>> recv_data;
+    std::vector<std::pair<int, message::MessageVariant>> recv_data;
 
     // clientからT型のメッセージを受信していればf1, そうでなければf2を実行する
     template <typename T, typename F1, typename F2>
@@ -15,7 +14,7 @@ struct DummyServer {
         std::lock_guard lock(server_m);
         for (const auto &m : recv_data) {
             if (m.first == T::kind) {
-                on_ok(std::any_cast<T>(m.second));
+                on_ok(std::get<T>(m.second));
                 return;
             }
         }
@@ -29,7 +28,7 @@ struct DummyServer {
                 std::lock_guard lock(server_m);
                 for (const auto &m : recv_data) {
                     if (m.first == T::kind) {
-                        on_ok(std::any_cast<T>(m.second));
+                        on_ok(std::get<T>(m.second));
                         return;
                     }
                 }

--- a/tests/dummy_server.h
+++ b/tests/dummy_server.h
@@ -6,7 +6,7 @@
 
 using namespace webcface;
 struct DummyServer {
-    std::vector<std::pair<int, message::MessageVariant>> recv_data;
+    std::vector<std::pair<int, std::shared_ptr<void>>> recv_data;
 
     // clientからT型のメッセージを受信していればf1, そうでなければf2を実行する
     template <typename T, typename F1, typename F2>
@@ -14,7 +14,7 @@ struct DummyServer {
         std::lock_guard lock(server_m);
         for (const auto &m : recv_data) {
             if (m.first == T::kind) {
-                on_ok(std::get<T>(m.second));
+                on_ok(*static_cast<T*>(m.second.get()));
                 return;
             }
         }
@@ -28,7 +28,7 @@ struct DummyServer {
                 std::lock_guard lock(server_m);
                 for (const auto &m : recv_data) {
                     if (m.first == T::kind) {
-                        on_ok(std::get<T>(m.second));
+                        on_ok(*static_cast<T*>(m.second.get()));
                         return;
                     }
                 }


### PR DESCRIPTION
macosのuniversalビルドでのみなぜかstd::bad_any_castになることがあってよくわからないので、anyをやめる
