### PR TITLE
View::inserter()追加

### DIFF
--- a/client/include/webcface/view.h
+++ b/client/include/webcface/view.h
@@ -248,7 +248,7 @@ class WEBCFACE_DLL View : protected Field {
     }
 
     /*!
-     * \brief back inserter iterator を返す
+     * \brief このViewに文字列を出力する back inserter iterator を返す
      * \since ver2.6
      *
      * * これが返すイテレーターを使うことでViewに文字列を追加できる。
@@ -258,6 +258,14 @@ class WEBCFACE_DLL View : protected Field {
     std::ostreambuf_iterator<char> inserter() const {
         return std::ostreambuf_iterator<char>(os);
     }
+    /*!
+     * \brief このViewに文字列を出力するostreamを返す
+     * \since ver2.6
+     *
+     * * 参照はこのViewが破棄されるまで有効
+     *
+     */
+    std::ostream &ostream() const { return os; }
 
     /*!
      * \brief Viewの内容をclientに反映し送信可能にする

--- a/client/include/webcface/view.h
+++ b/client/include/webcface/view.h
@@ -246,6 +246,18 @@ class WEBCFACE_DLL View : protected Field {
     }
 
     /*!
+     * \brief back inserter iterator を返す
+     * \since ver2.6
+     *
+     * * これが返すイテレーターを使うことでViewに文字列を追加できる。
+     * * fmt::format_to や std::format_to に渡して使う
+     *
+     */
+    std::ostreambuf_iterator<char> inserter() const {
+        return std::ostreambuf_iterator<char>(os);
+    }
+
+    /*!
      * \brief Viewの内容をclientに反映し送信可能にする
      *
      * * ver1.2以降: このViewオブジェクトの内容が変更されていなければ

--- a/docs/54_view.md
+++ b/docs/54_view.md
@@ -25,7 +25,7 @@ Viewの2回目以降の送信時にはWebCFace内部では前回からの差分�
     View::add() などで要素を追加し、
     最後にView::sync()をしてからClient::sync()をすることで送信されます。
 
-    Viewはstd::ostreamを継承しており、 add() の代わりに v << 表示する値; というようにもできます。
+    Viewはstd::ostreamを継承しており、 add() の代わりに `v << 表示する値;` というようにもできます。
     ostreamに出力可能なものはそのままviewにテキストとして出力できます。
     ostreamと同様にフォーマットを指定したり、std::endlで改行もできます。
 
@@ -41,9 +41,17 @@ Viewの2回目以降の送信時にはWebCFace内部では前回からの差分�
     ```
     ![example_view.png](https://github.com/na-trium-144/webcface/raw/main/docs/images/example_view.png)
 
+    <span class="since-c">2.6</span>
+    View::inserter() が返すイテレーターを使って、 `fmt::format_to()` や `std::format_to()` で出力することもできます。
+    ```cpp
+    #include <fmt/base.h>
+
+    fmt::format_to(v.inserter(), "with inserter: {}\n", i);
+    ```
+
     \warning
     <span class="since-c">2.0</span>
-    ワイド文字列を出力したい場合はostreamに直接渡すのではなく Component::text を使う必要があります。
+    ワイド文字列を出力したい場合はostreamやinserterに直接渡すのではなく Component::text を使う必要があります。
     (後述)
 
     C++ではViewのデストラクタでも自動的にView.sync()が呼ばれます。
@@ -186,11 +194,11 @@ Viewに追加する各種要素をViewComponentといいます。
 <div class="tabbed">
 
 - <b class="tab-title">C++</b>
-    std::ostreamでフォーマット可能なデータはそのまま渡して文字列化できます。
-    View::add()関数, set()関数でも同様に文字列に変換されます。
+    Viewをostreamとして使うことで、std::ostreamでフォーマット可能なデータはそのまま渡して文字列化できます。
+
+    View::add() 関数に数値や文字列などを渡すことでも文字列に変換されます。
     ```cpp
     v.add("hello").add(123);
-    v << "hello" << 123;
     ```
     
     文字列を直接渡す代わりに `text(文字列)` でViewComponentに変換すると、textColorなど後述のオプションを指定することもできるようになります。
@@ -200,6 +208,9 @@ Viewに追加する各種要素をViewComponentといいます。
 
     <span class="since-c">2.0</span>
     Viewに直接ワイド文字列を出力することはできませんが、text()の引数にはワイド文字列も使用可能です。
+
+    <span class="since-c">2.6</span>
+    View::inserter() が返すイテレーターを使って、 `fmt::format_to()` や `std::format_to()` で出力することもできます。
 
 - <b class="tab-title">C</b>
     wcfText, (<span class="since-c">2.0</span> wcfTextW) でテキストを指定します。

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -23,6 +23,7 @@ foreach e: example_src
   dependencies = [
     warning_options,
     webcface_dep,
+    fmt_dep,
   ]
   if e['libvips']
     dependencies += libvips_cpp_dep

--- a/examples/view.cc
+++ b/examples/view.cc
@@ -3,6 +3,7 @@
 #include <thread>
 #include <iostream>
 #include <chrono>
+#include <fmt/base.h>
 
 int main() {
     webcface::Client wcli("example_view");
@@ -17,6 +18,7 @@ int main() {
             auto v = wcli.view("a");
             v << "hello world" << std::endl;
             v << i << std::endl;
+            fmt::format_to(v.inserter(), "with inserter: {}\n", i);
             v << webcface::button("a",
                                   [] { std::cout << "hello" << std::endl; });
             v << std::endl;

--- a/tests/view_test.cc
+++ b/tests/view_test.cc
@@ -100,11 +100,15 @@ TEST_F(ViewTest, viewSet) {
     };
     v << manip2;
     EXPECT_EQ(manip_called, 1);
+    auto inserter = v.inserter();
+    *inserter = 'i';
+    *inserter = 'n';
+    *inserter = 's';
     v.sync();
     EXPECT_EQ(callback_called, 1);
     auto &view_data_base = **data_->view_store.getRecv(self_name, "b"_ss);
-    EXPECT_EQ(view_data_base.components.size(), 11u);
-    EXPECT_EQ(view_data_base.data_ids.size(), 11u);
+    EXPECT_EQ(view_data_base.components.size(), 12u);
+    EXPECT_EQ(view_data_base.data_ids.size(), 12u);
     std::vector<std::shared_ptr<message::ViewComponentData>> view_data;
     view_data.reserve(view_data_base.components.size());
     for (const auto &id : view_data_base.data_ids) {
@@ -198,6 +202,9 @@ TEST_F(ViewTest, viewSet) {
     // EXPECT_EQ(static_cast<std::string>(
     //               text(self_name, view_data[10].text_ref_->field_).get()),
     //           "aaa");
+
+    EXPECT_EQ(view_data[11]->type, static_cast<int>(ViewComponentType::text));
+    EXPECT_EQ(view_data[11]->text.u8String(), "ins");
 
     v.init();
     v.sync();


### PR DESCRIPTION
* View::inserter() 追加
* View::ostream() 追加
  * 昔はostreamの継承だったような? 今なんでユーザーがostreamに直接アクセスできないようになってたんだっけ