### PR TITLE
ClientData内のmutexをかける必要があるメンバーをstructにまとめた

### DIFF
--- a/client/include/webcface/internal/client_internal.h
+++ b/client/include/webcface/internal/client_internal.h
@@ -72,60 +72,6 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
     //  */
     // std::thread sync_thread;
 
-    /*!
-     * \brief ws_thread, recv_thread, queue 間の同期
-     *
-     * closing, connected, do_ws_init, do_ws_recv,
-     * sync_queue, recv_queue, sync_init_end が変化した時notifyする
-     *
-     */
-    std::condition_variable ws_cond;
-    std::mutex ws_m;
-    /*!
-     * close()が呼ばれたらtrue、すべてのスレッドは停止する
-     */
-    std::atomic<bool> closing = false;
-    /*!
-     * current_curl_connectedがWebSocket::initまたはrecv側の内部で変更されるので、
-     * それを呼び出したスレッドがそれをこっちに反映させる
-     */
-    bool connected = false;
-    /*!
-     * SyncInitEndを受信したらtrue
-     * 切断時にfalseにもどす
-     */
-    bool sync_init_end = false;
-    /*!
-     * Client側から関数が呼ばれたらtrue、
-     * WebSocket::側のinit関数が完了したらfalse
-     *
-     * trueになったときnotify
-     */
-    bool do_ws_init = false;
-    /*!
-     * Client側から関数が呼ばれたらtrue、
-     * WebSocket::側のrecv関数が完了したらfalse
-     *
-     * true,falseになったときnotify
-     *
-     * recv_readyの間にdo_ws_recvを立て、
-     * recv()を行い、これがfalseになったことで完了したことを知る
-     */
-    bool do_ws_recv = false;
-    /*!
-     * recv待機中true
-     * WebSocket::側のrecv関数が完了したらfalse
-     */
-    bool recv_ready = false;
-
-
-    /*!
-     * ただの設定フラグなのでmutexやcondとは無関係
-     */
-    std::atomic<bool> auto_reconnect = true;
-
-    std::queue<std::vector<std::pair<int, std::shared_ptr<void>>>> recv_queue;
-
     struct SyncDataSnapshot {
         std::chrono::system_clock::time_point time;
         StrMap1<ValueData> value_data;
@@ -138,18 +84,6 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
         std::vector<LogLineData> log_data;
         StrMap1<FuncData> func_data;
     };
-    /*!
-     * \brief 送信したいメッセージを入れるキュー
-     *
-     * 接続できていない場合送信されずキューにたまる
-     *
-     * msgpackのシリアライズに時間がかかるので、
-     * sync()時はシリアライズ後のメッセージではなく
-     * 必要なデータを含んだSyncDataSnapshotをpushし(syncData()),
-     * あとで別スレッドでそれをメッセージにする (packSyncData())
-     *
-     */
-    std::queue<std::variant<std::string, SyncDataSnapshot>> sync_queue;
 
     struct SyncDataFirst {
         StrMap2<unsigned int> value_req, text_req, robot_model_req, view_req,
@@ -159,36 +93,178 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
         bool ping_status_req;
         SyncDataSnapshot sync_data;
     };
