### PR TITLE
fabi-version=11を指定

### DIFF
--- a/.github/workflows/cmake-test-linux-gcc-multiarch.yaml
+++ b/.github/workflows/cmake-test-linux-gcc-multiarch.yaml
@@ -1,0 +1,81 @@
+name: Meson Test (Linux Arm GCC)
+
+on:
+  # push:
+  #   branches: [ "main" ]
+  pull_request:
+    branches: []
+
+jobs:
+  build-linux:
+    # The host should always be linux
+    runs-on: ubuntu-22.04
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+
+    # Run steps on a matrix of 4 arch/distro combinations
+    strategy:
+      matrix:
+        arch: [arm64, armhf]
+        distro: ["24.04"]
+        include:
+          # - arch: amd64
+          #   base: ubuntu
+          - arch: arm64
+            base: '--platform=linux/arm64/v8 arm64v8/ubuntu'
+          - arch: armhf
+            base: '--platform=linux/arm/v7 arm32v7/ubuntu'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: uraimo/run-on-arch-action@v2
+        name: Build artifact
+        id: build
+        with:
+          arch: none
+          distro: none
+          base_image: ${{matrix.base}}:${{matrix.distro}}
+
+          # Not required, but speeds up builds
+          # githubToken: ${{ github.token }}
+
+          # Create an artifacts directory
+          # setup: |
+          #   mkdir -p "${PWD}/artifacts"
+
+          # Mount the artifacts directory as /artifacts in the container
+          dockerRunArgs: |
+            --volume "${{github.workspace}}:/workspace"
+
+          # Pass some environment variables to the container
+          # env: | # YAML, but pipe character is necessary
+          #   artifact_name: git-${{ matrix.distro }}_${{ matrix.arch }}
+
+          # armv7のubuntu20.04でなぜかSSL周りがエラーになり、これでなぜか直る
+          env: |
+            SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+            CC: gcc-14
+            CXX: g++-14
+
+          # The shell to run commands with in the container
+          shell: /bin/sh
+
+          # Install some dependencies in the container. This speeds up builds if
+          # you are also using githubToken. Any dependencies installed here will
+          # be part of the container image that gets cached, so subsequent
+          # builds don't have to re-install them. The image layer is cached
+          # publicly in your project's package repository, so it is vital that
+          # no secrets are present in the container state or logs.
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y ca-certificates gpg wget lsb-release
+            wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc --no-check-certificate | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+            echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+            apt-get update -q -y
+            apt-get install -q -y build-essential gcc-14 g++-14 cmake meson file git python3-pip ninja-build zip pkg-config
+
+          # Produce a binary artifact and place it in the mounted volume
+          run: |
+            cd /workspace
+            meson setup build --buildtype=release -Dwrap_mode=forcefallback --prefix=/opt/webcface -Dversion_suffix= -Ddownload_webui=disabled -Dpkgconfig.relocatable=true
+            meson compile -C build || meson compile -C build
+            DESTDIR=/workspace/dist meson install -C build --skip-subprojects
+

--- a/.github/workflows/cmake-test-linux-gcc.yml
+++ b/.github/workflows/cmake-test-linux-gcc.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Check Exported Symbol
       if: matrix.dep == 'source'
       run: |
-        bash -c "! nm -g --defined-only build/libwebcface.so | grep -v webcface | grep -v wcf | grep -v St | grep -v gnu_cxx"
+        bash -c "! nm -g --defined-only build/libwebcface.so | c++filt | grep -v webcface | grep -v wcf | grep -v std:: | grep -v St | grep -v gnu_cxx"
         bash -c "! nm -g --defined-only build/libwebcface.so | grep -v webcface | grep -v wcf | grep spdlog"
         bash -c "! nm -g --defined-only build/libwebcface.so | grep -v webcface | grep -v wcf | grep fmt"
         bash -c "! nm -g --defined-only build/libwebcface.so | grep -v webcface | grep -v wcf | grep crow"

