### PR TITLE
Func::setArgs()で引数型の情報が失われるバグを修正

### DIFF
--- a/client/src/func_info.cc
+++ b/client/src/func_info.cc
@@ -26,6 +26,7 @@ void Arg::mergeConfig(const Arg &other) {
     if (other.msg_data) {
         if (!this->msg_data) {
             this->msg_data = other.msg_data;
+            this->msg_data->type_ = this->type_;
         } else {
             if (!other.msg_data->name_.empty()) {
                 this->msg_data->name_ = other.msg_data->name_;
@@ -57,6 +58,9 @@ const std::wstring &Arg::nameW() const {
 ValType Arg::type() const { return this->type_; }
 Arg &Arg::type(ValType type) {
     this->type_ = type;
+    if (this->msg_data) {
+        this->msg_data->type_ = type;
+    }
     return *this;
 }
 std::optional<ValAdaptor> Arg::init() const {


### PR DESCRIPTION
v2.0 0840edc25224b811827e51dc3c95062b93762df5 からあるバグ