### PR TITLE
Revert "curl8.12も除外する"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -520,9 +520,16 @@ endif
 utf8cpp_dep = dependency('utf8cpp')
 
 # curlはvisibilityがhiddenになっている
-curl_dep = dependency('libcurl', version: ['>=7.86.0', '<8.10'])
-# curl 8.10〜8.12 はバグがある: https://github.com/curl/curl/issues/15865
+curl_dep = dependency('libcurl', version: '>=7.86.0')
 if curl_dep.type_name() != 'internal'
+  if host_machine.system() == 'darwin' and \
+      curl_dep.version().version_compare('>=8.10.0') and \
+      curl_dep.version().version_compare('<8.12.0')
+    # https://github.com/curl/curl/issues/15865
+    error('The WebSocket support in libcurl versions 8.10.0 through 8.12.0 has a bug on MacOS. ' +
+      'Use other versions or set "--force-fallback-for=libcurl".',
+    )
+  endif
   curl_dep_version = curl_dep.version().split('-')[0].split('.')
   curl_runtime_version_test = cxx.run('''
     #include <curl/curl.h>


### PR DESCRIPTION
Reverts na-trium-144/webcface#484

嘘でした。curl8.12.0のリリースノートに問題のバグ修正は含まれています