### PR TITLE
完全型かどうかをstatic_assertするマクロ

### DIFF
--- a/client/include/webcface/complete.h
+++ b/client/include/webcface/complete.h
@@ -27,6 +27,7 @@ constexpr bool isComplete(T *) {
 define_assert_complete(Member, member.h)
 define_assert_complete(Value, value.h)
 define_assert_complete(Text, text.h)
+define_assert_complete(Variant, text.h)
 define_assert_complete(View, view.h)
 define_assert_complete(Image, image.h)
 define_assert_complete(Func, func.h)
@@ -41,8 +42,8 @@ define_assert_complete(Log, log.h)
 
 #define WEBCFACE_COMPLETE(Type)                                                \
     typename Type##_ = Type,                                                   \
-             std::nullptr_t =                                                  \
-                 ::webcface::traits::assertComplete##Type<Type##_>()
+             std::nullptr_t = ::webcface::traits::assertComplete##Type<        \
+                 std::enable_if_t<std::is_same_v<Type##_, Type>, Type##_>>()
 
 } // namespace traits
 WEBCFACE_NS_END

--- a/client/include/webcface/complete.h
+++ b/client/include/webcface/complete.h
@@ -16,7 +16,7 @@ constexpr bool isComplete(T *) {
 
 #define define_assert_complete(Type, header)                                   \
     template <typename T>                                                      \
-    std::nullptr_t assertComplete##Type() {                                    \
+    constexpr std::nullptr_t assertComplete##Type() {                          \
         static_assert(isComplete((T *)nullptr),                                \
                       "Please include <webcface/" #header                      \
                       "> to use class '" #Type "'!");                          \

--- a/client/include/webcface/complete.h
+++ b/client/include/webcface/complete.h
@@ -23,17 +23,19 @@ constexpr bool isComplete(T *) {
         return nullptr;                                                        \
     }
 
-define_assert_complete(Member, member.h);
-define_assert_complete(Value, value.h);
-define_assert_complete(Text, text.h);
-define_assert_complete(View, view.h);
-define_assert_complete(Image, image.h);
-define_assert_complete(Func, func.h);
-define_assert_complete(FuncListener, func.h);
-define_assert_complete(RobotModel, robot_model.h);
-define_assert_complete(Canvas2D, canvas2d.h);
-define_assert_complete(Canvas3D, canvas3d.h);
-define_assert_complete(Log, log.h);
+// clang-format off
+define_assert_complete(Member, member.h)
+define_assert_complete(Value, value.h)
+define_assert_complete(Text, text.h)
+define_assert_complete(View, view.h)
+define_assert_complete(Image, image.h)
+define_assert_complete(Func, func.h)
+define_assert_complete(FuncListener, func.h)
+define_assert_complete(RobotModel, robot_model.h)
+define_assert_complete(Canvas2D, canvas2d.h)
+define_assert_complete(Canvas3D, canvas3d.h)
+define_assert_complete(Log, log.h)
+// clang-format on
 
 #undef define_assert_complete
 

--- a/client/include/webcface/complete.h
+++ b/client/include/webcface/complete.h
@@ -1,0 +1,46 @@
+#pragma once
+#include <cstddef>
+#ifdef WEBCFACE_MESON
+#include "webcface-config.h"
+#else
+#include "webcface/common/webcface-config.h"
+#endif
+
+WEBCFACE_NS_BEGIN
+namespace traits {
+constexpr bool isComplete(...) { return false; }
+template <typename T, int = sizeof(T)>
+constexpr bool isComplete(T *) {
+    return true;
+}
+
+#define define_assert_complete(Type, header)                                   \
+    template <typename T>                                                      \
+    std::nullptr_t assertComplete##Type() {                                    \
+        static_assert(isComplete((T *)nullptr),                                \
+                      "Please include <webcface/" #header                      \
+                      "> to use class '" #Type "'!");                          \
+        return nullptr;                                                        \
+    }
+
+define_assert_complete(Member, member.h);
+define_assert_complete(Value, value.h);
+define_assert_complete(Text, text.h);
+define_assert_complete(View, view.h);
+define_assert_complete(Image, image.h);
+define_assert_complete(Func, func.h);
+define_assert_complete(FuncListener, func.h);
+define_assert_complete(RobotModel, robot_model.h);
+define_assert_complete(Canvas2D, canvas2d.h);
+define_assert_complete(Canvas3D, canvas3d.h);
+define_assert_complete(Log, log.h);
+
+#undef define_assert_complete
+
+#define WEBCFACE_COMPLETE(Type)                                                \
+    typename Type##_ = Type,                                                   \
+             std::nullptr_t =                                                  \
+                 ::webcface::traits::assertComplete##Type<Type##_>()
+
+} // namespace traits
+WEBCFACE_NS_END

--- a/client/include/webcface/complete.h
+++ b/client/include/webcface/complete.h
@@ -19,7 +19,7 @@ constexpr bool isComplete(T *) {
     constexpr std::nullptr_t assertComplete##Type() {                          \
         static_assert(isComplete((T *)nullptr),                                \
                       "Please include <webcface/" #header                      \
-                      "> to use class '" #Type "'!");                          \
+                      "> to use class " #Type "!");                            \
         return nullptr;                                                        \
     }
 

--- a/client/include/webcface/component_canvas2d.h
+++ b/client/include/webcface/component_canvas2d.h
@@ -131,8 +131,10 @@ class WEBCFACE_DLL Canvas2DComponent {
      * \brief クリック時に実行される関数を取得
      * \since ver1.9
      */
-    std::optional<Func> onClick() const;
+    template <WEBCFACE_COMPLETE(Func)>
+    std::optional<Func_> onClick() const;
 };
+extern template std::optional<Func> Canvas2DComponent::onClick<Func, nullptr>() const;
 
 class WEBCFACE_DLL TemporalCanvas2DComponent {
     std::unique_ptr<internal::TemporalCanvas2DComponentData> msg_data;

--- a/client/include/webcface/component_canvas3d.h
+++ b/client/include/webcface/component_canvas3d.h
@@ -105,8 +105,11 @@ class WEBCFACE_DLL Canvas3DComponent {
      * \brief RobotModelを取得
      *
      */
-    std::optional<RobotModel> robotModel() const;
+    template <WEBCFACE_COMPLETE(RobotModel)>
+    std::optional<RobotModel_> robotModel() const;
 };
+extern template std::optional<RobotModel>
+Canvas3DComponent::robotModel<RobotModel, nullptr>() const;
 
 /*!
  * \brief Canvas3Dを構築するときに使う一時的なCanvas3DComponent

--- a/client/include/webcface/component_view.h
+++ b/client/include/webcface/component_view.h
@@ -199,7 +199,8 @@ class WEBCFACE_DLL ViewComponent {
      * \brief クリック時に実行される関数を取得
      *
      */
-    std::optional<Func> onClick() const;
+    template <WEBCFACE_COMPLETE(Func)>
+    std::optional<Func_> onClick() const;
     /*!
      * \brief inputの値の変化時に実行される関数を取得
      * \since ver1.10
@@ -210,7 +211,8 @@ class WEBCFACE_DLL ViewComponent {
      * 内部データはonClickと共通
      *
      */
-    std::optional<Func> onChange() const;
+    template <WEBCFACE_COMPLETE(Func)>
+    std::optional<Func_> onChange() const;
     /*!
      * \brief inputの現在の値を取得
      * \since ver1.10
@@ -220,7 +222,8 @@ class WEBCFACE_DLL ViewComponent {
      * * ver2.0〜 戻り値をText型からVariant型に変更
      *
      */
-    std::optional<Variant> bind() const;
+    template <WEBCFACE_COMPLETE(Variant)>
+    std::optional<Variant_> bind() const;
 
     /*!
      * \brief 文字色を取得
@@ -258,6 +261,12 @@ class WEBCFACE_DLL ViewComponent {
      */
     std::vector<ValAdaptor> option() const;
 };
+extern template std::optional<Func>
+ViewComponent::onClick<Func, nullptr>() const;
+extern template std::optional<Func>
+ViewComponent::onChange<Func, nullptr>() const;
+extern template std::optional<Variant>
+ViewComponent::bind<Variant, nullptr>() const;
 
 /*!
  * \brief Viewを構築するときに使う一時的なViewComponent

--- a/client/include/webcface/field.h
+++ b/client/include/webcface/field.h
@@ -9,6 +9,7 @@
 #include "webcface/common/webcface-config.h"
 #endif
 #include "webcface/common/encoding.h"
+#include "webcface/complete.h"
 
 WEBCFACE_NS_BEGIN
 
@@ -102,7 +103,10 @@ struct WEBCFACE_DLL Field : public FieldBase {
      * \brief Memberを返す
      *
      */
-    Member member() const;
+    template <WEBCFACE_COMPLETE(Member)>
+    Member_ member() const {
+        return *this;
+    }
     /*!
      * \brief field名を返す
      *
@@ -170,33 +174,92 @@ struct WEBCFACE_DLL Field : public FieldBase {
      */
     Field operator[](int index) const { return child(index); }
 
-    Value value(std::string_view field = "") const;
-    Value value(std::wstring_view field) const;
-    Text text(std::string_view field = "") const;
-    Text text(std::wstring_view field) const;
-    RobotModel robotModel(std::string_view field = "") const;
-    RobotModel robotModel(std::wstring_view field) const;
-    Image image(std::string_view field = "") const;
-    Image image(std::wstring_view field) const;
-    Func func(std::string_view field = "") const;
-    Func func(std::wstring_view field) const;
-    FuncListener funcListener(std::string_view field) const;
-    FuncListener funcListener(std::wstring_view field) const;
-    View view(std::string_view field = "") const;
-    View view(std::wstring_view field) const;
-    Canvas3D canvas3D(std::string_view field = "") const;
-    Canvas3D canvas3D(std::wstring_view field) const;
-    Canvas2D canvas2D(std::string_view field = "") const;
-    Canvas2D canvas2D(std::wstring_view field) const;
+    template <WEBCFACE_COMPLETE(Value)>
+    Value_ value(std::string_view field = "") const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(Value)>
+    Value_ value(std::wstring_view field) const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(Text)>
+    Text_ text(std::string_view field = "") const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(Text)>
+    Text_ text(std::wstring_view field) const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(RobotModel)>
+    RobotModel_ robotModel(std::string_view field = "") const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(RobotModel)>
+    RobotModel_ robotModel(std::wstring_view field) const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(Image)>
+    Image_ image(std::string_view field = "") const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(Image)>
+    Image_ image(std::wstring_view field) const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(Func)>
+    Func_ func(std::string_view field = "") const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(Func)>
+    Func_ func(std::wstring_view field) const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(FuncListener)>
+    FuncListener_ funcListener(std::string_view field = "") const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(FuncListener)>
+    FuncListener_ funcListener(std::wstring_view field) const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(View)>
+    View_ view(std::string_view field = "") const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(View)>
+    View_ view(std::wstring_view field) const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(Canvas3D)>
+    Canvas3D_ canvas3D(std::string_view field = "") const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(Canvas3D)>
+    Canvas3D_ canvas3D(std::wstring_view field) const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(Canvas2D)>
+    Canvas2D_ canvas2D(std::string_view field = "") const {
+        return child(field);
+    }
+    template <WEBCFACE_COMPLETE(Canvas2D)>
+    Canvas2D_ canvas2D(std::wstring_view field) const {
+        return child(field);
+    }
     /*!
      * \since ver2.4
      */
-    Log log(std::string_view field = "") const;
+    template <WEBCFACE_COMPLETE(Log)>
+    Log_ log(std::string_view field = "") const {
+        return child(field);
+    }
     /*!
      * \since ver2.4
      */
-    Log log(std::wstring_view field) const;
-
+    template <WEBCFACE_COMPLETE(Log)>
+    Log_ log(std::wstring_view field) const {
+        return child(field);
+    }
 
     std::vector<Value> valueEntries() const;
     std::vector<Text> textEntries() const;

--- a/client/include/webcface/field.h
+++ b/client/include/webcface/field.h
@@ -261,18 +261,27 @@ struct WEBCFACE_DLL Field : public FieldBase {
         return child(field);
     }
 
-    std::vector<Value> valueEntries() const;
-    std::vector<Text> textEntries() const;
-    std::vector<RobotModel> robotModelEntries() const;
-    std::vector<Func> funcEntries() const;
-    std::vector<View> viewEntries() const;
-    std::vector<Canvas3D> canvas3DEntries() const;
-    std::vector<Canvas2D> canvas2DEntries() const;
-    std::vector<Image> imageEntries() const;
+    template <WEBCFACE_COMPLETE(Value)>
+    std::vector<Value_> valueEntries() const;
+    template <WEBCFACE_COMPLETE(Text)>
+    std::vector<Text_> textEntries() const;
+    template <WEBCFACE_COMPLETE(RobotModel)>
+    std::vector<RobotModel_> robotModelEntries() const;
+    template <WEBCFACE_COMPLETE(Func)>
+    std::vector<Func_> funcEntries() const;
+    template <WEBCFACE_COMPLETE(View)>
+    std::vector<View_> viewEntries() const;
+    template <WEBCFACE_COMPLETE(Canvas2D)>
+    std::vector<Canvas2D_> canvas2DEntries() const;
+    template <WEBCFACE_COMPLETE(Canvas3D)>
+    std::vector<Canvas3D_> canvas3DEntries() const;
+    template <WEBCFACE_COMPLETE(Image)>
+    std::vector<Image_> imageEntries() const;
     /*!
      * \since ver2.4
      */
-    std::vector<Log> logEntries() const;
+    template <WEBCFACE_COMPLETE(Log)>
+    std::vector<Log_> logEntries() const;
 
     /*!
      * \brief memberがselfならtrue
@@ -285,4 +294,18 @@ struct WEBCFACE_DLL Field : public FieldBase {
     bool operator==(const Field &other) const;
     bool operator!=(const Field &other) const { return !(*this == other); }
 };
+
+extern template std::vector<Value> Field::valueEntries<Value, nullptr>() const;
+extern template std::vector<Text> Field::textEntries<Text, nullptr>() const;
+extern template std::vector<RobotModel>
+Field::robotModelEntries<RobotModel, nullptr>() const;
+extern template std::vector<Func> Field::funcEntries<Func, nullptr>() const;
+extern template std::vector<View> Field::viewEntries<View, nullptr>() const;
+extern template std::vector<Canvas2D>
+Field::canvas2DEntries<Canvas2D, nullptr>() const;
+extern template std::vector<Canvas3D>
+Field::canvas3DEntries<Canvas3D, nullptr>() const;
+extern template std::vector<Image> Field::imageEntries<Image, nullptr>() const;
+extern template std::vector<Log> Field::logEntries<Log, nullptr>() const;
+
 WEBCFACE_NS_END

--- a/client/include/webcface/member.h
+++ b/client/include/webcface/member.h
@@ -1,14 +1,15 @@
 #pragma once
+#include <functional>
 #include <string>
 #include <vector>
 #include <optional>
+#include <chrono>
 #include "field.h"
 #ifdef WEBCFACE_MESON
 #include "webcface-config.h"
 #else
 #include "webcface/common/webcface-config.h"
 #endif
-#include "webcface/log.h"
 
 WEBCFACE_NS_BEGIN
 
@@ -56,16 +57,23 @@ class WEBCFACE_DLL Member : protected Field {
     /*!
      * \since ver2.4
      */
-    Log log(std::string_view name) const { return this->Field::log(name); }
+    template <WEBCFACE_COMPLETE(Log)>
+    Log_ log(std::string_view name) const {
+        return this->child(name);
+    }
     /*!
      * \since ver2.4
      */
-    Log log(std::wstring_view name) const { return this->Field::log(name); }
+    template <WEBCFACE_COMPLETE(Log)>
+    Log_ log(std::wstring_view name) const {
+        return this->child(name);
+    }
     /*!
      * ver2.4〜: nameを省略した場合 "default" として送信される。
      *
      */
-    Log log() const;
+    template <WEBCFACE_COMPLETE(Log)>
+    Log_ log() const;
 
     using Field::canvas2DEntries;
     using Field::canvas3DEntries;
@@ -282,5 +290,6 @@ class WEBCFACE_DLL Member : protected Field {
         return static_cast<Field>(*this) != static_cast<Field>(other);
     }
 };
+extern template Log Member::log<Log, nullptr>() const;
 
 WEBCFACE_NS_END

--- a/client/src/component_canvas2d.cc
+++ b/client/src/component_canvas2d.cc
@@ -167,8 +167,8 @@ TemporalCanvas2DComponent::geometry(const Geometry &g) & {
     return *this;
 }
 
-
-std::optional<Func> Canvas2DComponent::onClick() const {
+template <typename T, std::nullptr_t>
+std::optional<T> Canvas2DComponent::onClick() const {
     checkData();
     if (msg_data->on_click_member && msg_data->on_click_field) {
         return Field{data_w, *msg_data->on_click_member,
@@ -177,6 +177,8 @@ std::optional<Func> Canvas2DComponent::onClick() const {
         return std::nullopt;
     }
 }
+template WEBCFACE_DLL std::optional<Func>
+Canvas2DComponent::onClick<Func, nullptr>() const;
 TemporalCanvas2DComponent &
 TemporalCanvas2DComponent::onClick(const Func &func) & {
     msg_data->on_click_member = static_cast<FieldBase>(func).member_;

--- a/client/src/component_canvas3d.cc
+++ b/client/src/component_canvas3d.cc
@@ -15,7 +15,7 @@ Canvas3DComponent::Canvas3DComponent() = default;
 Canvas3DComponent::Canvas3DComponent(
     const std::shared_ptr<message::Canvas3DComponentData> &msg_data,
     const std::weak_ptr<internal::ClientData> &data_w, const SharedString &id)
-    : msg_data(msg_data), data_w(data_w) , id_(id){}
+    : msg_data(msg_data), data_w(data_w), id_(id) {}
 
 TemporalCanvas3DComponent::TemporalCanvas3DComponent(std::nullptr_t)
     : msg_data() {}
@@ -27,14 +27,14 @@ TemporalCanvas3DComponent::TemporalCanvas3DComponent(Canvas3DComponentType type)
 TemporalCanvas3DComponent::TemporalCanvas3DComponent(
     const TemporalCanvas3DComponent &other) {
     if (other.msg_data) {
-        msg_data =
-            std::make_unique<internal::TemporalCanvas3DComponentData>(*other.msg_data);
+        msg_data = std::make_unique<internal::TemporalCanvas3DComponentData>(
+            *other.msg_data);
     }
 }
 TemporalCanvas3DComponent &
 TemporalCanvas3DComponent::operator=(const TemporalCanvas3DComponent &other) {
-    msg_data =
-        std::make_unique<internal::TemporalCanvas3DComponentData>(*other.msg_data);
+    msg_data = std::make_unique<internal::TemporalCanvas3DComponentData>(
+        *other.msg_data);
     return *this;
 }
 TemporalCanvas3DComponent::~TemporalCanvas3DComponent() noexcept {}
@@ -113,7 +113,8 @@ TemporalCanvas3DComponent::geometry(const Geometry &g) & {
     msg_data->geometry_properties = g.properties;
     return *this;
 }
-std::optional<RobotModel> Canvas3DComponent::robotModel() const {
+template <typename T, std::nullptr_t>
+std::optional<T> Canvas3DComponent::robotModel() const {
     checkData();
     if (msg_data->field_member && msg_data->field_field &&
         msg_data->type ==
@@ -123,6 +124,8 @@ std::optional<RobotModel> Canvas3DComponent::robotModel() const {
         return std::nullopt;
     }
 }
+template WEBCFACE_DLL std::optional<RobotModel>
+Canvas3DComponent::robotModel<RobotModel, nullptr>() const;
 TemporalCanvas3DComponent &
 TemporalCanvas3DComponent::robotModel(const RobotModel &field) & {
     msg_data->data_w = static_cast<Field>(field).data_w;

--- a/client/src/component_view.cc
+++ b/client/src/component_view.cc
@@ -271,9 +271,14 @@ TemporalViewComponent &TemporalViewComponent::text(std::wstring_view text) & {
     msg_data->text = SharedString::encode(text);
     return *this;
 }
-
-std::optional<Func> ViewComponent::onChange() const { return onClick(); }
-std::optional<Func> ViewComponent::onClick() const {
+template <typename T, std::nullptr_t>
+std::optional<T> ViewComponent::onChange() const {
+    return onClick();
+}
+template WEBCFACE_DLL std::optional<Func>
+ViewComponent::onChange<Func, nullptr>() const;
+template <typename T, std::nullptr_t>
+std::optional<T> ViewComponent::onClick() const {
     checkData();
     if (msg_data->on_click_member && msg_data->on_click_field) {
         // assert(data_w.lock() != nullptr && "ClientData not set");
@@ -283,6 +288,8 @@ std::optional<Func> ViewComponent::onClick() const {
         return std::nullopt;
     }
 }
+template WEBCFACE_DLL std::optional<Func>
+ViewComponent::onClick<Func, nullptr>() const;
 TemporalViewComponent &TemporalViewComponent::onClick(const Func &func) & {
     msg_data->on_click_member.emplace(static_cast<FieldBase>(func).member_);
     msg_data->on_click_field.emplace(static_cast<FieldBase>(func).field_);
@@ -306,7 +313,8 @@ TemporalViewComponent &TemporalViewComponent::bind(const InputRef &ref) & {
     msg_data->text_ref_tmp = ref;
     return *this;
 }
-std::optional<Variant> ViewComponent::bind() const {
+template <typename T, std::nullptr_t>
+std::optional<T> ViewComponent::bind() const {
     checkData();
     if (msg_data->text_ref_member && msg_data->text_ref_field) {
         return Field{data_w, *msg_data->text_ref_member,
@@ -315,6 +323,8 @@ std::optional<Variant> ViewComponent::bind() const {
         return std::nullopt;
     }
 }
+template WEBCFACE_DLL std::optional<Variant>
+ViewComponent::bind<Variant, nullptr>() const;
 
 TemporalViewComponent &TemporalViewComponent::onChange(
     const std::shared_ptr<std::function<void WEBCFACE_CALL_FP(ValAdaptor)>>

--- a/client/src/field.cc
+++ b/client/src/field.cc
@@ -63,33 +63,60 @@ static auto entries(const Field *this_, S &store) {
     }
     return ret;
 }
-std::vector<Value> Field::valueEntries() const {
+template <typename T, std::nullptr_t>
+std::vector<T> Field::valueEntries() const {
     return entries<Value>(this, dataLock()->value_store);
 }
-std::vector<Text> Field::textEntries() const {
+template <typename T, std::nullptr_t>
+std::vector<T> Field::textEntries() const {
     return entries<Text>(this, dataLock()->text_store);
 }
-std::vector<RobotModel> Field::robotModelEntries() const {
+template <typename T, std::nullptr_t>
+std::vector<T> Field::robotModelEntries() const {
     return entries<RobotModel>(this, dataLock()->robot_model_store);
 }
-std::vector<Func> Field::funcEntries() const {
+template <typename T, std::nullptr_t>
+std::vector<T> Field::funcEntries() const {
     return entries<Func>(this, dataLock()->func_store);
 }
-std::vector<View> Field::viewEntries() const {
+template <typename T, std::nullptr_t>
+std::vector<T> Field::viewEntries() const {
     return entries<View>(this, dataLock()->view_store);
 }
-std::vector<Canvas3D> Field::canvas3DEntries() const {
+template <typename T, std::nullptr_t>
+std::vector<T> Field::canvas3DEntries() const {
     return entries<Canvas3D>(this, dataLock()->canvas3d_store);
 }
-std::vector<Canvas2D> Field::canvas2DEntries() const {
+template <typename T, std::nullptr_t>
+std::vector<T> Field::canvas2DEntries() const {
     return entries<Canvas2D>(this, dataLock()->canvas2d_store);
 }
-std::vector<Image> Field::imageEntries() const {
+template <typename T, std::nullptr_t>
+std::vector<T> Field::imageEntries() const {
     return entries<Image>(this, dataLock()->image_store);
 }
-std::vector<Log> Field::logEntries() const {
+template <typename T, std::nullptr_t>
+std::vector<T> Field::logEntries() const {
     return entries<Log>(this, dataLock()->log_store);
 }
+
+template WEBCFACE_DLL std::vector<Value>
+Field::valueEntries<Value, nullptr>() const;
+template WEBCFACE_DLL std::vector<Text>
+Field::textEntries<Text, nullptr>() const;
+template WEBCFACE_DLL std::vector<RobotModel>
+Field::robotModelEntries<RobotModel, nullptr>() const;
+template WEBCFACE_DLL std::vector<Func>
+Field::funcEntries<Func, nullptr>() const;
+template WEBCFACE_DLL std::vector<View>
+Field::viewEntries<View, nullptr>() const;
+template WEBCFACE_DLL std::vector<Canvas2D>
+Field::canvas2DEntries<Canvas2D, nullptr>() const;
+template WEBCFACE_DLL std::vector<Canvas3D>
+Field::canvas3DEntries<Canvas3D, nullptr>() const;
+template WEBCFACE_DLL std::vector<Image>
+Field::imageEntries<Image, nullptr>() const;
+template WEBCFACE_DLL std::vector<Log> Field::logEntries<Log, nullptr>() const;
 
 bool Field::expired() const { return data_w.expired(); }
 

--- a/client/src/field.cc
+++ b/client/src/field.cc
@@ -18,7 +18,6 @@
 #endif
 
 WEBCFACE_NS_BEGIN
-Member Field::member() const { return *this; }
 SharedString Field::lastName8() const {
     auto i = this->field_.u8String().rfind(field_separator);
     if (i != std::string::npos && i != 0 &&
@@ -50,35 +49,6 @@ Field Field::child(const SharedString &field) const {
                                                        field.u8String())};
     }
 }
-
-Value Field::value(std::string_view field) const { return child(field); }
-Value Field::value(std::wstring_view field) const { return child(field); }
-Text Field::text(std::string_view field) const { return child(field); }
-Text Field::text(std::wstring_view field) const { return child(field); }
-RobotModel Field::robotModel(std::string_view field) const {
-    return child(field);
-}
-RobotModel Field::robotModel(std::wstring_view field) const {
-    return child(field);
-}
-Image Field::image(std::string_view field) const { return child(field); }
-Image Field::image(std::wstring_view field) const { return child(field); }
-Func Field::func(std::string_view field) const { return child(field); }
-Func Field::func(std::wstring_view field) const { return child(field); }
-FuncListener Field::funcListener(std::string_view field) const {
-    return child(field);
-}
-FuncListener Field::funcListener(std::wstring_view field) const {
-    return child(field);
-}
-View Field::view(std::string_view field) const { return child(field); }
-View Field::view(std::wstring_view field) const { return child(field); }
-Canvas3D Field::canvas3D(std::string_view field) const { return child(field); }
-Canvas3D Field::canvas3D(std::wstring_view field) const { return child(field); }
-Canvas2D Field::canvas2D(std::string_view field) const { return child(field); }
-Canvas2D Field::canvas2D(std::wstring_view field) const { return child(field); }
-Log Field::log(std::string_view field) const { return child(field); }
-Log Field::log(std::wstring_view field) const { return child(field); }
 
 /// \private
 template <typename V, typename S>

--- a/client/src/member.cc
+++ b/client/src/member.cc
@@ -13,7 +13,12 @@
 WEBCFACE_NS_BEGIN
 
 // ver2.4〜: nameを省略した場合 "default" として送信される。
-Log Member::log() const { return Log{*this, message::Log::defaultLogName()}; }
+template <typename T, std::nullptr_t>
+T Member::log() const {
+    return Log{*this, message::Log::defaultLogName()};
+}
+template WEBCFACE_DLL Log Member::log<Log, nullptr>() const;
+
 
 const Member &Member::onValueEntry(std::function<void(Value)> callback) const {
     std::lock_guard lock(dataLock()->event_m);

--- a/scripts/config.h.in
+++ b/scripts/config.h.in
@@ -22,11 +22,20 @@
 
 // clang-format off
 /*
-WEBCFACE_DLL: 関数の宣言 (msvc, mingw, unix)
-WEBCFACE_DLL_TEMPLATE: テンプレートクラスの定義 (unix)
-WEBCFACE_DLL_INSTANCE_DECL: 明示的実体化の宣言 (msvc_import, mingw) (unixでは消す:gcc-10でエラー)
-WEBCFACE_DLL_INSTANCE_DEF: 明示的実体化の定義 (msvc_export, unix)
-
+* 関数の宣言 (msvc, mingw, unix)
+    WEBCFACE_DLL return_type WEBCFACE_CALL func_name(args...);
+* クラスの定義 (msvc, mingw, unix)
+    class WEBCFACE_DLL class_name {...};
+* テンプレートクラスの定義 (unix)
+    template <...> class WEBCFACE_DLL_TEMPLATE class_name {...};
+* テンプレートクラスの明示的実体化の宣言 (msvc_import, mingw) (unixでは消す:gcc-10でエラー)
+    extern template class WEBCFACE_DLL_INSTANCE_DECL class_name<...>;
+* テンプレートクラスの明示的実体化の定義 (msvc_export, unix)
+    template class WEBCFACE_DLL_INSTANCE_DEF class_name<...>;
+* テンプレートメンバ関数の明示的実体化の宣言
+    extern template return_type class_name::func_name<...>(args...);
+* テンプレートメンバ関数の明示的実体化の定義
+    template WEBCFACE_DLL return_type class_name::func_name<...>(args...);
 */
 // clang-format on
 
@@ -77,12 +86,12 @@ WEBCFACE_DLL_INSTANCE_DEF: 明示的実体化の定義 (msvc_export, unix)
 // clang-format off
 /*
 calling convention
-
-通常の関数またはstaticメンバ関数(dllexportしているもの)につける。
-メンバ関数はthiscallなのでつけない
-std::function<>の中には要る(ただし型推論ができたりできなかったりする)
-ただしcygwinでstd::functionの中にcdecl宣言するとmanglingがおかしなことになった(なぜ?)
-関数ポインタには要る (typedef return_type (WEBCFACE_CALL *name)(args...); )
+* 通常の関数またはstaticメンバ関数(dllexportしているもの)につける。
+* メンバ関数はthiscallなのでつけない
+* std::function<>の中には要る(ただし型推論ができたりできなかったりする)
+    * ただしcygwinでstd::functionの中にcdecl宣言するとmanglingがおかしなことになった(なぜ?)ので、
+    std::function<>の中では WEBCFACE_CALL_FP をつける(cygwinで消える)
+* 関数ポインタには要る (typedef return_type (WEBCFACE_CALL *name)(args...); )
 
 */
 // clang-format on


### PR DESCRIPTION
例えば `<webcface/value.h>` をincludeせずに使おうとすると
```
../client/include/webcface/complete.h: In instantiation of ‘auto webcface::v21_::traits::assertComplete() [with T = webcface::v21_::Value; webcface::v21_::traits::CheckedTypes t = webcface::v21_::traits::CheckedTypes::Value]’:
../client/include/webcface/field.h:187:15:   required by substitution of ‘template<class Value_, class> Value_ webcface::v21_::Field::value(std::string_view) const [with Value_ = webcface::v21_::Value; <template-parameter-1-2> = <missing>]’
../examples/value.cc:11:15:   required from here
../client/include/webcface/complete.h:19:59: error: static assertion failed: Please include <webcface/value.h> to use class 'Value'!
   19 |         static_assert(decltype(isComplete((T *)nullptr))::value,               \
      |                                                           ^~~~~
```
というエラーを出すようにする

MSVCの例:
```
C:\Users\shach\robotech\webcface\client\include\webcface\complete.h(28,1): error C2338: static_assert failed: 'Please include <webcface/value.h> to use class Value!' [C:\Users\shach\robotech\webcface\build_vs\examples\c590b3c@@webcface-example-value@exe.vcxproj]
C:\Users\shach\robotech\webcface\examples\value.cc(11,10): error C2027: 認識できない型 'webcface::v21_debug::Value' が使われています。 [C:\Users\shach\robotech\webcface\build_vs\examples\c590b3c@@webcface-example-value@exe.vcxproj]
C:\Users\shach\robotech\webcface\examples\value.cc(11,24): error C2582: 'operator '=' 関数を 'webcface::v21_debug::Value' で使用できません。 [C:\Users\shach\robotech\webcface\build_vs\examples\c590b3c@@webcface-example-value@exe.vcxproj]
```

* 関数の定義内でstatic_assertするよりテンプレートのsubstitutionでやったほうがgccではエラーメッセージがわかりやすい気がしたのでそうした
* これを実装するには今までsrcに書いていた実装もすべてテンプレートにしてinluneで書かないといけない、めんどくさい
* 代替案
  * デフォルト引数はgccで問答無用で評価されてしまう
  * 戻り値型をテンプレートクラスにしてその本体にstatic_assertがある場合使うときにだけインスタンス化されてよさそうだが、でも型変わるのはちょっと...
  * usingでは宣言時に型が確定するのでどうにもならない