--- a/.github/workflows/cmake-test-linux-gcc.yml
+++ b/.github/workflows/cmake-test-linux-gcc.yml
@@ -68,7 +68,7 @@ jobs:
         bash -c "! nm -g --defined-only build/libwebcface.so | grep -v webcface | grep -v wcf | grep fmt"
         bash -c "! nm -g --defined-only build/libwebcface.so | grep -v webcface | grep -v wcf | grep crow"
         bash -c "! nm -g --defined-only build/libwebcface.so | grep -v webcface | grep -v wcf | grep asio"
-        bash -c "! nm -g --defined-only build/libwebcface.so | grep -v webcface | grep -v wcf | grep utf8"
+        bash -c "! nm -g --defined-only build/libwebcface.so | grep -v webcface | grep -v wcf | grep -v codecvt_utf8 | grep utf8"
         bash -c "! nm -g --defined-only build/libwebcface.so | grep -v webcface | grep -v wcf | grep vips"
 
     - name: install

--- a/.github/workflows/cmake-test-linux-gcc.yml
+++ b/.github/workflows/cmake-test-linux-gcc.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         dep: ["apt", "source"]
-        gcc-ver: [7, 9, 11, 13]
+        gcc-ver: [7, 9, 11, 13, 14]
         include:
         - os: ubuntu-20.04
           gcc_ver: 7
@@ -21,6 +21,8 @@ jobs:
           gcc_ver: 11
         - os: ubuntu-24.04
           gcc_ver: 13
+        - os: ubuntu-24.04
+          gcc_ver: 14
         - dep: static
           os: ubuntu-20.04
           gcc_ver: 9

--- a/.github/workflows/cmake-test-linux-gcc.yml
+++ b/.github/workflows/cmake-test-linux-gcc.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         dep: ["apt", "source"]
-        gcc-ver: [7, 9, 11, 13, 14]
+        gcc_ver: [7, 9, 11, 13, 14]
         include:
         - os: ubuntu-20.04
           gcc_ver: 7

--- a/client/include/webcface/complete.h
+++ b/client/include/webcface/complete.h
@@ -16,11 +16,11 @@ constexpr bool isComplete(T *) {
 
 #define define_assert_complete(Type, header)                                   \
     template <typename T>                                                      \
-    constexpr std::nullptr_t assertComplete##Type() {                          \
+    constexpr bool assertComplete##Type() {                                    \
         static_assert(isComplete((T *)nullptr),                                \
                       "Please include <webcface/" #header                      \
                       "> to use class " #Type "!");                            \
-        return nullptr;                                                        \
+        return true;                                                           \
     }
 
 // clang-format off
@@ -42,7 +42,7 @@ define_assert_complete(Log, log.h)
 
 #define WEBCFACE_COMPLETE(Type)                                                \
     typename Type##_ = Type,                                                   \
-             std::nullptr_t = ::webcface::traits::assertComplete##Type<        \
+             bool = ::webcface::traits::assertComplete##Type<                  \
                  std::enable_if_t<std::is_same_v<Type##_, Type>, Type##_>>()
 
 } // namespace traits

--- a/client/include/webcface/component_canvas2d.h
+++ b/client/include/webcface/component_canvas2d.h
@@ -134,7 +134,7 @@ class WEBCFACE_DLL Canvas2DComponent {
     template <WEBCFACE_COMPLETE(Func)>
     std::optional<Func_> onClick() const;
 };
