### PR TITLE
syncInit受信時にそのメンバーの過去のデータを消す

### DIFF
--- a/client/include/webcface/internal/data_store2.h
+++ b/client/include/webcface/internal/data_store2.h
@@ -131,11 +131,11 @@ class SyncDataStore2 {
     bool unsetRecv(const FieldBase &base);
 
     /*!
-     * \brief memberのentryをクリア
+     * \brief memberのentryとデータをクリア
      *
      * ambiguousなので引数にFieldBaseは使わない (そもそも必要ない)
      */
-    void clearEntry(const SharedString &from);
+    void initMember(const SharedString &from);
     /*!
      * \brief 受信したentryを追加
      *

--- a/client/src/client_msg_recv.cc
+++ b/client/src/client_msg_recv.cc
@@ -384,15 +384,15 @@ void internal::ClientData::onRecv(
                 std::lock_guard lock(this->entry_m);
                 this->member_entry.emplace(r.member_name);
             }
-            this->value_store.clearEntry(r.member_name);
-            this->text_store.clearEntry(r.member_name);
-            this->func_store.clearEntry(r.member_name);
-            this->view_store.clearEntry(r.member_name);
-            this->image_store.clearEntry(r.member_name);
-            this->robot_model_store.clearEntry(r.member_name);
-            this->canvas3d_store.clearEntry(r.member_name);
-            this->canvas2d_store.clearEntry(r.member_name);
-            this->log_store.clearEntry(r.member_name);
+            this->value_store.initMember(r.member_name);
+            this->text_store.initMember(r.member_name);
+            this->func_store.initMember(r.member_name);
+            this->view_store.initMember(r.member_name);
+            this->image_store.initMember(r.member_name);
+            this->robot_model_store.initMember(r.member_name);
+            this->canvas3d_store.initMember(r.member_name);
+            this->canvas2d_store.initMember(r.member_name);
+            this->log_store.initMember(r.member_name);
             this->member_ids[r.member_name] = r.member_id;
             this->member_lib_name[r.member_id] = r.lib_name;
             this->member_lib_ver[r.member_id] = r.lib_ver;

--- a/client/src/data_store2.cc
+++ b/client/src/data_store2.cc
@@ -81,9 +81,10 @@ StrSet1 SyncDataStore2<T, ReqT>::getEntry(const SharedString &name) {
     }
 }
 template <typename T, typename ReqT>
-void SyncDataStore2<T, ReqT>::clearEntry(const SharedString &from) {
+void SyncDataStore2<T, ReqT>::initMember(const SharedString &from) {
     std::lock_guard lock(mtx);
     entry[from].clear();
+    data_recv[from].clear();
 }
 template <typename T, typename ReqT>
 void SyncDataStore2<T, ReqT>::setEntry(const SharedString &from,

--- a/tests/client_data_test.cc
+++ b/tests/client_data_test.cc
@@ -104,6 +104,13 @@ TEST_F(SyncDataStore2Test, setEntry) {
     EXPECT_EQ(s2.getEntry("a"_ss).size(), 1u);
     EXPECT_EQ(s2.getEntry("a"_ss).count("b"_ss), 1u);
 }
+TEST_F(SyncDataStore2Test, initMember) {
+    s2.setEntry("a"_ss, "b"_ss);
+    s2.setRecv("a"_ss, "b"_ss, "c");
+    s2.initMember("a"_ss);
+    EXPECT_TRUE(s2.getEntry("a"_ss).empty());
+    EXPECT_EQ(s2.getRecv("a"_ss, "b"_ss), std::nullopt);
+}
 
 class SyncDataStore1Test : public ::testing::Test {
   protected:


### PR DESCRIPTION
メンバーが再接続しsyncInitが送られてきたとき、そのメンバーがデータを何も送っていなくても受信側には前のデータが残ってしまっていた。
これによりviewの挙動がおかしくなっていた(送信側と受信側で値が一致していない状況になっていた)

* webcface-python: https://github.com/na-trium-144/webcface-python/pull/40
* webcface-js: https://github.com/na-trium-144/webcface-js/pull/238
* webcface-webui: https://github.com/na-trium-144/webcface-webui/pull/320