### PR TITLE
spdlogにvisibility:inlineshiddenを指定

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         arch: [amd64, arm64, armhf]
         distro: ["20.04"]
+        gcc_ver: [10]
         include:
           - arch: amd64
             base: ubuntu
@@ -53,6 +54,8 @@ jobs:
           # armv7のubuntu20.04でなぜかSSL周りがエラーになり、これでなぜか直る
           env: |
             SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+            CC: gcc-${{matrix.gcc_ver}}
+            CXX: g++-${{matrix.gcc_ver}}
 
           # The shell to run commands with in the container
           shell: /bin/sh
@@ -69,7 +72,7 @@ jobs:
             wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc --no-check-certificate | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
             echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
             apt-get update -q -y
-            apt-get install -q -y build-essential cmake file git python3-pip ninja-build zip pkg-config
+            apt-get install -q -y build-essential gcc-${{matrix.gcc_ver}} g++-${{matrix.gcc_ver}} cmake file git python3-pip ninja-build zip pkg-config
             pip3 install meson
 
           # Produce a binary artifact and place it in the mounted volume

--- a/.github/workflows/cmake-test-linux-gcc.yml
+++ b/.github/workflows/cmake-test-linux-gcc.yml
@@ -11,12 +11,14 @@ jobs:
     strategy:
       matrix:
         dep: ["apt", "source"]
-        gcc-ver: [7, 9, 11, 13]
+        gcc-ver: [7, 9, 10, 11, 13]
         include:
         - os: ubuntu-20.04
           gcc_ver: 7
         - os: ubuntu-20.04
           gcc_ver: 9
+        - os: ubuntu-20.04
+          gcc_ver: 10
         - os: ubuntu-22.04
           gcc_ver: 11
         - os: ubuntu-24.04
@@ -58,7 +60,8 @@ jobs:
       run: meson test -C build --print-errorlog
 
     - name: Check Exported Symbol
-      if: matrix.dep == 'source'
+      # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47877
+      if: matrix.dep == 'source' && matrix.gcc_ver >= 10
       run: |
         bash -c "! nm -g --defined-only build/libwebcface.so | grep -v webcface | grep -v wcf | grep -v St | grep -v gnu_cxx"
         bash -c "! nm -g --defined-only build/libwebcface.so | grep -v webcface | grep -v wcf | grep spdlog"

--- a/meson.build
+++ b/meson.build
@@ -352,43 +352,15 @@ msgpack_cxx_dep = dependency('msgpack-cxx',
     'std_variant=false', # msvcでなんかエラーになる
   ],
 )
-spdlog_link_depends = []
-if get_option('wrap_mode') != 'forcefallback' and not get_option('force_fallback_for').contains('spdlog')
-  spdlog_dep = dependency('spdlog', required: false)
-else
-  spdlog_dep = dependency('', required: false)
-endif
-if not spdlog_dep.found()
-  spdlog_proj = subproject('spdlog',
-    default_options: [
-      'tests=disabled',
-      'compile_library=true',
-      'default_library=static',
-      'external_fmt=disabled',
-      'std_format=disabled',
-    ],
-  )
-  spdlog_dep = spdlog_proj.get_variable('spdlog_dep')
-  spdlog_lib = spdlog_proj.get_variable('spdlog_lib', dependency('', required: false))  # disabler() は使えない
-  # webcfaceがsharedで、spdlogがstaticの場合にのみオプションを指定
-  if get_option('default_library') == 'shared' and spdlog_lib.found() and spdlog_lib.full_path().endswith('.a')
-    if webcface_system_exclude_libs
-      spdlog_dep = declare_dependency(
-        dependencies: [spdlog_dep],
-        link_args: ['-Wl,--exclude-libs,' + fs.name(spdlog_lib.full_path())],
-      )
-    elif webcface_system_hidden_l
-      spdlog_link_depends += spdlog_lib
-      spdlog_dep = declare_dependency(
-        dependencies: [spdlog_dep.partial_dependency(compile_args: true, includes: true)],
-        link_args: [
-          '-L' + fs.parent(spdlog_lib.full_path()),
-          '-Wl,-hidden-l' + spdlog_lib.name(),
-        ],
-      )
-    endif
-  endif
-endif
+spdlog_dep = dependency('spdlog',
+  default_options: [
+    'tests=disabled',
+    'compile_library=true',
+    'default_library=static',
+    'external_fmt=disabled',
+    'std_format=disabled',
+  ],
+)
 utf8cpp_dep = dependency('utf8cpp')
 
 if get_option('wrap_mode') != 'forcefallback' and not get_option('force_fallback_for').contains('libcurl')
@@ -770,9 +742,6 @@ webcface_lib = library(webcface_lib_name,
     utf8cpp_dep,
     spdlog_dep,
     curl_dep,
-  ],
-  link_depends: [
-    spdlog_link_depends,
   ],
   version: meson.project_version(),
   soversion: webcface_abi_major,