-    /*!
-     * 次回接続後一番最初に送信するメッセージ
-     *
-     * * syncDataFirst() の返り値であり、
-     * すべてのリクエストとすべてのsyncデータ(1時刻分)が含まれる
-     * * sync()時に未接続かつこれが空ならその時点のsyncDataFirstをこれにセット
-     * * 接続時にこれが空でなければ、
-     *   * これ + sync_queueの中身(=syncDataFirst以降のすべてのsync()データ)
-     * を、
-     *   * これが空ならその時点のsyncDataFirstを、
-     * * 送信する
-     * * <del>送信したら</del> 切断時に再度これを空にする
-     */
-    std::optional<SyncDataFirst> sync_first;
 
     /*!
-     * sync_firstとsyncData(),syncDataFirst()呼び出しをガードするmutex
+     * close()が呼ばれたらtrue、すべてのスレッドは停止する
+     */
+    std::atomic<bool> closing = false;
+
+    struct WsMutexedData {
+        /*!
+         * current_curl_connectedがWebSocket::initまたはrecv側の内部で変更されるので、
+         * それを呼び出したスレッドがそれをこっちに反映させる
+         */
+        bool connected = false;
+        /*!
+         * SyncInitEndを受信したらtrue
+         * 切断時にfalseにもどす
+         */
+        bool sync_init_end = false;
+        /*!
+         * Client側から関数が呼ばれたらtrue、
+         * WebSocket::側のinit関数が完了したらfalse
+         *
+         * trueになったときnotify
+         */
+        bool do_ws_init = false;
+        /*!
+         * Client側から関数が呼ばれたらtrue、
+         * WebSocket::側のrecv関数が完了したらfalse
+         *
+         * true,falseになったときnotify
+         *
+         * recv_readyの間にdo_ws_recvを立て、
+         * recv()を行い、これがfalseになったことで完了したことを知る
+         */
+        bool do_ws_recv = false;
+        /*!
+         * recv待機中true
+         * WebSocket::側のrecv関数が完了したらfalse
+         */
+        bool recv_ready = false;
+
+        std::queue<std::vector<std::pair<int, std::shared_ptr<void>>>>
+            recv_queue;
+        /*!
+         * \brief 送信したいメッセージを入れるキュー
+         *
+         * 接続できていない場合送信されずキューにたまる
+         *
+         * msgpackのシリアライズに時間がかかるので、
+         * sync()時はシリアライズ後のメッセージではなく
+         * 必要なデータを含んだSyncDataSnapshotをpushし(syncData()),
+         * あとで別スレッドでそれをメッセージにする (packSyncData())
+         *
+         * 変更するときはws_mをロックしws_condで変更通知をする
+         * (sync_mはロックしない)
+         */
+        std::queue<std::variant<std::string, SyncDataSnapshot>> sync_queue;
+    };
+
+  private:
+    WsMutexedData ws_data;
+    std::mutex ws_m;
+
+  public:
+    /*!
+     * \brief ws_thread, recv_thread, queue 間の同期
+     *
+     * ws_dataの中身
+     * (closing, connected, do_ws_init, do_ws_recv,
+     *  sync_queue, recv_queue, sync_init_end)
+     * が変化した時notifyする
+     *
+     */
+    std::condition_variable ws_cond;
+
+    /*!
+     * std::unique_lockのように使い、lockしている間だけWsMutexedDataにアクセスできる
+     */
+    class ScopedWsLock : public std::unique_lock<std::mutex> {
+        ClientData *data;
+
+      public:
+        explicit ScopedWsLock(ClientData *data)
+            : std::unique_lock<std::mutex>(data->ws_m), data(data) {}
+        explicit ScopedWsLock(const std::shared_ptr<ClientData> &data)
+            : ScopedWsLock(data.get()) {}
+        auto &getData() {
+            assert(this->owns_lock());
+            return data->ws_data;
+        }
+    };
+
+    /*!
+     * ただの設定フラグなのでmutexやcondとは無関係
+     */
+    std::atomic<bool> auto_reconnect = true;
+
+    struct SyncMutexedData {
+        /*!
+         * 次回接続後一番最初に送信するメッセージ
+         *
+         * * syncDataFirst() の返り値であり、
+         * すべてのリクエストとすべてのsyncデータ(1時刻分)が含まれる
+         * * sync()時に未接続かつこれが空ならその時点のsyncDataFirstをこれにセット
+         * * 接続時にこれが空でなければ、
+         *   * これ + sync_queueの中身(=syncDataFirst以降のすべてのsync()データ)
+         * を、
+         *   * これが空ならその時点のsyncDataFirstを、
+         * * 送信する
+         * * <del>送信したら</del> 切断時に再度これを空にする
+         */
+        std::optional<SyncDataFirst> sync_first;
+        /*!
+         * \brief 初期化時に送信するメッセージ
+         *
+         * 各種req と syncData(true) の全データが含まれる。
+         *
+         * 変数 sync_first の説明を参照
+         *
+         */
+        SyncDataFirst syncDataFirst(internal::ClientData *this_);
+        /*!
+         * \brief sync() 1回分のメッセージ
+         *
+         * value, text, view, log, funcの送信データの前回からの差分が含まれる。
+         * 各種reqはsyncとは無関係に送信される
+         *
+         * \param is_first trueのとき差分ではなく全データを送る
+         * (syncDataFirst()内から呼ばれる)
+         *
+         */
+        SyncDataSnapshot syncData(internal::ClientData *this_, bool is_first);
+    };
+
+  private:
+    SyncMutexedData sync_data;
+    /*!
+     * sync_first,syncData(),syncDataFirst()呼び出しをガードするmutex
+     *
+     * ws_mとsync_mを両方同時にロックすることがないようにする
+     *
+     * sync_queueへのpush時にはこれではなくws_mのロックが必要 (ややこしい)
      */
     std::mutex sync_m;