-extern template std::optional<Func> Canvas2DComponent::onClick<Func, nullptr>() const;
+extern template std::optional<Func> Canvas2DComponent::onClick<Func, true>() const;
 
 class WEBCFACE_DLL TemporalCanvas2DComponent {
     std::unique_ptr<internal::TemporalCanvas2DComponentData> msg_data;

--- a/client/include/webcface/component_canvas3d.h
+++ b/client/include/webcface/component_canvas3d.h
@@ -109,7 +109,7 @@ class WEBCFACE_DLL Canvas3DComponent {
     std::optional<RobotModel_> robotModel() const;
 };
 extern template std::optional<RobotModel>
-Canvas3DComponent::robotModel<RobotModel, nullptr>() const;
+Canvas3DComponent::robotModel<RobotModel, true>() const;
 
 /*!
  * \brief Canvas3Dを構築するときに使う一時的なCanvas3DComponent

--- a/client/include/webcface/component_view.h
+++ b/client/include/webcface/component_view.h
@@ -272,11 +272,11 @@ class WEBCFACE_DLL ViewComponent {
     int height() const;
 };
 extern template std::optional<Func>
-ViewComponent::onClick<Func, nullptr>() const;
+ViewComponent::onClick<Func, true>() const;
 extern template std::optional<Func>
-ViewComponent::onChange<Func, nullptr>() const;
+ViewComponent::onChange<Func, true>() const;
 extern template std::optional<Variant>
-ViewComponent::bind<Variant, nullptr>() const;
+ViewComponent::bind<Variant, true>() const;
 
 /*!
  * \brief Viewを構築するときに使う一時的なViewComponent

--- a/client/include/webcface/field.h
+++ b/client/include/webcface/field.h
@@ -285,7 +285,8 @@ struct WEBCFACE_DLL Field : public FieldBase {
      */
     std::vector<Field> childrenRecurse() const;
     /*!
-     * \brief 「(thisの名前).(追加の名前)」で公開されているデータが存在するかどうかを返す
+     * \brief
+     * 「(thisの名前).(追加の名前)」で公開されているデータが存在するかどうかを返す
      * \since ver2.6
      * \sa children(), childrenRecurse()
      */
@@ -370,17 +371,17 @@ struct WEBCFACE_DLL Field : public FieldBase {
     bool operator!=(const Field &other) const { return !(*this == other); }
 };
 
-extern template std::vector<Value> Field::valueEntries<Value, nullptr>() const;
-extern template std::vector<Text> Field::textEntries<Text, nullptr>() const;
+extern template std::vector<Value> Field::valueEntries<Value, true>() const;
+extern template std::vector<Text> Field::textEntries<Text, true>() const;
 extern template std::vector<RobotModel>
-Field::robotModelEntries<RobotModel, nullptr>() const;
-extern template std::vector<Func> Field::funcEntries<Func, nullptr>() const;
-extern template std::vector<View> Field::viewEntries<View, nullptr>() const;
+Field::robotModelEntries<RobotModel, true>() const;
+extern template std::vector<Func> Field::funcEntries<Func, true>() const;
+extern template std::vector<View> Field::viewEntries<View, true>() const;
 extern template std::vector<Canvas2D>
-Field::canvas2DEntries<Canvas2D, nullptr>() const;
+Field::canvas2DEntries<Canvas2D, true>() const;
 extern template std::vector<Canvas3D>
-Field::canvas3DEntries<Canvas3D, nullptr>() const;
-extern template std::vector<Image> Field::imageEntries<Image, nullptr>() const;
-extern template std::vector<Log> Field::logEntries<Log, nullptr>() const;
+Field::canvas3DEntries<Canvas3D, true>() const;
+extern template std::vector<Image> Field::imageEntries<Image, true>() const;
+extern template std::vector<Log> Field::logEntries<Log, true>() const;
 
 WEBCFACE_NS_END

--- a/client/include/webcface/internal/client_internal.h
+++ b/client/include/webcface/internal/client_internal.h
@@ -8,7 +8,6 @@
 #include <atomic>
 #include <unordered_map>
 #include <cstdlib>
-#include <spdlog/logger.h>
 #include "webcface/common/encoding.h"
 #include "webcface/common/internal/message/image.h"
 #include "webcface/field.h"
@@ -19,6 +18,14 @@
 #include "data_store2.h"
 #include "func_internal.h"
 #include "webcface/image_frame.h"
+#ifdef WEBCFACE_COMPILER_IS_GCC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wabi"
+#endif
+#include <spdlog/logger.h>
+#ifdef WEBCFACE_COMPILER_IS_GCC
+#pragma GCC diagnostic pop
+#endif
 
 WEBCFACE_NS_BEGIN
 

--- a/client/include/webcface/member.h
+++ b/client/include/webcface/member.h
@@ -293,6 +293,6 @@ class WEBCFACE_DLL Member : protected Field {
         return static_cast<Field>(*this) != static_cast<Field>(other);
     }
 };