--- a/subprojects/packagefiles/spdlog/LICENSE.build
+++ b/subprojects/packagefiles/spdlog/LICENSE.build
@@ -1,0 +1,19 @@
+Copyright (c) 2021 The Meson development team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/subprojects/packagefiles/spdlog/meson.build
+++ b/subprojects/packagefiles/spdlog/meson.build
@@ -1,0 +1,65 @@
+project(
+  'spdlog',
+  'cpp',
+  version: '1.15.0',
+  license: 'MIT',
+  meson_version: '>=0.56.0',
+)
+
+inc = include_directories('include')
+
+thread_dep = dependency('threads')
+
+spdlog_dependencies = [thread_dep]
+spdlog_compile_args = []
+
+if meson.get_compiler('cpp').has_header_symbol('format', '__cpp_lib_format', required: get_option('std_format'))
+  spdlog_compile_args += '-DSPDLOG_USE_STD_FORMAT'
+  fmt_dep = dependency('', required: false)
+else
+  fmt_dep = dependency('fmt', version: '>=8.1', required: get_option('external_fmt'))
+  if fmt_dep.found()
+    spdlog_dependencies += fmt_dep
+    spdlog_compile_args += '-DSPDLOG_FMT_EXTERNAL'
+  endif
+endif
+
+if get_option('compile_library')
+  spdlog_compile_args += '-DSPDLOG_COMPILED_LIB'
+  if get_option('default_library') != 'static'
+    spdlog_compile_args += '-DSPDLOG_SHARED_LIB'
+    spdlog_compile_args += '-Dspdlog_EXPORTS'
+    if not fmt_dep.found()
+      spdlog_compile_args += '-DFMT_EXPORT'
+      spdlog_compile_args += '-DFMT_SHARED'
+    endif
+  endif
+  subdir('src')
+
+  spdlog_dep = declare_dependency(
+    include_directories: inc,
+    dependencies: spdlog_dependencies,
+    link_with: spdlog_lib,
+    compile_args: spdlog_compile_args,
+  )
+else
+  spdlog_dep = declare_dependency(
+    include_directories: inc,
+    dependencies: spdlog_dependencies,
+    compile_args: spdlog_compile_args,
+  )
+endif
+
+# install header and pkg-config file
+install_subdir('include/spdlog', install_dir: get_option('includedir'))
+pkg = import('pkgconfig')
+pkg.generate(
+  name: 'libspdlog',
+  filebase: 'spdlog',
+  description: 'Fast C++ logging library.',
+  url: 'https://github.com/gabime/spdlog',
+  libraries: [spdlog_dep, fmt_dep],
+  extra_cflags: spdlog_compile_args,
+)
+
+# subdir('tests')

--- a/subprojects/packagefiles/spdlog/meson_options.txt
+++ b/subprojects/packagefiles/spdlog/meson_options.txt
@@ -1,0 +1,5 @@
+option('tests', type: 'feature', description: 'Build the unit tests')
+
+option('compile_library', type: 'boolean', value: false, description: 'Builds a static/shared lib for faster compile times')
+option('external_fmt', type: 'feature', description: 'Builds with external fmt lib instead of internal')
+option('std_format', type: 'feature', description: 'Use std::format instead of internal fmt lib')

--- a/subprojects/packagefiles/spdlog/src/meson.build
+++ b/subprojects/packagefiles/spdlog/src/meson.build
@@ -1,0 +1,21 @@
+src = files(
+  'async.cpp',
+  'cfg.cpp',
+  'color_sinks.cpp',
+  'file_sinks.cpp',
+  'spdlog.cpp',
+  'stdout_sinks.cpp',
+)
+
+if not fmt_dep.found()
+  src += files('bundled_fmtlib_format.cpp')
+endif
+
+spdlog_lib = library(
+  'spdlog',
+  src,
+  include_directories: inc,
+  dependencies: spdlog_dependencies,
+  cpp_args: spdlog_compile_args,
+  gnu_symbol_visibility: 'inlineshidden',
+)

--- a/subprojects/spdlog.wrap
+++ b/subprojects/spdlog.wrap
@@ -1,13 +1,9 @@
-[wrap-file]
-directory = spdlog-1.14.1
-source_url = https://github.com/gabime/spdlog/archive/refs/tags/v1.14.1.tar.gz
-source_filename = spdlog-1.14.1.tar.gz
-source_hash = 1586508029a7d0670dfcb2d97575dcdc242d3868a259742b69f100801ab4e16b
-patch_filename = spdlog_1.14.1-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/spdlog_1.14.1-2/get_patch
-patch_hash = d9fe1e98d330e3283214321844a89b9b339e272b91a2709c373ff47f8299942b
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/spdlog_1.14.1-2/spdlog-1.14.1.tar.gz
-wrapdb_version = 1.14.1-2
+[wrap-git]
+url = https://github.com/gabime/spdlog.git
+revision = v1.15.0
+depth = 1
+patch_directory = spdlog
+# meson.build copied from wrapdb 1.15.0-1 and modified
 
 [provide]
 spdlog = spdlog_dep


### PR DESCRIPTION
Macで-hidden-lを指定する必要がなくなる
が、Linuxでシンボルが消えてくれない...