+
+  public:
+    /*!
+     * std::unique_lockのように使い、lockしている間だけSyncMutexedDataにアクセスできる
+     */
+    class ScopedSyncLock : public std::unique_lock<std::mutex> {
+        ClientData *data;
+
+      public:
+        explicit ScopedSyncLock(ClientData *data)
+            : std::unique_lock<std::mutex>(data->sync_m), data(data) {}
+        explicit ScopedSyncLock(const std::shared_ptr<ClientData> &data)
+            : ScopedSyncLock(data.get()) {}
+        auto &getData() {
+            assert(this->owns_lock());
+            return data->sync_data;
+        }
+    };
 
     /*!
      * 接続中の場合メッセージをキューに入れtrueを返し、
      * 接続していない場合なにもせずfalseを返す
-     * 
+     *
      * Call, Pingなど
      */
     bool messagePushOnline(std::string &&msg) {
-        std::lock_guard lock(this->ws_m);
-        if (this->connected) {
-            this->sync_queue.push(std::move(msg));
+        ScopedWsLock lock_ws(this);
+        if (lock_ws.getData().connected) {
+            lock_ws.getData().sync_queue.push(std::move(msg));
             this->ws_cond.notify_all();
             return true;
         } else {
@@ -202,9 +278,14 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
      * Reqはsync_first時にすべて含まれるので。
      */
     bool messagePushReq(std::string &&msg) {
-        std::lock_guard lock(this->sync_m);
-        if (this->sync_first) {
-            this->sync_queue.push(std::move(msg));
+        bool has_sync_first;
+        {
+            ScopedSyncLock lock_s(this);
+            has_sync_first = (lock_s.getData().sync_first != std::nullopt);
+        }
+        if (has_sync_first) {
+            ScopedWsLock lock_ws(this);
+            lock_ws.getData().sync_queue.push(std::move(msg));
             this->ws_cond.notify_all();
             return true;
         } else {
@@ -217,15 +298,19 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
      * syncで確実に送信するデータに使う。
      */
     void messagePushAlways(std::string &&msg) {
-        std::lock_guard lock(this->ws_m);
-        this->sync_queue.push(std::move(msg));
+        ScopedWsLock lock_ws(this);
+        lock_ws.getData().sync_queue.push(std::move(msg));
         this->ws_cond.notify_all();
     }
     void messagePushAlways(SyncDataSnapshot &&msg) {
-        std::lock_guard lock(this->ws_m);
-        this->sync_queue.push(std::move(msg));
+        ScopedWsLock lock_ws(this);
+        lock_ws.getData().sync_queue.push(std::move(msg));
         this->ws_cond.notify_all();
     }
+
+    std::string packSyncDataFirst(const SyncDataFirst &data);
+    std::string packSyncData(std::stringstream &buffer, int &len,
+                             const SyncDataSnapshot &data);
 
     /*!
      * \brief 通信関係のスレッドを開始する
@@ -249,29 +334,6 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
     void syncImpl(bool sync, bool forever,
                   std::optional<std::chrono::microseconds> timeout);
 
-    /*!
-     * \brief 初期化時に送信するメッセージ
-     *
-     * 各種req と syncData(true) の全データが含まれる。
-     *
-     * 変数 sync_first の説明を参照
-     *
-     */
-    SyncDataFirst syncDataFirst();
-    std::string packSyncDataFirst(const SyncDataFirst &data);
-    /*!
-     * \brief sync() 1回分のメッセージ
-     *
-     * value, text, view, log, funcの送信データの前回からの差分が含まれる。
-     * 各種reqはsyncとは無関係に送信される
-     *
-     * \param is_first trueのとき差分ではなく全データを送る
-     * (syncDataFirst()内から呼ばれる)
-     *
-     */
-    SyncDataSnapshot syncData(bool is_first);
-    std::string packSyncData(std::stringstream &buffer, int &len,
-                             const SyncDataSnapshot &data);
     /*!
      * \brief 受信時の処理
      *

--- a/client/src/client_msg_recv.cc
+++ b/client/src/client_msg_recv.cc
@@ -81,8 +81,8 @@ void internal::ClientData::onRecv(
             this->self_member_id.emplace(r.member_id);
             this->svr_hostname = r.hostname;
             {
-                std::lock_guard lock(this->ws_m);
-                this->sync_init_end = true;
+                ScopedWsLock lock_ws(this);
+                lock_ws.getData().sync_init_end = true;
                 this->ws_cond.notify_all();
             }
             break;

--- a/client/src/client_msg_sync.cc
+++ b/client/src/client_msg_sync.cc
@@ -7,35 +7,35 @@ WEBCFACE_NS_BEGIN
 
 void internal::ClientData::pingStatusReq() {
     if (!ping_status_req) {
-        std::lock_guard lock(ws_m);
-        sync_queue.push(message::packSingle(message::PingStatusReq{}));
-        ws_cond.notify_all();
+        this->messagePushReq(message::packSingle(message::PingStatusReq{}));
     }
     ping_status_req = true;
 }
 
-internal::ClientData::SyncDataFirst internal::ClientData::syncDataFirst() {
+internal::ClientData::SyncDataFirst
+internal::ClientData::SyncMutexedData::syncDataFirst(
+    internal::ClientData *this_) {
 
     SyncDataFirst data;
-    data.value_req = value_store.transferReq();
-    data.text_req = text_store.transferReq();
-    data.view_req = view_store.transferReq();
-    data.robot_model_req = robot_model_store.transferReq();
-    data.canvas3d_req = canvas3d_store.transferReq();
-    data.canvas2d_req = canvas2d_store.transferReq();
+    data.value_req = this_->value_store.transferReq();
+    data.text_req = this_->text_store.transferReq();
+    data.view_req = this_->view_store.transferReq();
+    data.robot_model_req = this_->robot_model_store.transferReq();
+    data.canvas3d_req = this_->canvas3d_store.transferReq();
+    data.canvas2d_req = this_->canvas2d_store.transferReq();
     {
-        std::lock_guard image_lock(image_store.mtx);
-        data.image_req = image_store.transferReq();
+        std::lock_guard image_lock(this_->image_store.mtx);
+        data.image_req = this_->image_store.transferReq();
         for (const auto &v : data.image_req) {
             for (const auto &v2 : v.second) {
                 data.image_req_info[v.first][v2.first] =
-                    image_store.getReqInfo(v.first, v2.first);
+                    this_->image_store.getReqInfo(v.first, v2.first);
             }
         }
     }
-    data.log_req = log_store.transferReq();
-    data.ping_status_req = ping_status_req;
-    data.sync_data = syncData(true);
+    data.log_req = this_->log_store.transferReq();
+    data.ping_status_req = this_->ping_status_req;
+    data.sync_data = syncData(this_, true);
 
     return data;
 }
@@ -108,53 +108,55 @@ std::string internal::ClientData::packSyncDataFirst(const SyncDataFirst &data) {
     return packSyncData(buffer, len, data.sync_data);
 }
 internal::ClientData::SyncDataSnapshot
-internal::ClientData::syncData(bool is_first) {
+internal::ClientData::SyncMutexedData::syncData(internal::ClientData *this_,
+                                                bool is_first) {
 
     SyncDataSnapshot data;
     data.time = std::chrono::system_clock::now();
 
-    // std::lock_guard value_lock(value_store.mtx);
-    data.value_data = value_store.transferSend(is_first);
-    // std::lock_guard text_lock(text_store.mtx);
-    data.text_data = text_store.transferSend(is_first);
-    // std::lock_guard robot_model_lock(robot_model_store.mtx);
-    data.robot_model_data = robot_model_store.transferSend(is_first);
+    // std::lock_guard value_lock(this_->value_store.mtx);
+    data.value_data = this_->value_store.transferSend(is_first);
+    // std::lock_guard text_lock(this_->text_store.mtx);
+    data.text_data = this_->text_store.transferSend(is_first);
+    // std::lock_guard robot_model_lock(this_->robot_model_store.mtx);
+    data.robot_model_data = this_->robot_model_store.transferSend(is_first);
     {
-        std::lock_guard view_lock(view_store.mtx);
-        data.view_prev = view_store.getSendPrev(is_first);
-        data.view_data = view_store.transferSend(is_first);
+        std::lock_guard view_lock(this_->view_store.mtx);
+        data.view_prev = this_->view_store.getSendPrev(is_first);
+        data.view_data = this_->view_store.transferSend(is_first);
     }
     {
-        std::lock_guard canvas3d_lock(canvas3d_store.mtx);
-        data.canvas3d_prev = canvas3d_store.getSendPrev(is_first);
-        data.canvas3d_data = canvas3d_store.transferSend(is_first);
+        std::lock_guard canvas3d_lock(this_->canvas3d_store.mtx);
+        data.canvas3d_prev = this_->canvas3d_store.getSendPrev(is_first);
+        data.canvas3d_data = this_->canvas3d_store.transferSend(is_first);
     }
     {
-        std::lock_guard canvas2d_lock(canvas2d_store.mtx);
-        data.canvas2d_prev = canvas2d_store.getSendPrev(is_first);
-        data.canvas2d_data = canvas2d_store.transferSend(is_first);
+        std::lock_guard canvas2d_lock(this_->canvas2d_store.mtx);
+        data.canvas2d_prev = this_->canvas2d_store.getSendPrev(is_first);
+        data.canvas2d_data = this_->canvas2d_store.transferSend(is_first);
     }
-    // std::lock_guard image_lock(image_store.mtx);
-    data.image_data = image_store.transferSend(is_first);
+    // std::lock_guard image_lock(this_->image_store.mtx);
+    data.image_data = this_->image_store.transferSend(is_first);
 
-    // std::lock_guard log_lock(log_store.mtx);
-    auto log_self_opt = log_store.getRecv(self_member_name);
+    // std::lock_guard log_lock(this_->log_store.mtx);
+    auto log_self_opt = this_->log_store.getRecv(this_->self_member_name);
     if (!log_self_opt) {
         throw std::runtime_error("self log data is null");
     } else {
         auto &log_s = *log_self_opt;
-        if ((log_s->size() > 0 && is_first) || log_s->size() > log_sent_lines) {
+        if ((log_s->size() > 0 && is_first) ||
+            log_s->size() > this_->log_sent_lines) {
             auto begin = log_s->begin();
             auto end = log_s->end();
             if (!is_first) {
-                begin += static_cast<int>(log_sent_lines);
+                begin += static_cast<int>(this_->log_sent_lines);
             }
-            log_sent_lines = log_s->size();
+            this_->log_sent_lines = log_s->size();
             data.log_data = std::vector<LogLineData>(begin, end);
         }
     }
-    // std::lock_guard func_lock(func_store.mtx);
-    data.func_data = func_store.transferSend(is_first);
+    // std::lock_guard func_lock(this_->func_store.mtx);
+    data.func_data = this_->func_store.transferSend(is_first);
 
     return data;
 }

--- a/client/src/client_threading.cc
+++ b/client/src/client_threading.cc
@@ -260,9 +260,9 @@ void internal::ClientData::syncImpl(
                 lock_s.getData().sync_first =
                     lock_s.getData().syncDataFirst(this);
             } else {
-                auto sync_data = lock_s.getData().syncData(this, false);
+                auto sync_now_data = lock_s.getData().syncData(this, false);
                 lock_s.unlock();
-                this->messagePushAlways(std::move(sync_data));
+                this->messagePushAlways(std::move(sync_now_data));
             }
         }
     }

--- a/tests/func_test.cc
+++ b/tests/func_test.cc
@@ -351,24 +351,28 @@ TEST_F(FuncTest, funcRunRemote) {
     EXPECT_TRUE(res.finished());
     EXPECT_FALSE(res.found());
     EXPECT_TRUE(res.isError());
-    EXPECT_TRUE(data_->sync_queue.empty());
-
-    data_->connected = true;
-
+    {
+        internal::ClientData::ScopedWsLock lock_ws(data_);
+        EXPECT_TRUE(lock_ws.getData().sync_queue.empty());
+        lock_ws.getData().connected = true;
+    }
     res = func("a", "b").runAsync(1.23, true, "abc");
     EXPECT_FALSE(res.reached());
     bool call_msg_found = false;
-    while (!data_->sync_queue.empty()) {
-        auto msg = data_->sync_queue.front();
-        data_->sync_queue.pop();
-        if (std::get<0>(msg) ==
-            message::packSingle(message::Call{
-                1,
-                0,
-                0,
-                "b"_ss,
-                {ValAdaptor(1.23), ValAdaptor(true), ValAdaptor("abc")}})) {
-            call_msg_found = true;
+    {
+        internal::ClientData::ScopedWsLock lock_ws(data_);
+        while (!lock_ws.getData().sync_queue.empty()) {
+            auto msg = lock_ws.getData().sync_queue.front();
+            lock_ws.getData().sync_queue.pop();
+            if (std::get<0>(msg) ==
+                message::packSingle(message::Call{
+                    1,
+                    0,
+                    0,
+                    "b"_ss,
+                    {ValAdaptor(1.23), ValAdaptor(true), ValAdaptor("abc")}})) {
+                call_msg_found = true;
+            }
         }
     }
     EXPECT_TRUE(call_msg_found);


### PR DESCRIPTION
* v2.2.0〜2.2.1で追加したsync_mをかける場所が間違っていてセグフォを起こしていたのを修正
* データをstructにまとめ、生のmutexを直接触るのではなくロックしてデータを返すScopedLockクラスを実装