-extern template Log Member::log<Log, nullptr>() const;
+extern template Log Member::log<Log, true>() const;
 
 WEBCFACE_NS_END

--- a/client/meson.build
+++ b/client/meson.build
@@ -52,7 +52,14 @@ webcface_client_lib = static_library('webcface-client',
     m_dep,
   ],
   build_by_default: false,
-  cpp_args: ['-DWEBCFACE_BUILDING'],
+  cpp_args: [
+    '-DWEBCFACE_BUILDING',
+    cxx.get_supported_arguments(
+      # https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html
+      '-fabi-version=11',
+      '-Wabi',
+    ),
+  ],
   gnu_symbol_visibility: 'inlineshidden',
 )
 webcface_client_dep = declare_dependency(

--- a/client/meson.build
+++ b/client/meson.build
@@ -58,6 +58,7 @@ webcface_client_lib = static_library('webcface-client',
       # https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html
       '-fabi-version=11',
       '-Wabi',
+      '-Wpsabi',
     ),
   ],
   gnu_symbol_visibility: 'inlineshidden',

--- a/client/src/client_threading.cc
+++ b/client/src/client_threading.cc
@@ -165,6 +165,10 @@ void internal::wsThreadMain(const std::shared_ptr<ClientData> &data) {
             {
                 // sendの前にrecvを行う
                 ScopedUnlock un(lock_ws);
+#ifdef WEBCFACE_COMPILER_IS_GCC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wabi"
+#endif
                 while (
                     // curl側に溜まっているデータがなくなるまで受信処理
                     internal::WebSocket::recv(data, [data](std::string &&msg) {
@@ -176,6 +180,9 @@ void internal::wsThreadMain(const std::shared_ptr<ClientData> &data) {
                         data->ws_cond.notify_all();
                     })) {
                 }
+#ifdef WEBCFACE_COMPILER_IS_GCC
+#pragma GCC diagnostic pop
+#endif
             }
             lock_ws.getData().do_ws_recv = false;
             lock_ws.getData().recv_ready = false;

--- a/client/src/client_threading.cc
+++ b/client/src/client_threading.cc
@@ -3,10 +3,18 @@
 #include "webcface/internal/client_internal.h"
 #include "webcface/internal/client_ws.h"
 #include "webcface/common/internal/unlock.h"
+
+#ifdef WEBCFACE_COMPILER_IS_GCC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wabi"
+#endif
+#include <spdlog/sinks/stdout_color_sinks.h>
+#ifdef WEBCFACE_COMPILER_IS_GCC
+#pragma GCC diagnostic pop
+#endif
 #include <string>
 #include <chrono>
 #include <thread>
-#include <spdlog/sinks/stdout_color_sinks.h>
 
 WEBCFACE_NS_BEGIN
 

--- a/client/src/component_canvas2d.cc
+++ b/client/src/component_canvas2d.cc
@@ -167,7 +167,7 @@ TemporalCanvas2DComponent::geometry(const Geometry &g) & {
     return *this;
 }
 
-template <typename T, std::nullptr_t>
+template <typename T, bool>
 std::optional<T> Canvas2DComponent::onClick() const {
     checkData();
     if (msg_data->on_click_member && msg_data->on_click_field) {
@@ -178,7 +178,7 @@ std::optional<T> Canvas2DComponent::onClick() const {
     }
 }
 template WEBCFACE_DLL std::optional<Func>
-Canvas2DComponent::onClick<Func, nullptr>() const;
+Canvas2DComponent::onClick<Func, true>() const;
 TemporalCanvas2DComponent &
 TemporalCanvas2DComponent::onClick(const Func &func) & {
     msg_data->on_click_member = static_cast<FieldBase>(func).member_;

--- a/client/src/component_canvas3d.cc
+++ b/client/src/component_canvas3d.cc
@@ -113,7 +113,7 @@ TemporalCanvas3DComponent::geometry(const Geometry &g) & {
     msg_data->geometry_properties = g.properties;
     return *this;
 }
-template <typename T, std::nullptr_t>
+template <typename T, bool>
 std::optional<T> Canvas3DComponent::robotModel() const {
     checkData();
     if (msg_data->field_member && msg_data->field_field &&
@@ -125,7 +125,7 @@ std::optional<T> Canvas3DComponent::robotModel() const {
     }
 }
 template WEBCFACE_DLL std::optional<RobotModel>
-Canvas3DComponent::robotModel<RobotModel, nullptr>() const;
+Canvas3DComponent::robotModel<RobotModel, true>() const;
 TemporalCanvas3DComponent &
 TemporalCanvas3DComponent::robotModel(const RobotModel &field) & {
     msg_data->data_w = static_cast<Field>(field).data_w;

--- a/client/src/component_view.cc
+++ b/client/src/component_view.cc
@@ -271,13 +271,13 @@ TemporalViewComponent &TemporalViewComponent::text(std::wstring_view text) & {
     msg_data->text = SharedString::encode(text);
     return *this;
 }
-template <typename T, std::nullptr_t>
+template <typename T, bool>
 std::optional<T> ViewComponent::onChange() const {
     return onClick();
 }
 template WEBCFACE_DLL std::optional<Func>
-ViewComponent::onChange<Func, nullptr>() const;
-template <typename T, std::nullptr_t>
+ViewComponent::onChange<Func, true>() const;
+template <typename T, bool>
 std::optional<T> ViewComponent::onClick() const {
     checkData();
     if (msg_data->on_click_member && msg_data->on_click_field) {
@@ -289,7 +289,7 @@ std::optional<T> ViewComponent::onClick() const {
     }
 }
 template WEBCFACE_DLL std::optional<Func>
-ViewComponent::onClick<Func, nullptr>() const;
+ViewComponent::onClick<Func, true>() const;
 TemporalViewComponent &TemporalViewComponent::onClick(const Func &func) & {
     msg_data->on_click_member.emplace(static_cast<FieldBase>(func).member_);
     msg_data->on_click_field.emplace(static_cast<FieldBase>(func).field_);
@@ -313,7 +313,7 @@ TemporalViewComponent &TemporalViewComponent::bind(const InputRef &ref) & {
     msg_data->text_ref_tmp = ref;
     return *this;
 }
-template <typename T, std::nullptr_t>
+template <typename T, bool>
 std::optional<T> ViewComponent::bind() const {
     checkData();
     if (msg_data->text_ref_member && msg_data->text_ref_field) {
@@ -324,7 +324,7 @@ std::optional<T> ViewComponent::bind() const {
     }
 }
 template WEBCFACE_DLL std::optional<Variant>
-ViewComponent::bind<Variant, nullptr>() const;
+ViewComponent::bind<Variant, true>() const;
 
 TemporalViewComponent &TemporalViewComponent::onChange(
     const std::shared_ptr<std::function<void WEBCFACE_CALL_FP(ValAdaptor)>>

--- a/client/src/field.cc
+++ b/client/src/field.cc
@@ -143,60 +143,57 @@ std::vector<Field> Field::children() const {
     entries(ret, this, data->log_store, false);
     return ret;
 }
-template <typename T, std::nullptr_t>
+template <typename T, bool>
 std::vector<T> Field::valueEntries() const {
     return entries<Value>(this, dataLock()->value_store);
 }
-template <typename T, std::nullptr_t>
+template <typename T, bool>
 std::vector<T> Field::textEntries() const {
     return entries<Text>(this, dataLock()->text_store);
 }
-template <typename T, std::nullptr_t>
+template <typename T, bool>
 std::vector<T> Field::robotModelEntries() const {
     return entries<RobotModel>(this, dataLock()->robot_model_store);
 }
-template <typename T, std::nullptr_t>
+template <typename T, bool>
 std::vector<T> Field::funcEntries() const {
     return entries<Func>(this, dataLock()->func_store);
 }
-template <typename T, std::nullptr_t>
+template <typename T, bool>
 std::vector<T> Field::viewEntries() const {
     return entries<View>(this, dataLock()->view_store);
 }
-template <typename T, std::nullptr_t>
+template <typename T, bool>
 std::vector<T> Field::canvas3DEntries() const {
     return entries<Canvas3D>(this, dataLock()->canvas3d_store);
 }
-template <typename T, std::nullptr_t>
+template <typename T, bool>
 std::vector<T> Field::canvas2DEntries() const {
     return entries<Canvas2D>(this, dataLock()->canvas2d_store);
 }
-template <typename T, std::nullptr_t>
+template <typename T, bool>
 std::vector<T> Field::imageEntries() const {
     return entries<Image>(this, dataLock()->image_store);
 }
-template <typename T, std::nullptr_t>
+template <typename T, bool>
 std::vector<T> Field::logEntries() const {
     return entries<Log>(this, dataLock()->log_store);
 }
 
 template WEBCFACE_DLL std::vector<Value>
-Field::valueEntries<Value, nullptr>() const;
-template WEBCFACE_DLL std::vector<Text>
-Field::textEntries<Text, nullptr>() const;
+Field::valueEntries<Value, true>() const;
+template WEBCFACE_DLL std::vector<Text> Field::textEntries<Text, true>() const;
 template WEBCFACE_DLL std::vector<RobotModel>
-Field::robotModelEntries<RobotModel, nullptr>() const;
-template WEBCFACE_DLL std::vector<Func>
-Field::funcEntries<Func, nullptr>() const;
-template WEBCFACE_DLL std::vector<View>
-Field::viewEntries<View, nullptr>() const;
+Field::robotModelEntries<RobotModel, true>() const;
+template WEBCFACE_DLL std::vector<Func> Field::funcEntries<Func, true>() const;
+template WEBCFACE_DLL std::vector<View> Field::viewEntries<View, true>() const;
 template WEBCFACE_DLL std::vector<Canvas2D>
-Field::canvas2DEntries<Canvas2D, nullptr>() const;
+Field::canvas2DEntries<Canvas2D, true>() const;
 template WEBCFACE_DLL std::vector<Canvas3D>
-Field::canvas3DEntries<Canvas3D, nullptr>() const;
+Field::canvas3DEntries<Canvas3D, true>() const;
 template WEBCFACE_DLL std::vector<Image>
-Field::imageEntries<Image, nullptr>() const;
-template WEBCFACE_DLL std::vector<Log> Field::logEntries<Log, nullptr>() const;
+Field::imageEntries<Image, true>() const;
+template WEBCFACE_DLL std::vector<Log> Field::logEntries<Log, true>() const;
 
 bool Field::expired() const { return data_w.expired(); }
 

--- a/client/src/member.cc
+++ b/client/src/member.cc
@@ -13,11 +13,11 @@
 WEBCFACE_NS_BEGIN
 
 // ver2.4〜: nameを省略した場合 "default" として送信される。
-template <typename T, std::nullptr_t>
+template <typename T, bool>
 T Member::log() const {
     return Log{*this, message::Log::defaultLogName()};
 }
-template WEBCFACE_DLL Log Member::log<Log, nullptr>() const;
+template WEBCFACE_DLL Log Member::log<Log, true>() const;
 
 
 const Member &Member::onValueEntry(std::function<void(Value)> callback) const {

--- a/client/src/transform.cc
+++ b/client/src/transform.cc
@@ -347,8 +347,7 @@ Rotation::axisAngleToQuaternion(const std::array<double, 3> &axis,
                 axis[2] / norm * s};
     }
 }
-std::pair<std::array<double, 3>, double>
-Rotation::quaternionToAxisAngle(const std::array<double, 4> &quat) {
+AxisAngle Rotation::quaternionToAxisAngle(const std::array<double, 4> &quat) {
     double w = quat[0];
     double x = quat[1];
     double y = quat[2];

--- a/common/include/webcface/common/internal/message/fmt.h
+++ b/common/include/webcface/common/internal/message/fmt.h
@@ -2,7 +2,21 @@
 #ifndef SPDLOG_FMT_EXTERNAL
 #error "SPDLOG_FMT_EXTERNAL must be enabled. Clear the build directory and try again."
 #endif
+
+#ifdef WEBCFACE_MESON
+#include "webcface-config.h"
+#else
+#include "webcface/common/webcface-config.h"
+#endif
+
+#ifdef WEBCFACE_COMPILER_IS_GCC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wabi"
+#endif
 #include <fmt/base.h>
+#ifdef WEBCFACE_COMPILER_IS_GCC
+#pragma GCC diagnostic pop
+#endif
 
 #define WEBCFACE_MESSAGE_FMT(Type)                                             \
     template <>                                                                \

--- a/common/include/webcface/common/internal/message/pack.h
+++ b/common/include/webcface/common/internal/message/pack.h
@@ -6,10 +6,18 @@
 #include <msgpack.hpp>
 #include <string>
 #include <cstdint>
-#include <spdlog/logger.h>
 #include <utf8.h>
 #include "webcface/common/val_adaptor.h"
 #include "./base.h"
+
+#ifdef WEBCFACE_COMPILER_IS_GCC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wabi"
+#endif
+#include <spdlog/logger.h>
+#ifdef WEBCFACE_COMPILER_IS_GCC
+#pragma GCC diagnostic pop
+#endif
 
 MSGPACK_ADD_ENUM(webcface::ValType)
 

--- a/common/include/webcface/common/internal/unix_path.h
+++ b/common/include/webcface/common/internal/unix_path.h
@@ -4,7 +4,14 @@
 #else
 #include "webcface/common/webcface-config.h"
 #endif
+#ifdef WEBCFACE_COMPILER_IS_GCC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wabi"
+#endif
 #include <spdlog/logger.h>
+#ifdef WEBCFACE_COMPILER_IS_GCC
+#pragma GCC diagnostic pop
+#endif
 
 #if WEBCFACE_EXP_FILESYSTEM
 #include <experimental/filesystem>

--- a/common/src/fmt.cc
+++ b/common/src/fmt.cc
@@ -1,15 +1,23 @@
-#include <webcface/common/internal/message/value.h>
-#include <webcface/common/internal/message/text.h>
-#include <webcface/common/internal/message/view.h>
-#include <webcface/common/internal/message/canvas2d.h>
-#include <webcface/common/internal/message/canvas3d.h>
-#include <webcface/common/internal/message/image.h>
-#include <webcface/common/internal/message/func.h>
-#include <webcface/common/internal/message/log.h>
-#include <webcface/common/internal/message/robot_model.h>
-#include <webcface/common/internal/message/sync.h>
+#include "webcface/common/internal/message/value.h"
+#include "webcface/common/internal/message/text.h"
+#include "webcface/common/internal/message/view.h"
+#include "webcface/common/internal/message/canvas2d.h"
+#include "webcface/common/internal/message/canvas3d.h"
+#include "webcface/common/internal/message/image.h"
+#include "webcface/common/internal/message/func.h"
+#include "webcface/common/internal/message/log.h"
+#include "webcface/common/internal/message/robot_model.h"
+#include "webcface/common/internal/message/sync.h"
+
+#ifdef WEBCFACE_COMPILER_IS_GCC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wabi"
+#endif
 #include <fmt/std.h>
 #include <fmt/chrono.h>
+#ifdef WEBCFACE_COMPILER_IS_GCC
+#pragma GCC diagnostic pop
+#endif
 
 #define WEBCFACE_MESSAGE_FMT_DEF(Type)                                         \
     auto fmt::formatter<Type>::format([[maybe_unused]] const Type &m,          \

--- a/meson.build
+++ b/meson.build
@@ -279,6 +279,9 @@ endif
 if cxx.get_id() == 'gcc' and cxx.get_argument_syntax() != 'msvc'
   warning_options = declare_dependency(
     compile_args: cxx.get_supported_arguments(
+      # https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html
+      '-fabi-version=11',
+      '-Wabi',
       '-Wno-inline',
       '-Wno-attributes',
       '-Wno-error=psabi', # refer to PR#9

--- a/meson.build
+++ b/meson.build
@@ -281,7 +281,6 @@ if cxx.get_id() == 'gcc' and cxx.get_argument_syntax() != 'msvc'
     compile_args: cxx.get_supported_arguments(
       '-Wno-inline',
       '-Wno-attributes',
-      '-Wno-error=psabi', # refer to PR#9
       # crow
       '-Wno-error=type-limits',
       # inside fmt (fmtlib/fmt#3354)

--- a/meson.build
+++ b/meson.build
@@ -279,9 +279,6 @@ endif
 if cxx.get_id() == 'gcc' and cxx.get_argument_syntax() != 'msvc'
   warning_options = declare_dependency(
     compile_args: cxx.get_supported_arguments(
-      # https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html
-      '-fabi-version=11',
-      '-Wabi',
       '-Wno-inline',
       '-Wno-attributes',
       '-Wno-error=psabi', # refer to PR#9

--- a/scripts/config.h.in
+++ b/scripts/config.h.in
@@ -107,6 +107,11 @@ calling convention
 #define WEBCFACE_CALL_FP
 #endif
 
+// gccかどうかのチェック: webcfaceを使う側でも必要なので、コンパイル時にチェックする
+#if defined(__GNUC__) && !defined(__clang__)
+#define WEBCFACE_COMPILER_IS_GCC
+#endif
+
 // doxygenを生成するときは namespace webcface だけにする
 #ifdef WEBCFACE_DOXYGEN
 #define WEBCFACE_NS_BEGIN namespace webcface {

--- a/tests/transform_test.cc
+++ b/tests/transform_test.cc
@@ -306,13 +306,17 @@ TEST(TransformTest, quat) {
         Transform tf2 = rotFromQuat(w, x, y, z);
         Transform tf3 = rotFromQuat(tf2.rotQuat());
         Transform tf4 = rotFromEuler(tf2.rotEuler());
+        auto [axis, angle] = tf2.rotAxisAngle();
+        Transform tf5 = rotFromAxisAngle(axis, angle);
         auto axis_angle = tf2.rotAxisAngle();
-        Transform tf5 = rotFromAxisAngle(axis_angle.first, axis_angle.second);
+        Transform tf5_2 =
+            rotFromAxisAngle(get<0>(axis_angle), get<1>(axis_angle));
         for (std::size_t i = 0; i < 3; i++) {
             for (std::size_t j = 0; j < 3; j++) {
                 EXPECT_NEAR(tf2.rotMatrix(i, j), tf3.rotMatrix(i, j), 1e-8);
                 EXPECT_NEAR(tf2.rotMatrix(i, j), tf4.rotMatrix(i, j), 1e-8);
                 EXPECT_NEAR(tf2.rotMatrix(i, j), tf5.rotMatrix(i, j), 1e-8);
+                EXPECT_NEAR(tf2.rotMatrix(i, j), tf5_2.rotMatrix(i, j), 1e-8);
             }
         }
     };


### PR DESCRIPTION
gcc-9以前と10以降でABIが変わってしまう箇所を修正 & 今後同じことを起こさないようabi-version=11(g++-7)と互換性のないコードでwarningを出すようにした
https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html

* テンプレートのnullptrをboolに変更
* rotAxisAngle() の返り値をstd::pairから独自のstructに変更
  * .first や .second でアクセスできなくなるが、やむなし
