### PR TITLE
生配列をshared_stringに保存できるようにする

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,4 @@ UseTab: Never
 MaxEmptyLinesToKeep: 2
 SortIncludes: false
 AlwaysBreakTemplateDeclarations: true
+BreakAfterAttributes: Always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 * benchmark (#515)
 * NumVectorクラス (#516)
 	* Value::getVec() の返す型をstd::vectorからNumVectorに変更
+* StringView, StringInitializer (#526)
+	* ValAdaptor::getStringRef(), Variant::getStringRef(), InputRef::getStringRef() で　const参照を返せないのでdeprecatedに (stringのコピーを返す仕様にして残す)
+	* ValAdaptorからstring_viewへの暗黙変換を可能に、ValAdaptorからstringへの変換はexplicitに
+	* Variant::get() InputRef::get() をValAdaptorの参照からコピーに変更
+* `using ValAdapter = ValAdaptor;` を追加 (#526)
+
 ### Fixed
 * Logメッセージをwstringで渡した際のメモリ管理のミスを修正 (#510)
 ### Changed
@@ -19,6 +25,7 @@
 * std::condition_variableを使わずpollingするようにし、sync()を3割高速化 (#515)
 * クライアントの投げる例外の型をすべて独自のクラスに変更、メッセージを改善 (#518)
 * msgpackでシリアライズ時にdoubleをintやfloatに変換可能なら変換してからpackするようにした (#516)
+* Funcのtraitチェックのエラーメッセージを改善し、問題の引数がどれかわかるようにした (#526)
 
 ## [2.9.0] - 2025-02-09
 ### Added

--- a/benchmarks/encoding.cc
+++ b/benchmarks/encoding.cc
@@ -1,0 +1,60 @@
+#include <benchmark/benchmark.h>
+#include <webcface/common/encoding.h>
+
+void stringConstruct(benchmark::State &state){
+    std::string str = "hello, world";
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(std::string(str));
+    }
+}
+void SharedStringConstruct(benchmark::State &state){
+    std::string str = "hello, world";
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(webcface::SharedString::fromU8String(str));
+    }
+}
+void stringConstructStatic(benchmark::State &state){
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(std::string("hello, world"));
+    }
+}
+void SharedStringConstructStatic(benchmark::State &state){
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(webcface::SharedString::fromU8StringStatic("hello, world"));
+    }
+}
+void stringView(benchmark::State &state){
+    std::string str = "hello, world";
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(std::string_view(str));
+    }
+}
+void SharedStringView(benchmark::State &state){
+    webcface::SharedString ss = webcface::SharedString::fromU8StringStatic("hello, world");
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(ss.u8StringView());
+    }
+}
+void stringCompare(benchmark::State &state){
+    std::string str1 = "hello, world";
+    std::string str2 = "hello, world2";
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(str1 == str2);
+    }
+}
+void SharedStringCompare(benchmark::State &state){
+    webcface::SharedString ss1 = webcface::SharedString::fromU8StringStatic("hello, world");
+    webcface::SharedString ss2 = webcface::SharedString::fromU8StringStatic("hello, world2");
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(ss1 == ss2);
+    }
+}
+
+BENCHMARK(stringConstruct);
+BENCHMARK(SharedStringConstruct);
+BENCHMARK(stringConstructStatic);
+BENCHMARK(SharedStringConstructStatic);
+BENCHMARK(stringView);
+BENCHMARK(SharedStringView);
+BENCHMARK(stringCompare);
+BENCHMARK(SharedStringCompare);

--- a/benchmarks/encoding.cc
+++ b/benchmarks/encoding.cc
@@ -21,6 +21,16 @@ void SharedStringConstruct(benchmark::State &state){
         benchmark::DoNotOptimize(webcface::SharedString::fromU8String(strings[i++ % 10]));
     }
 }
+void SharedStringConstructWide(benchmark::State &state){
+    std::vector<std::wstring> strings;
+    for (int i = 0; i < 10; i++){
+        strings.emplace_back(L"hello, world " + std::to_wstring(i));
+    }
+    int i = 0;
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(webcface::SharedString::encode(strings[i++ % 10]));
+    }
+}
 void stringConstructStatic(benchmark::State &state){
     const char strings[][15] = {
         "hello, world 0", "hello, world 1", "hello, world 2", "hello, world 3",
@@ -76,13 +86,22 @@ void SharedStringCompare(benchmark::State &state){
         benchmark::DoNotOptimize(ss1 == ss2);
     }
 }
+void SharedStringCompareWide(benchmark::State &state){
+    webcface::SharedString ss1 = webcface::SharedString::fromU8StringStatic("hello, world");
+    webcface::SharedString ss2 = webcface::SharedString::encodeStatic(L"hello, world2");
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(ss1 == ss2);
+    }
+}
 
 BENCHMARK(stringConstruct);
 BENCHMARK(SharedStringConstruct);
 BENCHMARK(stringConstructStatic);
 BENCHMARK(SharedStringConstructStatic);
+BENCHMARK(SharedStringConstructWide);
 BENCHMARK(stringView);
 BENCHMARK(SharedStringView);
 BENCHMARK(SharedStringViewShare);
 BENCHMARK(stringCompare);
 BENCHMARK(SharedStringCompare);
+BENCHMARK(SharedStringCompareWide);

--- a/benchmarks/encoding.cc
+++ b/benchmarks/encoding.cc
@@ -35,6 +35,12 @@ void SharedStringView(benchmark::State &state){
         benchmark::DoNotOptimize(ss.u8StringView());
     }
 }
+void SharedStringViewShare(benchmark::State &state){
+    webcface::SharedString ss = webcface::SharedString::fromU8StringStatic("hello, world");
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(ss.u8StringViewShare());
+    }
+}
 void stringCompare(benchmark::State &state){
     std::string str1 = "hello, world";
     std::string str2 = "hello, world2";
@@ -56,5 +62,6 @@ BENCHMARK(stringConstructStatic);
 BENCHMARK(SharedStringConstructStatic);
 BENCHMARK(stringView);
 BENCHMARK(SharedStringView);
+BENCHMARK(SharedStringViewShare);
 BENCHMARK(stringCompare);
 BENCHMARK(SharedStringCompare);

--- a/benchmarks/encoding.cc
+++ b/benchmarks/encoding.cc
@@ -2,25 +2,46 @@
 #include <webcface/common/encoding.h>
 
 void stringConstruct(benchmark::State &state){
-    std::string str = "hello, world";
+    std::vector<std::string> strings;
+    for (int i = 0; i < 10; i++){
+        strings.emplace_back("hello, world " + std::to_string(i));
+    }
+    int i = 0;
     for (auto _ : state) {
-        benchmark::DoNotOptimize(std::string(str));
+        benchmark::DoNotOptimize(std::string(strings[i++ % 10]));
     }
 }
 void SharedStringConstruct(benchmark::State &state){
-    std::string str = "hello, world";
+    std::vector<std::string> strings;
+    for (int i = 0; i < 10; i++){
+        strings.emplace_back("hello, world " + std::to_string(i));
+    }
+    int i = 0;
     for (auto _ : state) {
-        benchmark::DoNotOptimize(webcface::SharedString::fromU8String(str));
+        benchmark::DoNotOptimize(webcface::SharedString::fromU8String(strings[i++ % 10]));
     }
 }
 void stringConstructStatic(benchmark::State &state){
+    const char strings[][15] = {
+        "hello, world 0", "hello, world 1", "hello, world 2", "hello, world 3",
+        "hello, world 4", "hello, world 5", "hello, world 6", "hello, world 7",
+        "hello, world 8", "hello, world 9"
+    };
+    int i = 0;
     for (auto _ : state) {
-        benchmark::DoNotOptimize(std::string("hello, world"));
+        benchmark::DoNotOptimize(std::string(strings[i++ % 10]));
     }
 }
 void SharedStringConstructStatic(benchmark::State &state){
+    const char strings[][15] = {
+        "hello, world 0", "hello, world 1", "hello, world 2", "hello, world 3",
+        "hello, world 4", "hello, world 5", "hello, world 6", "hello, world 7",
+        "hello, world 8", "hello, world 9"
+    };
+    int i = 0;
     for (auto _ : state) {
-        benchmark::DoNotOptimize(webcface::SharedString::fromU8StringStatic("hello, world"));
+        benchmark::DoNotOptimize(webcface::SharedString::fromU8StringStatic(
+            std::string_view(strings[i++ % 10])));
     }
 }
 void stringView(benchmark::State &state){

--- a/benchmarks/meson.build
+++ b/benchmarks/meson.build
@@ -42,5 +42,5 @@ webcface_benchmark = executable('webcface-benchmark',
   ],
 )
 benchmark('webcface-benchmark', webcface_benchmark,
-  timeout: 120,
+  timeout: 300,
 )

--- a/benchmarks/meson.build
+++ b/benchmarks/meson.build
@@ -1,5 +1,6 @@
 benchmark_src = [
   'main.cc',
+  'encoding.cc',
   'sync-value.cc',
   'sync-text.cc',
   'latency-value.cc',

--- a/client/include/webcface/arg.h
+++ b/client/include/webcface/arg.h
@@ -110,6 +110,20 @@ class WEBCFACE_DLL Arg {
     Arg &init(const T &init) {
         return this->init(ValAdaptor(init));
     }
+    /*!
+     * \since ver2.10
+     */
+    template <std::size_t N>
+    Arg &init(const char (&init)[N]) {
+        return this->init(ValAdaptor(init));
+    }
+    /*!
+     * \since ver2.10
+     */
+    template <std::size_t N>
+    Arg &init(const wchar_t (&init)[N]) {
+        return this->init(ValAdaptor(init));
+    }
     Arg &init(const ValAdaptor &init);
     /*!
      * \brief 最小値を取得する。

--- a/client/include/webcface/arg.h
+++ b/client/include/webcface/arg.h
@@ -68,9 +68,9 @@ class WEBCFACE_DLL Arg {
     /*!
      * \brief 引数名を設定する。
      *
-     * ver2.0〜wstring対応、ver2.10〜 String 型に変更
+     * ver2.0〜wstring対応、ver2.10〜 StringInitializer 型に変更
      */
-    Arg(String name) : Arg(static_cast<SharedString &>(name)) {}
+    Arg(StringInitializer name) : Arg(static_cast<SharedString &>(name)) {}
 
     /*!
      * \brief 引数の名前を取得する。

--- a/client/include/webcface/arg.h
+++ b/client/include/webcface/arg.h
@@ -16,7 +16,7 @@ WEBCFACE_NS_BEGIN
 namespace message {
 struct Arg;
 }
-namespace internal{
+namespace internal {
 struct FuncInfo;
 }
 
@@ -68,24 +68,25 @@ class WEBCFACE_DLL Arg {
     /*!
      * \brief 引数名を設定する。
      *
+     * ver2.0〜wstring対応、ver2.10〜 String 型に変更
      */
-    Arg(std::string_view name) : Arg(SharedString::encode(name)) {}
-    /*!
-     * \brief 引数名を設定する。(wstring)
-     * \since ver2.0
-     */
-    Arg(std::wstring_view name) : Arg(SharedString::encode(name)) {}
+    Arg(String name) : Arg(static_cast<SharedString &>(name)) {}
 
     /*!
      * \brief 引数の名前を取得する。
      *
+     * ver2.10〜 StringView に変更
+     *
      */
-    const std::string &name() const;
+    StringView name() const;
     /*!
      * \brief 引数の名前を取得する。(wstring)
      * \since ver2.0
+     *
+     * ver2.10〜 WStringView に変更
+     *
      */
-    const std::wstring &nameW() const;
+    WStringView nameW() const;
     /*!
      * \brief 引数の型を取得する。
      *

--- a/client/include/webcface/canvas2d.h
+++ b/client/include/webcface/canvas2d.h
@@ -44,10 +44,10 @@ class WEBCFACE_DLL Canvas2D : protected Field {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      *
      */
-    Canvas2D child(String field) const {
+    Canvas2D child(StringInitializer field) const {
         return this->Field::child(static_cast<SharedString &>(field));
     }
     /*!
@@ -62,10 +62,10 @@ class WEBCFACE_DLL Canvas2D : protected Field {
      * child()と同じ
      * \since ver1.11
      * 
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      * 
      */
-    Canvas2D operator[](String field) const { return child(std::move(field)); }
+    Canvas2D operator[](StringInitializer field) const { return child(std::move(field)); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/canvas2d.h
+++ b/client/include/webcface/canvas2d.h
@@ -66,15 +66,6 @@ class WEBCFACE_DLL Canvas2D : protected Field {
      * 
      */
     Canvas2D operator[](String field) const { return child(std::move(field)); }
-    // /*!
-    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
-    //  * \since ver1.11
-    //  */
-    // Canvas2D operator[](const char *field) const { return child(field); }
-    // /*!
-    //  * \since ver2.0
-    //  */
-    // Canvas2D operator[](const wchar_t *field) const { return child(field); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/canvas2d.h
+++ b/client/include/webcface/canvas2d.h
@@ -44,16 +44,11 @@ class WEBCFACE_DLL Canvas2D : protected Field {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     *
      */
-    Canvas2D child(std::string_view field) const {
-        return this->Field::child(field);
-    }
-    /*!
-     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField (wstring)
-     * \since ver2.0
-     */
-    Canvas2D child(std::wstring_view field) const {
-        return this->Field::child(field);
+    Canvas2D child(String field) const {
+        return this->Field::child(static_cast<SharedString &>(field));
     }
     /*!
      * \since ver1.11
@@ -66,22 +61,20 @@ class WEBCFACE_DLL Canvas2D : protected Field {
     /*!
      * child()と同じ
      * \since ver1.11
+     * 
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    Canvas2D operator[](std::string_view field) const { return child(field); }
-    /*!
-     * child()と同じ
-     * \since ver2.0
-     */
-    Canvas2D operator[](std::wstring_view field) const { return child(field); }
-    /*!
-     * operator[](long, const char *)と解釈されるのを防ぐための定義
-     * \since ver1.11
-     */
-    Canvas2D operator[](const char *field) const { return child(field); }
-    /*!
-     * \since ver2.0
-     */
-    Canvas2D operator[](const wchar_t *field) const { return child(field); }
+    Canvas2D operator[](String field) const { return child(std::move(field)); }
+    // /*!
+    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
+    //  * \since ver1.11
+    //  */
+    // Canvas2D operator[](const char *field) const { return child(field); }
+    // /*!
+    //  * \since ver2.0
+    //  */
+    // Canvas2D operator[](const wchar_t *field) const { return child(field); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/canvas3d.h
+++ b/client/include/webcface/canvas3d.h
@@ -64,15 +64,6 @@ class WEBCFACE_DLL Canvas3D : protected Field {
      * 
      */
     Canvas3D operator[](String field) const { return child(std::move(field)); }
-    // /*!
-    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
-    //  * \since ver1.11
-    //  */
-    // Canvas3D operator[](const char *field) const { return child(field); }
-    // /*!
-    //  * \since ver2.0
-    //  */
-    // Canvas3D operator[](const wchar_t *field) const { return child(field); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/canvas3d.h
+++ b/client/include/webcface/canvas3d.h
@@ -42,16 +42,11 @@ class WEBCFACE_DLL Canvas3D : protected Field {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    Canvas3D child(std::string_view field) const {
-        return this->Field::child(field);
-    }
-    /*!
-     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField (wstring)
-     * \since ver2.0
-     */
-    Canvas3D child(std::wstring_view field) const {
-        return this->Field::child(field);
+    Canvas3D child(String field) const {
+        return this->Field::child(static_cast<SharedString &>(field));
     }
     /*!
      * \since ver1.11
@@ -64,22 +59,20 @@ class WEBCFACE_DLL Canvas3D : protected Field {
     /*!
      * child()と同じ
      * \since ver1.11
+     * 
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    Canvas3D operator[](std::string_view field) const { return child(field); }
-    /*!
-     * child()と同じ
-     * \since ver2.0
-     */
-    Canvas3D operator[](std::wstring_view field) const { return child(field); }
-    /*!
-     * operator[](long, const char *)と解釈されるのを防ぐための定義
-     * \since ver1.11
-     */
-    Canvas3D operator[](const char *field) const { return child(field); }
-    /*!
-     * \since ver2.0
-     */
-    Canvas3D operator[](const wchar_t *field) const { return child(field); }
+    Canvas3D operator[](String field) const { return child(std::move(field)); }
+    // /*!
+    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
+    //  * \since ver1.11
+    //  */
+    // Canvas3D operator[](const char *field) const { return child(field); }
+    // /*!
+    //  * \since ver2.0
+    //  */
+    // Canvas3D operator[](const wchar_t *field) const { return child(field); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/canvas3d.h
+++ b/client/include/webcface/canvas3d.h
@@ -42,10 +42,10 @@ class WEBCFACE_DLL Canvas3D : protected Field {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      * 
      */
-    Canvas3D child(String field) const {
+    Canvas3D child(StringInitializer field) const {
         return this->Field::child(static_cast<SharedString &>(field));
     }
     /*!
@@ -60,10 +60,10 @@ class WEBCFACE_DLL Canvas3D : protected Field {
      * child()と同じ
      * \since ver1.11
      * 
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      * 
      */
-    Canvas3D operator[](String field) const { return child(std::move(field)); }
+    Canvas3D operator[](StringInitializer field) const { return child(std::move(field)); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/client.h
+++ b/client/include/webcface/client.h
@@ -32,33 +32,18 @@ class WEBCFACE_DLL Client : public Member {
     /*!
      * \brief 名前を指定しサーバーに接続する
      *
-     * サーバーのホストとポートを省略した場合 127.0.0.1:7530 になる
+     * * サーバーのホストとポートを省略した場合 127.0.0.1:7530 になる
+     * * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
      *
      * \arg name 名前
      * \arg host サーバーのアドレス
      * \arg port サーバーのポート
      *
      */
-    explicit Client(const std::string &name,
-                    const std::string &host = "127.0.0.1",
+    explicit Client(String name,
+                    String host = "127.0.0.1",
                     int port = WEBCFACE_DEFAULT_PORT)
-        : Client(SharedString::encode(name), SharedString::encode(host), port) {
-    }
-    /*!
-     * \brief 名前を指定しサーバーに接続する (wstring)
-     * \since ver2.0
-     *
-     * サーバーのホストとポートを省略した場合 127.0.0.1:7530 になる
-     *
-     * \arg name 名前
-     * \arg host サーバーのアドレス
-     * \arg port サーバーのポート
-     *
-     */
-    explicit Client(const std::wstring &name,
-                    const std::wstring &host = L"127.0.0.1",
-                    int port = WEBCFACE_DEFAULT_PORT)
-        : Client(SharedString::encode(name), SharedString::encode(host), port) {
+        : Client(static_cast<SharedString &>(name), static_cast<SharedString &>(host), port) {
     }
 
     explicit Client(const SharedString &name, const SharedString &host,
@@ -246,22 +231,13 @@ class WEBCFACE_DLL Client : public Member {
     /*!
      * \brief 他のmemberにアクセスする
      *
-     * (ver1.7から)nameが空の場合 *this を返す
+     * * (ver1.7から)nameが空の場合 *this を返す
+     * * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
      *
      * \sa members(), onMemberEntry()
      */
-    Member member(std::string_view name) const {
-        return member(SharedString::encode(name));
-    }
-    /*!
-     * \brief 他のmemberにアクセスする (wstring)
-     * \since ver2.0
-     * nameが空の場合 *this を返す
-     *
-     * \sa members(), onMemberEntry()
-     */
-    Member member(std::wstring_view name) const {
-        return member(SharedString::encode(name));
+    Member member(String name) const {
+        return member(static_cast<SharedString &>(name));
     }
     /*!
      * \brief サーバーに接続されている他のmemberのリストを得る。
@@ -309,9 +285,10 @@ class WEBCFACE_DLL Client : public Member {
      * \since ver2.4
      *
      * * nameを省略した場合 "default" になる。
+     * * ver2.10〜 String 型に変更
      *
      */
-    std::streambuf *loggerStreamBuf(std::string_view name) const;
+    std::streambuf *loggerStreamBuf(String name) const;
     /*!
      * \brief webcfaceに出力するostream
      *
@@ -330,9 +307,10 @@ class WEBCFACE_DLL Client : public Member {
      * \since ver2.4
      *
      * * nameを省略した場合 "default" になる。
+     * * ver2.10〜 String 型に変更
      *
      */
-    std::ostream &loggerOStream(std::string_view name) const;
+    std::ostream &loggerOStream(String name) const;
     /*!
      * \brief webcfaceに出力するwstreambuf
      * \since ver2.0
@@ -344,9 +322,10 @@ class WEBCFACE_DLL Client : public Member {
      * \since ver2.4
      *
      * * nameを省略した場合 "default" になる。
+     * * ver2.10〜 String 型に変更
      *
      */
-    std::wstreambuf *loggerWStreamBuf(std::wstring_view name) const;
+    std::wstreambuf *loggerWStreamBuf(String name) const;
     /*!
      * \brief webcfaceに出力するwostream
      * \since ver2.0
@@ -358,9 +337,10 @@ class WEBCFACE_DLL Client : public Member {
      * \since ver2.4
      *
      * * nameを省略した場合 "default" になる。
+     * * ver2.10〜 String 型に変更
      *
      */
-    std::wostream &loggerWOStream(std::wstring_view name) const;
+    std::wostream &loggerWOStream(String name) const;
 
     /*!
      * \brief WebCFaceサーバーのバージョン情報

--- a/client/include/webcface/client.h
+++ b/client/include/webcface/client.h
@@ -33,14 +33,14 @@ class WEBCFACE_DLL Client : public Member {
      * \brief 名前を指定しサーバーに接続する
      *
      * * サーバーのホストとポートを省略した場合 127.0.0.1:7530 になる
-     * * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      *
      * \arg name 名前
      * \arg host サーバーのアドレス
      * \arg port サーバーのポート
      *
      */
-    explicit Client(String name, String host = "127.0.0.1",
+    explicit Client(StringInitializer name, StringInitializer host = "127.0.0.1",
                     int port = WEBCFACE_DEFAULT_PORT)
         : Client(static_cast<SharedString &>(name),
                  static_cast<SharedString &>(host), port) {}
@@ -231,11 +231,11 @@ class WEBCFACE_DLL Client : public Member {
      * \brief 他のmemberにアクセスする
      *
      * * (ver1.7から)nameが空の場合 *this を返す
-     * * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      *
      * \sa members(), onMemberEntry()
      */
-    Member member(String name) const {
+    Member member(StringInitializer name) const {
         return member(static_cast<SharedString &>(name));
     }
     /*!
@@ -284,10 +284,10 @@ class WEBCFACE_DLL Client : public Member {
      * \since ver2.4
      *
      * * nameを省略した場合 "default" になる。
-     * * ver2.10〜 String 型に変更
+     * * ver2.10〜 StringInitializer 型に変更
      *
      */
-    std::streambuf *loggerStreamBuf(const String &name) const;
+    std::streambuf *loggerStreamBuf(const StringInitializer &name) const;
     /*!
      * \brief webcfaceに出力するostream
      *
@@ -306,10 +306,10 @@ class WEBCFACE_DLL Client : public Member {
      * \since ver2.4
      *
      * * nameを省略した場合 "default" になる。
-     * * ver2.10〜 String 型に変更
+     * * ver2.10〜 StringInitializer 型に変更
      *
      */
-    std::ostream &loggerOStream(const String &name) const;
+    std::ostream &loggerOStream(const StringInitializer &name) const;
     /*!
      * \brief webcfaceに出力するwstreambuf
      * \since ver2.0
@@ -321,10 +321,10 @@ class WEBCFACE_DLL Client : public Member {
      * \since ver2.4
      *
      * * nameを省略した場合 "default" になる。
-     * * ver2.10〜 String 型に変更
+     * * ver2.10〜 StringInitializer 型に変更
      *
      */
-    std::wstreambuf *loggerWStreamBuf(const String &name) const;
+    std::wstreambuf *loggerWStreamBuf(const StringInitializer &name) const;
     /*!
      * \brief webcfaceに出力するwostream
      * \since ver2.0
@@ -336,10 +336,10 @@ class WEBCFACE_DLL Client : public Member {
      * \since ver2.4
      *
      * * nameを省略した場合 "default" になる。
-     * * ver2.10〜 String 型に変更
+     * * ver2.10〜 StringInitializer 型に変更
      *
      */
-    std::wostream &loggerWOStream(const String &name) const;
+    std::wostream &loggerWOStream(const StringInitializer &name) const;
 
     /*!
      * \brief WebCFaceサーバーのバージョン情報

--- a/client/include/webcface/client.h
+++ b/client/include/webcface/client.h
@@ -40,11 +40,10 @@ class WEBCFACE_DLL Client : public Member {
      * \arg port サーバーのポート
      *
      */
-    explicit Client(String name,
-                    String host = "127.0.0.1",
+    explicit Client(String name, String host = "127.0.0.1",
                     int port = WEBCFACE_DEFAULT_PORT)
-        : Client(static_cast<SharedString &>(name), static_cast<SharedString &>(host), port) {
-    }
+        : Client(static_cast<SharedString &>(name),
+                 static_cast<SharedString &>(host), port) {}
 
     explicit Client(const SharedString &name, const SharedString &host,
                     int port);
@@ -288,7 +287,7 @@ class WEBCFACE_DLL Client : public Member {
      * * ver2.10〜 String 型に変更
      *
      */
-    std::streambuf *loggerStreamBuf(String name) const;
+    std::streambuf *loggerStreamBuf(const String &name) const;
     /*!
      * \brief webcfaceに出力するostream
      *
@@ -310,7 +309,7 @@ class WEBCFACE_DLL Client : public Member {
      * * ver2.10〜 String 型に変更
      *
      */
-    std::ostream &loggerOStream(String name) const;
+    std::ostream &loggerOStream(const String &name) const;
     /*!
      * \brief webcfaceに出力するwstreambuf
      * \since ver2.0
@@ -325,7 +324,7 @@ class WEBCFACE_DLL Client : public Member {
      * * ver2.10〜 String 型に変更
      *
      */
-    std::wstreambuf *loggerWStreamBuf(String name) const;
+    std::wstreambuf *loggerWStreamBuf(const String &name) const;
     /*!
      * \brief webcfaceに出力するwostream
      * \since ver2.0
@@ -340,7 +339,7 @@ class WEBCFACE_DLL Client : public Member {
      * * ver2.10〜 String 型に変更
      *
      */
-    std::wostream &loggerWOStream(String name) const;
+    std::wostream &loggerWOStream(const String &name) const;
 
     /*!
      * \brief WebCFaceサーバーのバージョン情報

--- a/client/include/webcface/component_canvas2d.h
+++ b/client/include/webcface/component_canvas2d.h
@@ -184,10 +184,10 @@ class WEBCFACE_DLL TemporalCanvas2DComponent {
      * \brief idを設定
      * \since ver2.5
      *
-     * ver2.10〜 String 型で置き換え
+     * ver2.10〜 StringInitializer 型で置き換え
      *
      */
-    TemporalCanvas2DComponent &id(String id);
+    TemporalCanvas2DComponent &id(StringInitializer id);
     /*!
      * \brief 要素の移動・回転
      *
@@ -270,17 +270,17 @@ class WEBCFACE_DLL TemporalCanvas2DComponent {
      * \since ver1.9
      *
      * (ver2.0からstring_viewに変更)
-     * (ver2.10〜 String 型に変更)
+     * (ver2.10〜 StringInitializer 型に変更)
      *
      */
-    TemporalCanvas2DComponent &text(String text) &;
+    TemporalCanvas2DComponent &text(StringInitializer text) &;
     /*!
      * \since ver2.5
      *
-     * (ver2.10〜 String 型に変更)
+     * (ver2.10〜 StringInitializer 型に変更)
      *
      */
-    TemporalCanvas2DComponent &&text(String text) && {
+    TemporalCanvas2DComponent &&text(StringInitializer text) && {
         this->text(std::move(text));
         return std::move(*this);
     }

--- a/client/include/webcface/component_canvas2d.h
+++ b/client/include/webcface/component_canvas2d.h
@@ -56,9 +56,10 @@ class WEBCFACE_DLL Canvas2DComponent {
      * * 要素が増減したり順序が変わったりしなければ、
      * 同じ要素には常に同じidが振られる。
      * * (ver2.5〜) canvas2d作成側でidを指定した場合その値が返る。
+     * * ver2.10〜 StringView型で置き換え
      *
      */
-    std::string id() const;
+    StringView id() const;
     /*!
      * \brief そのcanvas2d内で一意のid (wstring)
      * \since ver2.5
@@ -66,9 +67,10 @@ class WEBCFACE_DLL Canvas2DComponent {
      * * 要素が増減したり順序が変わったりしなければ、
      * 同じ要素には常に同じidが振られる。
      * * canvas2d作成側でidを指定した場合その値が返る。
+     * * ver2.10〜 WStringView型で置き換え
      *
      */
-    std::wstring idW() const;
+    WStringView idW() const;
 
     /*!
      * \since ver1.11
@@ -115,13 +117,19 @@ class WEBCFACE_DLL Canvas2DComponent {
     /*!
      * \brief 表示する文字列
      * \since ver1.9
+     *
+     * ver2.10〜 StringView型で置き換え
+     *
      */
-    std::string text() const;
+    StringView text() const;
     /*!
      * \brief 表示する文字列 (wstring)
      * \since ver2.0
+     *
+     * ver2.10〜 WStringView型で置き換え
+     *
      */
-    std::wstring textW() const;
+    WStringView textW() const;
     /*!
      * \brief geometryを取得
      *
@@ -134,7 +142,8 @@ class WEBCFACE_DLL Canvas2DComponent {
     template <WEBCFACE_COMPLETE(Func)>
     std::optional<Func_> onClick() const;
 };
-extern template std::optional<Func> Canvas2DComponent::onClick<Func, true>() const;
+extern template std::optional<Func>
+Canvas2DComponent::onClick<Func, true>() const;
 
 class WEBCFACE_DLL TemporalCanvas2DComponent {
     std::unique_ptr<internal::TemporalCanvas2DComponentData> msg_data;
@@ -174,9 +183,9 @@ class WEBCFACE_DLL TemporalCanvas2DComponent {
     /*!
      * \brief idを設定
      * \since ver2.5
-     * 
+     *
      * ver2.10〜 String 型で置き換え
-     * 
+     *
      */
     TemporalCanvas2DComponent &id(String id);
     /*!
@@ -267,9 +276,9 @@ class WEBCFACE_DLL TemporalCanvas2DComponent {
     TemporalCanvas2DComponent &text(String text) &;
     /*!
      * \since ver2.5
-     * 
+     *
      * (ver2.10〜 String 型に変更)
-     * 
+     *
      */
     TemporalCanvas2DComponent &&text(String text) && {
         this->text(std::move(text));

--- a/client/include/webcface/component_canvas2d.h
+++ b/client/include/webcface/component_canvas2d.h
@@ -174,13 +174,11 @@ class WEBCFACE_DLL TemporalCanvas2DComponent {
     /*!
      * \brief idを設定
      * \since ver2.5
+     * 
+     * ver2.10〜 String 型で置き換え
+     * 
      */
-    TemporalCanvas2DComponent &id(std::string_view id);
-    /*!
-     * \brief idを設定 (wstring)
-     * \since ver2.5
-     */
-    TemporalCanvas2DComponent &id(std::wstring_view id);
+    TemporalCanvas2DComponent &id(String id);
     /*!
      * \brief 要素の移動・回転
      *
@@ -263,27 +261,18 @@ class WEBCFACE_DLL TemporalCanvas2DComponent {
      * \since ver1.9
      *
      * (ver2.0からstring_viewに変更)
+     * (ver2.10〜 String 型に変更)
      *
      */
-    TemporalCanvas2DComponent &text(std::string_view text) &;
+    TemporalCanvas2DComponent &text(String text) &;
     /*!
      * \since ver2.5
+     * 
+     * (ver2.10〜 String 型に変更)
+     * 
      */
-    TemporalCanvas2DComponent &&text(std::string_view text) && {
-        this->text(text);
-        return std::move(*this);
-    }
-    /*!
-     * \brief 表示する文字列を設定 (wstring)
-     * \since ver2.0
-     */
-    TemporalCanvas2DComponent &text(std::wstring_view text) &;
-    /*!
-     * \brief 表示する文字列を設定 (wstring)
-     * \since ver2.5
-     */
-    TemporalCanvas2DComponent &&text(std::wstring_view text) && {
-        this->text(text);
+    TemporalCanvas2DComponent &&text(String text) && {
+        this->text(std::move(text));
         return std::move(*this);
     }
     /*!

--- a/client/include/webcface/component_canvas3d.h
+++ b/client/include/webcface/component_canvas3d.h
@@ -154,13 +154,11 @@ class WEBCFACE_DLL TemporalCanvas3DComponent {
     /*!
      * \brief idを設定
      * \since ver2.5
+     * 
+     * ver2.10〜 String 型で置き換え
+     * 
      */
-    TemporalCanvas3DComponent &id(std::string_view id);
-    /*!
-     * \brief idを設定 (wstring)
-     * \since ver2.5
-     */
-    TemporalCanvas3DComponent &id(std::wstring_view id);
+    TemporalCanvas3DComponent &id(String id);
     /*!
      * \brief 要素の移動
      *

--- a/client/include/webcface/component_canvas3d.h
+++ b/client/include/webcface/component_canvas3d.h
@@ -157,10 +157,10 @@ class WEBCFACE_DLL TemporalCanvas3DComponent {
      * \brief idを設定
      * \since ver2.5
      *
-     * ver2.10〜 String 型で置き換え
+     * ver2.10〜 StringInitializer 型で置き換え
      *
      */
-    TemporalCanvas3DComponent &id(String id);
+    TemporalCanvas3DComponent &id(StringInitializer id);
     /*!
      * \brief 要素の移動
      *

--- a/client/include/webcface/component_canvas3d.h
+++ b/client/include/webcface/component_canvas3d.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <unordered_map>
+#include <map>
 #include "webcface/component_view.h"
 #include "webcface/geometry.h"
 #include "webcface/transform.h"
@@ -56,9 +56,10 @@ class WEBCFACE_DLL Canvas3DComponent {
      * * 要素が増減したり順序が変わったりしなければ、
      * 同じ要素には常に同じidが振られる。
      * * (ver2.5〜) canvas3d作成側でidを指定した場合その値が返る。
+     * * ver2.10〜 StringView型で置き換え
      *
      */
-    std::string id() const;
+    StringView id() const;
     /*!
      * \brief そのcanvas3d内で一意のid (wstring)
      * \since ver2.5
@@ -66,9 +67,10 @@ class WEBCFACE_DLL Canvas3DComponent {
      * * 要素が増減したり順序が変わったりしなければ、
      * 同じ要素には常に同じidが振られる。
      * * canvas3d作成側でidを指定した場合その値が返る。
+     * * ver2.10〜 WStringView型で置き換え
      *
      */
-    std::wstring idW() const;
+    WStringView idW() const;
 
     /*!
      * \since ver1.11
@@ -154,9 +156,9 @@ class WEBCFACE_DLL TemporalCanvas3DComponent {
     /*!
      * \brief idを設定
      * \since ver2.5
-     * 
+     *
      * ver2.10〜 String 型で置き換え
-     * 
+     *
      */
     TemporalCanvas3DComponent &id(String id);
     /*!
@@ -208,14 +210,17 @@ class WEBCFACE_DLL TemporalCanvas3DComponent {
      * \brief RobotModelの関節をまとめて設定
      * \param angles RobotJointの名前と角度のリスト
      *
+     * * ver2.10〜 `std::unordered_map<std::string, double>` から
+     * `std::map<std::string, double, std::less<>>` に変更
+     *
      */
     TemporalCanvas3DComponent &
-    angles(const std::unordered_map<std::string, double> &angles) &;
+    angles(const std::map<std::string, double, std::less<>> &angles) &;
     /*!
      * \since ver2.5
      */
     TemporalCanvas3DComponent &&
-    angles(const std::unordered_map<std::string, double> &angles) && {
+    angles(const std::map<std::string, double, std::less<>> &angles) && {
         this->angles(angles);
         return std::move(*this);
     }
@@ -225,14 +230,17 @@ class WEBCFACE_DLL TemporalCanvas3DComponent {
      * \since ver2.0
      * \param angles RobotJointの名前と角度のリスト
      *
+     * * ver2.10〜 `std::unordered_map<std::wstring, double>` から
+     * `std::map<std::wstring, double, std::less<>>` に変更
+     *
      */
     TemporalCanvas3DComponent &
-    angles(const std::unordered_map<std::wstring, double> &angles) &;
+    angles(const std::map<std::wstring, double, std::less<>> &angles) &;
     /*!
      * \since ver2.5
      */
     TemporalCanvas3DComponent &&
-    angles(const std::unordered_map<std::wstring, double> &angles) && {
+    angles(const std::map<std::wstring, double, std::less<>> &angles) && {
         this->angles(angles);
         return std::move(*this);
     }
@@ -242,13 +250,15 @@ class WEBCFACE_DLL TemporalCanvas3DComponent {
      * \param joint_name RobotJointの名前
      * \param angle 角度
      *
+     * * ver2.10〜 std::string_view に変更
+     * 
      */
-    TemporalCanvas3DComponent &angle(const std::string &joint_name,
+    TemporalCanvas3DComponent &angle(std::string_view joint_name,
                                      double angle) &;
     /*!
      * \since ver2.5
      */
-    TemporalCanvas3DComponent &&angle(const std::string &joint_name,
+    TemporalCanvas3DComponent &&angle(std::string_view joint_name,
                                       double angle) && {
         this->angle(joint_name, angle);
         return std::move(*this);
@@ -259,13 +269,15 @@ class WEBCFACE_DLL TemporalCanvas3DComponent {
      * \param joint_name RobotJointの名前
      * \param angle 角度
      *
+     * * ver2.10〜 std::wstring_view に変更
+     * 
      */
-    TemporalCanvas3DComponent &angle(const std::wstring &joint_name,
+    TemporalCanvas3DComponent &angle(std::wstring_view joint_name,
                                      double angle) &;
     /*!
      * \since ver2.5
      */
-    TemporalCanvas3DComponent &&angle(const std::wstring &joint_name,
+    TemporalCanvas3DComponent &&angle(std::wstring_view joint_name,
                                       double angle) && {
         this->angle(joint_name, angle);
         return std::move(*this);

--- a/client/include/webcface/component_view.h
+++ b/client/include/webcface/component_view.h
@@ -148,9 +148,10 @@ class WEBCFACE_DLL ViewComponent {
      * * 要素が増減したり順序が変わったりしなければ、
      * 同じ要素には常に同じidが振られる。
      * * (ver2.5〜) view作成側でidを指定した場合その値が返る。
+     * * ver2.10〜 StringView型で置き換え
      *
      */
-    std::string id() const;
+    StringView id() const;
     /*!
      * \brief そのview内で一意のid (wstring)
      * \since ver2.5
@@ -158,9 +159,10 @@ class WEBCFACE_DLL ViewComponent {
      * * 要素が増減したり順序が変わったりしなければ、
      * 同じ要素には常に同じidが振られる。
      * * view作成側でidを指定した場合その値が返る。
+     * * ver2.10〜 WStringView型で置き換え
      *
      */
-    std::wstring idW() const;
+    WStringView idW() const;
 
     /*!
      * \brief 要素の比較
@@ -188,13 +190,18 @@ class WEBCFACE_DLL ViewComponent {
     /*!
      * \brief 表示する文字列を取得
      *
+     * * ver2.10〜 StringView型で置き換え
+     *
      */
-    std::string text() const;
+    StringView text() const;
     /*!
      * \brief 表示する文字列を取得 (wstring)
      * \since ver2.0
+     *
+     * * ver2.10〜 WStringView型で置き換え
+     *
      */
-    std::wstring textW() const;
+    WStringView textW() const;
     /*!
      * \brief クリック時に実行される関数を取得
      *
@@ -271,10 +278,8 @@ class WEBCFACE_DLL ViewComponent {
      */
     int height() const;
 };
-extern template std::optional<Func>
-ViewComponent::onClick<Func, true>() const;
-extern template std::optional<Func>
-ViewComponent::onChange<Func, true>() const;
+extern template std::optional<Func> ViewComponent::onClick<Func, true>() const;
+extern template std::optional<Func> ViewComponent::onChange<Func, true>() const;
 extern template std::optional<Variant>
 ViewComponent::bind<Variant, true>() const;
 
@@ -328,9 +333,9 @@ class WEBCFACE_DLL TemporalViewComponent {
     /*!
      * \brief idを設定
      * \since ver2.5
-     * 
+     *
      * ver2.10〜 String 型で置き換え
-     * 
+     *
      */
     TemporalViewComponent &id(String id);
     /*!
@@ -343,9 +348,9 @@ class WEBCFACE_DLL TemporalViewComponent {
     TemporalViewComponent &text(String text) &;
     /*!
      * \since ver2.5
-     * 
+     *
      * (ver2.10〜 String 型で置き換え)
-     * 
+     *
      */
     TemporalViewComponent &&text(String text) && {
         this->text(std::move(text));

--- a/client/include/webcface/component_view.h
+++ b/client/include/webcface/component_view.h
@@ -504,11 +504,41 @@ class WEBCFACE_DLL TemporalViewComponent {
         return this->init(ValAdaptor{init});
     }
     /*!
+     * \since ver2.10
+     */
+    template <std::size_t N>
+    TemporalViewComponent &init(const char (&init)[N]) & {
+        return this->init(ValAdaptor(init));
+    }
+    /*!
+     * \since ver2.10
+     */
+    template <std::size_t N>
+    TemporalViewComponent &init(const wchar_t (&init)[N]) & {
+        return this->init(ValAdaptor(init));
+    }
+    /*!
      * \brief デフォルト値を設定する。
      * \since ver2.5
      */
     template <typename T>
     TemporalViewComponent &&init(const T &init) && {
+        this->init(init);
+        return std::move(*this);
+    }
+    /*!
+     * \since ver2.10
+     */
+    template <std::size_t N>
+    TemporalViewComponent &&init(const char (&init)[N]) && {
+        this->init(init);
+        return std::move(*this);
+    }
+    /*!
+     * \since ver2.10
+     */
+    template <std::size_t N>
+    TemporalViewComponent &&init(const wchar_t (&init)[N]) && {
         this->init(init);
         return std::move(*this);
     }

--- a/client/include/webcface/component_view.h
+++ b/client/include/webcface/component_view.h
@@ -328,38 +328,27 @@ class WEBCFACE_DLL TemporalViewComponent {
     /*!
      * \brief idを設定
      * \since ver2.5
+     * 
+     * ver2.10〜 String 型で置き換え
+     * 
      */
-    TemporalViewComponent &id(std::string_view id);
-    /*!
-     * \brief idを設定 (wstring)
-     * \since ver2.5
-     */
-    TemporalViewComponent &id(std::wstring_view id);
+    TemporalViewComponent &id(String id);
     /*!
      * \brief 表示する文字列を設定
      *
      * (ver2.0からstring_viewに変更)
+     * (ver2.10〜 String 型で置き換え)
      *
      */
-    TemporalViewComponent &text(std::string_view text) &;
+    TemporalViewComponent &text(String text) &;
     /*!
      * \since ver2.5
+     * 
+     * (ver2.10〜 String 型で置き換え)
+     * 
      */
-    TemporalViewComponent &&text(std::string_view text) && {
-        this->text(text);
-        return std::move(*this);
-    }
-    /*!
-     * \brief 表示する文字列を設定 (wstring)
-     * \since ver2.0
-     */
-    TemporalViewComponent &text(std::wstring_view text) &;
-    /*!
-     * \brief 表示する文字列を設定 (wstring)
-     * \since ver2.5
-     */
-    TemporalViewComponent &&text(std::wstring_view text) && {
-        this->text(text);
+    TemporalViewComponent &&text(String text) && {
+        this->text(std::move(text));
         return std::move(*this);
     }
     /*!

--- a/client/include/webcface/component_view.h
+++ b/client/include/webcface/component_view.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "webcface/func_trait.h"
 #include <functional>
 #include <optional>
 #include <unordered_map>
@@ -440,12 +441,15 @@ class WEBCFACE_DLL TemporalViewComponent {
      */
     template <typename T>
     TemporalViewComponent &onChange(T func) & {
+        static_assert(traits::InvokeObjTrait<T>::ArgsSize == 1);
+        using FirstArgType =
+            typename traits::InvokeObjTrait<T>::template ArgsAt<0>;
         InputRef ref;
         return onChange(
             std::make_shared<std::function<void WEBCFACE_CALL_FP(ValAdaptor)>>(
-                [ref, func = std::move(func)](ValAdaptor val) {
+                [ref, func = std::move(func)](const ValAdaptor &val) {
                     ref.lockedField().set(val);
-                    return func(val);
+                    return func(static_cast<FirstArgType>(val));
                 }),
             ref);
     }

--- a/client/include/webcface/component_view.h
+++ b/client/include/webcface/component_view.h
@@ -334,25 +334,25 @@ class WEBCFACE_DLL TemporalViewComponent {
      * \brief idを設定
      * \since ver2.5
      *
-     * ver2.10〜 String 型で置き換え
+     * ver2.10〜 StringInitializer 型で置き換え
      *
      */
-    TemporalViewComponent &id(String id);
+    TemporalViewComponent &id(StringInitializer id);
     /*!
      * \brief 表示する文字列を設定
      *
      * (ver2.0からstring_viewに変更)
-     * (ver2.10〜 String 型で置き換え)
+     * (ver2.10〜 StringInitializer 型で置き換え)
      *
      */
-    TemporalViewComponent &text(String text) &;
+    TemporalViewComponent &text(StringInitializer text) &;
     /*!
      * \since ver2.5
      *
-     * (ver2.10〜 String 型で置き換え)
+     * (ver2.10〜 StringInitializer 型で置き換え)
      *
      */
-    TemporalViewComponent &&text(String text) && {
+    TemporalViewComponent &&text(StringInitializer text) && {
         this->text(std::move(text));
         return std::move(*this);
     }

--- a/client/include/webcface/component_view.h
+++ b/client/include/webcface/component_view.h
@@ -449,7 +449,7 @@ class WEBCFACE_DLL TemporalViewComponent {
             std::make_shared<std::function<void WEBCFACE_CALL_FP(ValAdaptor)>>(
                 [ref, func = std::move(func)](const ValAdaptor &val) {
                     ref.lockedField().set(val);
-                    return func(static_cast<FirstArgType>(val));
+                    return func(val.as<FirstArgType>());
                 }),
             ref);
     }

--- a/client/include/webcface/components.h
+++ b/client/include/webcface/components.h
@@ -45,8 +45,10 @@ struct TemporalComponent {
     /*!
      * \brief idを設定
      * \since ver2.5
+     * 
+     * ver2.10〜 String 型で置き換え
      */
-    TemporalComponent &id(std::string_view id) & {
+    TemporalComponent &id(const String &id) & {
         if constexpr (V) {
             component_v.id(id);
         }
@@ -61,30 +63,7 @@ struct TemporalComponent {
     /*!
      * \since ver2.5
      */
-    TemporalComponent &&id(std::string_view id) && {
-        this->id(id);
-        return std::move(*this);
-    }
-    /*!
-     * \brief idを設定(wstring)
-     * \since ver2.5
-     */
-    TemporalComponent &id(std::wstring_view id) & {
-        if constexpr (V) {
-            component_v.id(id);
-        }
-        if constexpr (C2) {
-            component_2d.id(id);
-        }
-        if constexpr (C3) {
-            component_3d.id(id);
-        }
-        return *this;
-    }
-    /*!
-     * \since ver2.5
-     */
-    TemporalComponent &&id(std::wstring_view id) && {
+    TemporalComponent &&id(const String &id) && {
         this->id(id);
         return std::move(*this);
     }
@@ -225,8 +204,11 @@ struct TemporalComponent {
     /*!
      * \brief 表示する文字列 (View, Canvas2D)
      * \since ver2.0
+     * 
+     * ver2.10〜 String 型で置き換え
+     * 
      */
-    TemporalComponent &text(std::string_view str) & {
+    TemporalComponent &text(const String &str) & {
         static_assert(V || C2,
                       "text can be set only for View, Canvas2D components");
         if constexpr (V) {
@@ -239,30 +221,11 @@ struct TemporalComponent {
     }
     /*!
      * \since ver2.5
+     * 
+     * ver2.10〜 String 型で置き換え
+     * 
      */
-    TemporalComponent &&text(std::string_view str) && {
-        this->text(str);
-        return std::move(*this);
-    }
-    /*!
-     * \brief 表示する文字列(wstring) (View, Canvas2D)
-     * \since ver2.0
-     */
-    TemporalComponent &text(std::wstring_view str) & {
-        static_assert(V || C2,
-                      "text can be set only for View, Canvas2D components");
-        if constexpr (V) {
-            component_v.text(str);
-        }
-        if constexpr (C2) {
-            component_2d.text(str);
-        }
-        return *this;
-    }
-    /*!
-     * \since ver2.5
-     */
-    TemporalComponent &&text(std::wstring_view str) && {
+    TemporalComponent &&text(const String &str) && {
         this->text(str);
         return std::move(*this);
     }
@@ -638,17 +601,10 @@ namespace Geometries = geometries; // 〜ver1.11
 /*!
  * \brief textコンポーネント
  *
+ * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+ * 
  */
-inline TemporalComponent<true, true, false> text(std::string_view text) {
-    return TemporalComponent<true, true, false>(
-               ViewComponentType::text, Canvas2DComponentType::text, nullptr)
-        .text(text);
-}
-/*!
- * \brief textコンポーネント (wstring)
- * \since ver2.0
- */
-inline TemporalComponent<true, true, false> text(std::wstring_view text) {
+inline TemporalComponent<true, true, false> text(const String &text) {
     return TemporalComponent<true, true, false>(
                ViewComponentType::text, Canvas2DComponentType::text, nullptr)
         .text(text);
@@ -664,9 +620,11 @@ inline TemporalViewComponent newLine() {
 /*!
  * \brief buttonコンポーネント
  *
+ * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+ * 
  */
 template <typename T>
-inline TemporalViewComponent button(std::string_view text, T &&func) {
+inline TemporalViewComponent button(const String &text, T &&func) {
     return TemporalViewComponent(ViewComponentType::button)
         .text(text)
         .onClick(std::forward<T>(func));
@@ -682,60 +640,31 @@ inline TemporalViewComponent button(std::wstring_view text, T &&func) {
         .onClick(std::forward<T>(func));
 }
 
-inline TemporalViewComponent textInput(std::string_view text = "") {
+inline TemporalViewComponent textInput(const String &text = {}) {
     return TemporalViewComponent(ViewComponentType::text_input).text(text);
 }
-inline TemporalViewComponent textInput(std::wstring_view text) {
-    return TemporalViewComponent(ViewComponentType::text_input).text(text);
-}
-inline TemporalViewComponent decimalInput(std::string_view text = "") {
+inline TemporalViewComponent decimalInput(const String &text = {}) {
     return TemporalViewComponent(ViewComponentType::decimal_input)
         .text(text)
         .init(0);
 }
-inline TemporalViewComponent decimalInput(std::wstring_view text) {
-    return TemporalViewComponent(ViewComponentType::decimal_input)
-        .text(text)
-        .init(0);
-}
-inline TemporalViewComponent numberInput(std::string_view text = "") {
+inline TemporalViewComponent numberInput(const String &text = {}) {
     return TemporalViewComponent(ViewComponentType::number_input)
         .text(text)
         .init(0);
 }
-inline TemporalViewComponent numberInput(std::wstring_view text) {
-    return TemporalViewComponent(ViewComponentType::number_input)
-        .text(text)
-        .init(0);
-}
-inline TemporalViewComponent toggleInput(std::string_view text = "") {
+inline TemporalViewComponent toggleInput(const String &text = {}) {
     return TemporalViewComponent(ViewComponentType::toggle_input).text(text);
 }
-inline TemporalViewComponent toggleInput(std::wstring_view text) {
-    return TemporalViewComponent(ViewComponentType::toggle_input).text(text);
-}
-inline TemporalViewComponent selectInput(std::string_view text = "") {
+inline TemporalViewComponent selectInput(const String &text = {}) {
     return TemporalViewComponent(ViewComponentType::select_input).text(text);
 }
-inline TemporalViewComponent selectInput(std::wstring_view text) {
-    return TemporalViewComponent(ViewComponentType::select_input).text(text);
-}
-inline TemporalViewComponent sliderInput(std::string_view text = "") {
+inline TemporalViewComponent sliderInput(const String &text = {}) {
     return TemporalViewComponent(ViewComponentType::slider_input)
         .text(text)
         .init(0);
 }
-inline TemporalViewComponent sliderInput(std::wstring_view text) {
-    return TemporalViewComponent(ViewComponentType::slider_input)
-        .text(text)
-        .init(0);
-}
-inline TemporalViewComponent checkInput(std::string_view text = "") {
-    return TemporalViewComponent(ViewComponentType::check_input)
-        .text(text)
-        .init(false);
-}
-inline TemporalViewComponent checkInput(std::wstring_view text) {
+inline TemporalViewComponent checkInput(const String &text = {}) {
     return TemporalViewComponent(ViewComponentType::check_input)
         .text(text)
         .init(false);

--- a/client/include/webcface/components.h
+++ b/client/include/webcface/components.h
@@ -46,9 +46,9 @@ struct TemporalComponent {
      * \brief idを設定
      * \since ver2.5
      * 
-     * ver2.10〜 String 型で置き換え
+     * ver2.10〜 StringInitializer 型で置き換え
      */
-    TemporalComponent &id(const String &id) & {
+    TemporalComponent &id(const StringInitializer &id) & {
         if constexpr (V) {
             component_v.id(id);
         }
@@ -63,7 +63,7 @@ struct TemporalComponent {
     /*!
      * \since ver2.5
      */
-    TemporalComponent &&id(const String &id) && {
+    TemporalComponent &&id(const StringInitializer &id) && {
         this->id(id);
         return std::move(*this);
     }
@@ -205,10 +205,10 @@ struct TemporalComponent {
      * \brief 表示する文字列 (View, Canvas2D)
      * \since ver2.0
      * 
-     * ver2.10〜 String 型で置き換え
+     * ver2.10〜 StringInitializer 型で置き換え
      * 
      */
-    TemporalComponent &text(const String &str) & {
+    TemporalComponent &text(const StringInitializer &str) & {
         static_assert(V || C2,
                       "text can be set only for View, Canvas2D components");
         if constexpr (V) {
@@ -222,10 +222,10 @@ struct TemporalComponent {
     /*!
      * \since ver2.5
      * 
-     * ver2.10〜 String 型で置き換え
+     * ver2.10〜 StringInitializer 型で置き換え
      * 
      */
-    TemporalComponent &&text(const String &str) && {
+    TemporalComponent &&text(const StringInitializer &str) && {
         this->text(str);
         return std::move(*this);
     }
@@ -601,10 +601,10 @@ namespace Geometries = geometries; // 〜ver1.11
 /*!
  * \brief textコンポーネント
  *
- * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+ * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
  * 
  */
-inline TemporalComponent<true, true, false> text(const String &text) {
+inline TemporalComponent<true, true, false> text(const StringInitializer &text) {
     return TemporalComponent<true, true, false>(
                ViewComponentType::text, Canvas2DComponentType::text, nullptr)
         .text(text);
@@ -620,11 +620,11 @@ inline TemporalViewComponent newLine() {
 /*!
  * \brief buttonコンポーネント
  *
- * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+ * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
  * 
  */
 template <typename T>
-inline TemporalViewComponent button(const String &text, T &&func) {
+inline TemporalViewComponent button(const StringInitializer &text, T &&func) {
     return TemporalViewComponent(ViewComponentType::button)
         .text(text)
         .onClick(std::forward<T>(func));
@@ -640,31 +640,31 @@ inline TemporalViewComponent button(std::wstring_view text, T &&func) {
         .onClick(std::forward<T>(func));
 }
 
-inline TemporalViewComponent textInput(const String &text = {}) {
+inline TemporalViewComponent textInput(const StringInitializer &text = {}) {
     return TemporalViewComponent(ViewComponentType::text_input).text(text);
 }
-inline TemporalViewComponent decimalInput(const String &text = {}) {
+inline TemporalViewComponent decimalInput(const StringInitializer &text = {}) {
     return TemporalViewComponent(ViewComponentType::decimal_input)
         .text(text)
         .init(0);
 }
-inline TemporalViewComponent numberInput(const String &text = {}) {
+inline TemporalViewComponent numberInput(const StringInitializer &text = {}) {
     return TemporalViewComponent(ViewComponentType::number_input)
         .text(text)
         .init(0);
 }
-inline TemporalViewComponent toggleInput(const String &text = {}) {
+inline TemporalViewComponent toggleInput(const StringInitializer &text = {}) {
     return TemporalViewComponent(ViewComponentType::toggle_input).text(text);
 }
-inline TemporalViewComponent selectInput(const String &text = {}) {
+inline TemporalViewComponent selectInput(const StringInitializer &text = {}) {
     return TemporalViewComponent(ViewComponentType::select_input).text(text);
 }
-inline TemporalViewComponent sliderInput(const String &text = {}) {
+inline TemporalViewComponent sliderInput(const StringInitializer &text = {}) {
     return TemporalViewComponent(ViewComponentType::slider_input)
         .text(text)
         .init(0);
 }
-inline TemporalViewComponent checkInput(const String &text = {}) {
+inline TemporalViewComponent checkInput(const StringInitializer &text = {}) {
     return TemporalViewComponent(ViewComponentType::check_input)
         .text(text)
         .init(false);

--- a/client/include/webcface/field.h
+++ b/client/include/webcface/field.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <memory>
 #include <string>
-#include <string_view>
 #include <vector>
 #ifdef WEBCFACE_MESON
 #include "webcface-config.h"

--- a/client/include/webcface/field.h
+++ b/client/include/webcface/field.h
@@ -29,6 +29,7 @@ class Canvas3D;
 class Log;
 
 constexpr char field_separator = '.';
+constexpr std::string_view field_separator_sv = ".";
 
 /*!
  * \brief メンバ名とデータ名を持つクラス

--- a/client/include/webcface/field.h
+++ b/client/include/webcface/field.h
@@ -113,7 +113,7 @@ struct WEBCFACE_DLL Field : public FieldBase {
      * ver2.10〜 std::stringの参照から StringView に変更
      *
      */
-    StringView name() const { return field_.decode(); }
+    StringView name() const { return field_.decodeShare(); }
     /*!
      * \brief field名を返す (wstring)
      * \since ver2.0
@@ -121,7 +121,7 @@ struct WEBCFACE_DLL Field : public FieldBase {
      * ver2.10〜 std::wstringの参照から WStringView に変更
      *
      */
-    WStringView nameW() const { return field_.decodeW(); }
+    WStringView nameW() const { return field_.decodeShareW(); }
 
   protected:
     SharedString lastName8() const;

--- a/client/include/webcface/field.h
+++ b/client/include/webcface/field.h
@@ -110,13 +110,18 @@ struct WEBCFACE_DLL Field : public FieldBase {
     /*!
      * \brief field名を返す
      *
+     * ver2.10〜 std::stringの参照から StringView に変更
+     *
      */
-    const std::string &name() const { return field_.decode(); }
+    StringView name() const { return field_.decode(); }
     /*!
      * \brief field名を返す (wstring)
      * \since ver2.0
+     *
+     * ver2.10〜 std::wstringの参照から WStringView に変更
+     *
      */
-    const std::wstring &nameW() const { return field_.decodeW(); }
+    WStringView nameW() const { return field_.decodeW(); }
 
   protected:
     SharedString lastName8() const;
@@ -128,12 +133,14 @@ struct WEBCFACE_DLL Field : public FieldBase {
      * \brief nameのうちピリオドで区切られた最後の部分を取り出す
      * \since ver1.11
      */
-    std::string lastName() const { return lastName8().decode(); }
+    std::string lastName() const { return std::string(lastName8().decode()); }
     /*!
      * \brief nameのうちピリオドで区切られた最後の部分を取り出す (wstring)
      * \since ver2.0
      */
-    std::wstring lastNameW() const { return lastName8().decodeW(); }
+    std::wstring lastNameW() const {
+        return std::wstring(lastName8().decodeW());
+    }
     /*!
      * \brief nameの最後のピリオドの前までを新しい名前とするField
      * \since ver1.11
@@ -142,16 +149,12 @@ struct WEBCFACE_DLL Field : public FieldBase {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      * \since ver1.11
+     *
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     *
      */
-    Field child(std::string_view field) const {
-        return child(SharedString::encode(field));
-    }
-    /*!
-     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField (wstring)
-     * \since ver2.0
-     */
-    Field child(std::wstring_view field) const {
-        return child(SharedString::encode(field));
+    Field child(String field) const {
+        return child(static_cast<SharedString &>(field));
     }
     /*!
      * \brief 「(thisの名前).(index)」を新しい名前とするField
@@ -165,108 +168,66 @@ struct WEBCFACE_DLL Field : public FieldBase {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      * \since ver1.11
+     *
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     *
      */
-    Field operator[](std::string_view field) const { return child(field); }
-    /*!
-     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField (wstring)
-     * \since ver2.0
-     */
-    Field operator[](std::wstring_view field) const { return child(field); }
+    Field operator[](String field) const {
+        return child(static_cast<SharedString &>(field));
+    }
     /*!
      * \brief 「(thisの名前).(index)」を新しい名前とするField
      * \since ver1.11
      * \deprecated ver2.8〜
      */
     [[deprecated]]
-    Field operator[](int index) const {
+    Field
+    operator[](int index) const {
         return child(std::to_string(index));
     }
 
     template <WEBCFACE_COMPLETE(Value)>
-    Value_ value(std::string_view field = "") const {
-        return child(field);
-    }
-    template <WEBCFACE_COMPLETE(Value)>
-    Value_ value(std::wstring_view field) const {
-        return child(field);
+    Value_ value(String field = String()) const {
+        return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(Text)>
-    Text_ text(std::string_view field = "") const {
-        return child(field);
-    }
-    template <WEBCFACE_COMPLETE(Text)>
-    Text_ text(std::wstring_view field) const {
-        return child(field);
+    Text_ text(String field = String()) const {
+        return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(RobotModel)>
-    RobotModel_ robotModel(std::string_view field = "") const {
-        return child(field);
-    }
-    template <WEBCFACE_COMPLETE(RobotModel)>
-    RobotModel_ robotModel(std::wstring_view field) const {
-        return child(field);
+    RobotModel_ robotModel(String field = String()) const {
+        return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(Image)>
-    Image_ image(std::string_view field = "") const {
-        return child(field);
-    }
-    template <WEBCFACE_COMPLETE(Image)>
-    Image_ image(std::wstring_view field) const {
-        return child(field);
+    Image_ image(String field = String()) const {
+        return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(Func)>
-    Func_ func(std::string_view field = "") const {
-        return child(field);
-    }
-    template <WEBCFACE_COMPLETE(Func)>
-    Func_ func(std::wstring_view field) const {
-        return child(field);
+    Func_ func(String field = String()) const {
+        return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(FuncListener)>
-    FuncListener_ funcListener(std::string_view field = "") const {
-        return child(field);
-    }
-    template <WEBCFACE_COMPLETE(FuncListener)>
-    FuncListener_ funcListener(std::wstring_view field) const {
-        return child(field);
+    FuncListener_ funcListener(String field = String()) const {
+        return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(View)>
-    View_ view(std::string_view field = "") const {
-        return child(field);
-    }
-    template <WEBCFACE_COMPLETE(View)>
-    View_ view(std::wstring_view field) const {
-        return child(field);
+    View_ view(String field = String()) const {
+        return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(Canvas3D)>
-    Canvas3D_ canvas3D(std::string_view field = "") const {
-        return child(field);
-    }
-    template <WEBCFACE_COMPLETE(Canvas3D)>
-    Canvas3D_ canvas3D(std::wstring_view field) const {
-        return child(field);
+    Canvas3D_ canvas3D(String field = String()) const {
+        return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(Canvas2D)>
-    Canvas2D_ canvas2D(std::string_view field = "") const {
-        return child(field);
-    }
-    template <WEBCFACE_COMPLETE(Canvas2D)>
-    Canvas2D_ canvas2D(std::wstring_view field) const {
-        return child(field);
+    Canvas2D_ canvas2D(String field = String()) const {
+        return child(static_cast<SharedString &>(field));
     }
     /*!
      * \since ver2.4
      */
     template <WEBCFACE_COMPLETE(Log)>
-    Log_ log(std::string_view field = "") const {
-        return child(field);
-    }
-    /*!
-     * \since ver2.4
-     */
-    template <WEBCFACE_COMPLETE(Log)>
-    Log_ log(std::wstring_view field) const {
-        return child(field);
+    Log_ log(String field = String()) const {
+        return child(static_cast<SharedString &>(field));
     }
 
 

--- a/client/include/webcface/field.h
+++ b/client/include/webcface/field.h
@@ -150,10 +150,10 @@ struct WEBCFACE_DLL Field : public FieldBase {
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      * \since ver1.11
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      *
      */
-    Field child(String field) const {
+    Field child(StringInitializer field) const {
         return child(static_cast<SharedString &>(field));
     }
     /*!
@@ -169,10 +169,10 @@ struct WEBCFACE_DLL Field : public FieldBase {
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      * \since ver1.11
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      *
      */
-    Field operator[](String field) const {
+    Field operator[](StringInitializer field) const {
         return child(static_cast<SharedString &>(field));
     }
     /*!
@@ -187,46 +187,46 @@ struct WEBCFACE_DLL Field : public FieldBase {
     }
 
     template <WEBCFACE_COMPLETE(Value)>
-    Value_ value(String field = String()) const {
+    Value_ value(StringInitializer field = StringInitializer()) const {
         return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(Text)>
-    Text_ text(String field = String()) const {
+    Text_ text(StringInitializer field = StringInitializer()) const {
         return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(RobotModel)>
-    RobotModel_ robotModel(String field = String()) const {
+    RobotModel_ robotModel(StringInitializer field = StringInitializer()) const {
         return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(Image)>
-    Image_ image(String field = String()) const {
+    Image_ image(StringInitializer field = StringInitializer()) const {
         return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(Func)>
-    Func_ func(String field = String()) const {
+    Func_ func(StringInitializer field = StringInitializer()) const {
         return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(FuncListener)>
-    FuncListener_ funcListener(String field = String()) const {
+    FuncListener_ funcListener(StringInitializer field = StringInitializer()) const {
         return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(View)>
-    View_ view(String field = String()) const {
+    View_ view(StringInitializer field = StringInitializer()) const {
         return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(Canvas3D)>
-    Canvas3D_ canvas3D(String field = String()) const {
+    Canvas3D_ canvas3D(StringInitializer field = StringInitializer()) const {
         return child(static_cast<SharedString &>(field));
     }
     template <WEBCFACE_COMPLETE(Canvas2D)>
-    Canvas2D_ canvas2D(String field = String()) const {
+    Canvas2D_ canvas2D(StringInitializer field = StringInitializer()) const {
         return child(static_cast<SharedString &>(field));
     }
     /*!
      * \since ver2.4
      */
     template <WEBCFACE_COMPLETE(Log)>
-    Log_ log(String field = String()) const {
+    Log_ log(StringInitializer field = StringInitializer()) const {
         return child(static_cast<SharedString &>(field));
     }
 

--- a/client/include/webcface/func.h
+++ b/client/include/webcface/func.h
@@ -20,7 +20,7 @@ struct FuncArgTypeCheck<true> {
 };
 template <typename... Args>
 struct FuncArgTypesTrait
-    : FuncArgTypeCheck<(ConvertibleFromValAdaptor<Args> && ...)> {};
+    : FuncArgTypeCheck<(std::is_constructible_v<std::decay_t<Args>, ValAdaptor> && ...)> {};
 
 template <bool>
 struct FuncReturnTypeCheck {};

--- a/client/include/webcface/func.h
+++ b/client/include/webcface/func.h
@@ -110,16 +110,11 @@ class WEBCFACE_DLL Func : protected Field {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    Func child(std::string_view field) const {
-        return this->Field::child(field);
-    }
-    /*!
-     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField (wstring)
-     * \since ver2.0
-     */
-    Func child(std::wstring_view field) const {
-        return this->Field::child(field);
+    Func child(String field) const {
+        return this->Field::child(static_cast<SharedString &>(field));
     }
     /*!
      * \since ver1.11
@@ -132,22 +127,20 @@ class WEBCFACE_DLL Func : protected Field {
     /*!
      * child()と同じ
      * \since ver1.11
+     * 
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    Func operator[](std::string_view field) const { return child(field); }
-    /*!
-     * child()と同じ
-     * \since ver2.0
-     */
-    Func operator[](std::wstring_view field) const { return child(field); }
-    /*!
-     * operator[](long, const char *)と解釈されるのを防ぐための定義
-     * \since ver1.11
-     */
-    Func operator[](const char *field) const { return child(field); }
-    /*!
-     * \since ver2.0
-     */
-    Func operator[](const wchar_t *field) const { return child(field); }
+    Func operator[](String field) const { return child(std::move(field)); }
+    // /*!
+    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
+    //  * \since ver1.11
+    //  */
+    // Func operator[](const char *field) const { return child(field); }
+    // /*!
+    //  * \since ver2.0
+    //  */
+    // Func operator[](const wchar_t *field) const { return child(field); }
     /*!
      * child()と同じ
      * \since ver1.11
@@ -497,7 +490,7 @@ class WEBCFACE_DLL Func : protected Field {
         p.waitFinish();
         if (p.found()) {
             if (p.isError()) {
-                throw Rejection(*this, p.rejection());
+                throw Rejection(*this, std::string(p.rejection()));
             } else {
                 return p.response();
             }

--- a/client/include/webcface/func.h
+++ b/client/include/webcface/func.h
@@ -23,6 +23,14 @@ template <typename T>
 using InvokeSignature =
     decltype(getInvokeSignature(std::declval<std::decay_t<T>>()));
 
+// ValAdaptorからstringへは暗黙変換できないようにしているが、
+// Funcの引数では例外的にstringを許可する
+template <typename T>
+constexpr bool isArgTypeSupportedByWebCFaceFunc =
+    std::is_convertible_v<ValAdaptor, T> ||
+    std::is_convertible_v<std::string, T> ||
+    std::is_convertible_v<std::wstring, T>;
+
 template <bool>
 struct FuncArgTypeCheck {};
 template <>
@@ -31,7 +39,7 @@ struct FuncArgTypeCheck<true> {
 };
 template <typename... Args>
 struct FuncArgTypesTrait
-    : FuncArgTypeCheck<(std::is_convertible_v<ValAdaptor, Args> && ...)> {};
+    : FuncArgTypeCheck<(isArgTypeSupportedByWebCFaceFunc<Args> && ...)> {};
 
 template <bool>
 struct FuncReturnTypeCheck {};

--- a/client/include/webcface/func.h
+++ b/client/include/webcface/func.h
@@ -118,10 +118,10 @@ class WEBCFACE_DLL Func : protected Field {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      *
      */
-    Func child(String field) const {
+    Func child(StringInitializer field) const {
         return this->Field::child(static_cast<SharedString &>(field));
     }
     /*!
@@ -136,10 +136,10 @@ class WEBCFACE_DLL Func : protected Field {
      * child()と同じ
      * \since ver1.11
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      *
      */
-    Func operator[](String field) const { return child(std::move(field)); }
+    Func operator[](StringInitializer field) const { return child(std::move(field)); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/func.h
+++ b/client/include/webcface/func.h
@@ -41,8 +41,8 @@ struct FuncReturnTypeCheck<true> {
 };
 template <typename Ret>
 struct FuncReturnTypeTrait
-    : FuncReturnTypeCheck<std::is_same_v<Ret, void> ||
-                          std::is_constructible_v<ValAdaptor, Ret>> {};
+    : FuncReturnTypeCheck<std::disjunction_v<
+          std::is_void<Ret>, std::is_constructible<ValAdaptor, Ret>>> {};
 
 template <typename T>
 struct FuncSignatureTrait {};
@@ -111,7 +111,7 @@ class WEBCFACE_DLL Func : protected Field {
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
      * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
-     * 
+     *
      */
     Func child(String field) const {
         return this->Field::child(static_cast<SharedString &>(field));
@@ -127,9 +127,9 @@ class WEBCFACE_DLL Func : protected Field {
     /*!
      * child()と同じ
      * \since ver1.11
-     * 
+     *
      * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
-     * 
+     *
      */
     Func operator[](String field) const { return child(std::move(field)); }
     /*!
@@ -138,7 +138,8 @@ class WEBCFACE_DLL Func : protected Field {
      * \deprecated ver2.8〜
      */
     [[deprecated]]
-    Func operator[](int index) const {
+    Func
+    operator[](int index) const {
         return child(std::to_string(index));
     }
     /*!
@@ -300,7 +301,8 @@ class WEBCFACE_DLL Func : protected Field {
      *
      */
     template <typename T>
-    [[deprecated("use set() or setAsync()")]] const Func &
+    [[deprecated("use set() or setAsync()")]]
+    const Func &
     operator=(T func) const {
         this->set(std::move(func));
         return *this;
@@ -495,7 +497,8 @@ class WEBCFACE_DLL Func : protected Field {
      */
     template <typename... Args>
     [[deprecated("use runAsync")]]
-    ValAdaptor operator()(Args... args) const {
+    ValAdaptor
+    operator()(Args... args) const {
         return run(args...);
     }
 

--- a/client/include/webcface/func.h
+++ b/client/include/webcface/func.h
@@ -132,15 +132,6 @@ class WEBCFACE_DLL Func : protected Field {
      * 
      */
     Func operator[](String field) const { return child(std::move(field)); }
-    // /*!
-    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
-    //  * \since ver1.11
-    //  */
-    // Func operator[](const char *field) const { return child(field); }
-    // /*!
-    //  * \since ver2.0
-    //  */
-    // Func operator[](const wchar_t *field) const { return child(field); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/func_result.h
+++ b/client/include/webcface/func_result.h
@@ -386,6 +386,20 @@ class WEBCFACE_DLL CallHandle : Field {
         respond(ValAdaptor(value));
     }
     /*!
+     * \since ver2.10
+     */
+    template <std::size_t N>
+    void respond(const char (&value)[N]) const {
+        respond(ValAdaptor(value));
+    }
+    /*!
+     * \since ver2.10
+     */
+    template <std::size_t N>
+    void respond(const wchar_t (&value)[N]) const {
+        respond(ValAdaptor(value));
+    }
+    /*!
      * \brief 空の値を関数の結果として送信する
      *
      * * ver1.11まで: 2回呼ぶと std::future_error を投げ、

--- a/client/include/webcface/func_result.h
+++ b/client/include/webcface/func_result.h
@@ -5,7 +5,6 @@
 #include "webcface/common/webcface-config.h"
 #endif
 #include <optional>
-#include <string>
 #include <future>
 #include <memory>
 #include <stdexcept>
@@ -59,8 +58,9 @@ class WEBCFACE_DLL Promise : Field {
      * started.get(), started.wait() 使用時の注意はwaitReach()を参照。
      *
      */
-    [[deprecated("use reached(), found() or waitReach()")]]
-    std::shared_future<bool> started;
+    [[deprecated(
+        "use reached(), found() or waitReach()")]] std::shared_future<bool>
+        started;
     /*!
      * \brief 関数の実行が完了した時戻り値が入る
      *
@@ -72,8 +72,10 @@ class WEBCFACE_DLL Promise : Field {
      * を推奨。 result.get(), result.wait() 使用時の注意はwaitFinish()を参照。
      *
      */
-    [[deprecated("use finished(), response(), rejection(), or waitFinish()")]]
-    std::shared_future<ValAdaptor> result;
+    [[deprecated(
+        "use finished(), response(), rejection(), or waitFinish()")]] std::
+        shared_future<ValAdaptor>
+            result;
 
   private:
     void waitReachImpl(std::optional<std::chrono::microseconds> timeout) const;
@@ -173,14 +175,19 @@ class WEBCFACE_DLL Promise : Field {
      * \brief 関数の実行がエラーになった場合そのエラーメッセージを返す
      * \since ver2.0
      *
+     * ver2.10〜 StringView型に変更
+     *
      */
-    const std::string &rejection() const;
+    StringView rejection() const;
     /*!
      * \brief 関数の実行がエラーになった場合そのエラーメッセージを返す (wstring)
      * \since ver2.0
      * \sa rejection()
+     *
+     * ver2.10〜 WStringView型に変更
+     *
      */
-    const std::wstring &rejectionW() const;
+    WStringView rejectionW() const;
 
     /*!
      * \brief 関数の実行が完了するまで待機
@@ -394,18 +401,11 @@ class WEBCFACE_DLL CallHandle : Field {
      * * ver1.11まで: 2回呼ぶと std::future_error を投げ、
      * このHandleがデフォルト構築されていた場合 std::runtime_error を投げる
      * * ver2.0から: respondable() がfalseの場合 std::runtime_error を投げる
+     * * ver2.0〜 wstring対応、ver2.10〜 String型に変更
      *
      */
-    void reject(std::string_view message) const { reject(ValAdaptor(message)); }
-    /*!
-     * \brief 関数の結果を例外として送信する (wstring)
-     * \since ver2.0
-     *
-     * * respondable() がfalseの場合 std::runtime_error を投げる
-     *
-     */
-    void reject(std::wstring_view message) const {
-        reject(ValAdaptor(message));
+    void reject(String message) const {
+        reject(ValAdaptor(std::move(message)));
     }
 
     /*!

--- a/client/include/webcface/func_result.h
+++ b/client/include/webcface/func_result.h
@@ -418,7 +418,7 @@ class WEBCFACE_DLL CallHandle : Field {
      * * ver2.0〜 wstring対応、ver2.10〜 String型に変更
      *
      */
-    void reject(String message) const {
+    void reject(StringInitializer message) const {
         reject(ValAdaptor(std::move(message)));
     }
 

--- a/client/include/webcface/func_trait.h
+++ b/client/include/webcface/func_trait.h
@@ -1,0 +1,60 @@
+#pragma once
+#include "webcface/common/val_adaptor.h"
+#include <tuple>
+#ifdef WEBCFACE_MESON
+#include "webcface-config.h"
+#else
+#include "webcface/common/webcface-config.h"
+#endif
+
+WEBCFACE_NS_BEGIN
+namespace traits {
+template <typename T>
+constexpr auto getInvokeSignature(T &&) -> decltype(&T::operator()) {
+    return &T::operator();
+}
+template <typename Ret, typename... Args>
+constexpr auto getInvokeSignature(Ret (*p)(Args...)) {
+    return p;
+}
+template <typename T>
+struct InvokeSignatureTrait {};
+template <typename Ret, typename... Args>
+struct InvokeSignatureTrait<Ret(Args...)> {
+    using ReturnType = Ret;
+    using ArgsTuple = std::tuple<std::decay_t<Args>...>;
+    static constexpr std::size_t ArgsSize = std::tuple_size_v<ArgsTuple>;
+    template <std::size_t Index>
+    using ArgsAt = std::tuple_element_t<Index, ArgsTuple>;
+};
+template <typename Ret, typename T, typename... Args>
+struct InvokeSignatureTrait<Ret (T::*)(Args...)>
+    : InvokeSignatureTrait<Ret(Args...)> {};
+template <typename Ret, typename T, typename... Args>
+struct InvokeSignatureTrait<Ret (T::*)(Args...) const>
+    : InvokeSignatureTrait<Ret(Args...)> {};
+template <typename Ret, typename... Args>
+struct InvokeSignatureTrait<Ret (*)(Args...)>
+    : InvokeSignatureTrait<Ret(Args...)> {};
+
+/*!
+ * * Tは関数オブジェクト型、または関数型
+ * * getInvokeSignature<T> で関数呼び出しの型 ( Ret(*)(Args...) や
+ * Ret(T::*)(Args...) ) を取得し、
+ * * InvokeSignatureTrait<Ret(Args...)> が各種メンバー型や定数を定義する
+ *
+ */
+template <typename T>
+using InvokeObjTrait = InvokeSignatureTrait<decltype(getInvokeSignature(
+    std::declval<std::decay_t<T>>()))>;
+
+// ValAdaptorからstringへは暗黙変換できないようにしているが、
+// Funcの引数では例外的にstringを許可する
+template <typename T>
+constexpr bool ConvertibleFromValAdaptor =
+    std::is_convertible_v<ValAdaptor, T> ||
+    std::is_convertible_v<std::string, T> ||
+    std::is_convertible_v<std::wstring, T>;
+
+} // namespace traits
+WEBCFACE_NS_END

--- a/client/include/webcface/func_trait.h
+++ b/client/include/webcface/func_trait.h
@@ -48,13 +48,5 @@ template <typename T>
 using InvokeObjTrait = InvokeSignatureTrait<decltype(getInvokeSignature(
     std::declval<std::decay_t<T>>()))>;
 
-// ValAdaptorからstringへは暗黙変換できないようにしているが、
-// Funcの引数では例外的にstringを許可する
-template <typename T>
-constexpr bool ConvertibleFromValAdaptor =
-    std::is_convertible_v<ValAdaptor, T> ||
-    std::is_convertible_v<std::string, T> ||
-    std::is_convertible_v<std::wstring, T>;
-
 } // namespace traits
 WEBCFACE_NS_END

--- a/client/include/webcface/image.h
+++ b/client/include/webcface/image.h
@@ -58,15 +58,6 @@ class WEBCFACE_DLL Image : protected Field {
      * 
      */
     Image operator[](String field) const { return child(std::move(field)); }
-    // /*!
-    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
-    //  * \since ver1.11
-    //  */
-    // Image operator[](const char *field) const { return child(field); }
-    // /*!
-    //  * \since ver2.0
-    //  */
-    // Image operator[](const wchar_t *field) const { return child(field); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/image.h
+++ b/client/include/webcface/image.h
@@ -36,10 +36,10 @@ class WEBCFACE_DLL Image : protected Field {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      * 
      */
-    Image child(String field) const {
+    Image child(StringInitializer field) const {
         return this->Field::child(static_cast<SharedString &>(field));
     }
     /*!
@@ -54,10 +54,10 @@ class WEBCFACE_DLL Image : protected Field {
      * child()と同じ
      * \since ver1.11
      * 
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      * 
      */
-    Image operator[](String field) const { return child(std::move(field)); }
+    Image operator[](StringInitializer field) const { return child(std::move(field)); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/image.h
+++ b/client/include/webcface/image.h
@@ -36,16 +36,11 @@ class WEBCFACE_DLL Image : protected Field {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    Image child(std::string_view field) const {
-        return this->Field::child(field);
-    }
-    /*!
-     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField (wstring)
-     * \since ver2.0
-     */
-    Image child(std::wstring_view field) const {
-        return this->Field::child(field);
+    Image child(String field) const {
+        return this->Field::child(static_cast<SharedString &>(field));
     }
     /*!
      * \since ver1.11
@@ -58,22 +53,20 @@ class WEBCFACE_DLL Image : protected Field {
     /*!
      * child()と同じ
      * \since ver1.11
+     * 
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    Image operator[](std::string_view field) const { return child(field); }
-    /*!
-     * child()と同じ
-     * \since ver2.0
-     */
-    Image operator[](std::wstring_view field) const { return child(field); }
-    /*!
-     * operator[](long, const char *)と解釈されるのを防ぐための定義
-     * \since ver1.11
-     */
-    Image operator[](const char *field) const { return child(field); }
-    /*!
-     * \since ver2.0
-     */
-    Image operator[](const wchar_t *field) const { return child(field); }
+    Image operator[](String field) const { return child(std::move(field)); }
+    // /*!
+    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
+    //  * \since ver1.11
+    //  */
+    // Image operator[](const char *field) const { return child(field); }
+    // /*!
+    //  * \since ver2.0
+    //  */
+    // Image operator[](const wchar_t *field) const { return child(field); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/internal/client_internal.h
+++ b/client/include/webcface/internal/client_internal.h
@@ -92,7 +92,7 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
     struct SyncDataSnapshot {
         std::chrono::system_clock::time_point time;
         StrMap1<MutableNumVector> value_data;
-        StrMap1<std::shared_ptr<TextData>> text_data;
+        StrMap1<ValAdaptor> text_data;
         StrMap1<std::shared_ptr<RobotModelData>> robot_model_data;
         StrMap1<std::shared_ptr<message::ViewData>> view_prev, view_data;
         StrMap1<std::shared_ptr<message::Canvas3DData>> canvas3d_prev,
@@ -318,7 +318,7 @@ struct ClientData : std::enable_shared_from_this<ClientData> {
     SharedMutexProxy<StrMap1<bool>> member_entry;
 
     SyncDataStore2<MutableNumVector> value_store;
-    SyncDataStore2<std::shared_ptr<TextData>> text_store;
+    SyncDataStore2<ValAdaptor> text_store;
     SyncDataStore2<std::shared_ptr<FuncData>> func_store;
     SyncDataStore2<std::shared_ptr<message::ViewData>> view_store;
     SyncDataStore2<ImageData, message::ImageReq> image_store;

--- a/client/include/webcface/internal/data_buffer.h
+++ b/client/include/webcface/internal/data_buffer.h
@@ -120,7 +120,7 @@ class ViewBuf final : public std::stringbuf,
      *
      */
     void addVC(TemporalViewComponent &&vc);
-    void addText(std::string_view text,
+    void addText(String text,
                  const TemporalViewComponent *vc = nullptr);
     void syncSetBuf() { this->DataSetBuffer<TemporalViewComponent>::sync(); }
 

--- a/client/include/webcface/internal/data_buffer.h
+++ b/client/include/webcface/internal/data_buffer.h
@@ -120,7 +120,7 @@ class ViewBuf final : public std::stringbuf,
      *
      */
     void addVC(TemporalViewComponent &&vc);
-    void addText(String text,
+    void addText(std::string_view text,
                  const TemporalViewComponent *vc = nullptr);
     void syncSetBuf() { this->DataSetBuffer<TemporalViewComponent>::sync(); }
 

--- a/client/include/webcface/internal/data_store2.h
+++ b/client/include/webcface/internal/data_store2.h
@@ -194,7 +194,6 @@ struct Canvas3DData;
 struct ImageReq;
 } // namespace message
 namespace internal {
-using TextData = ValAdaptor;
 using FuncData = FuncInfo;
 using RobotModelData = std::vector<std::shared_ptr<internal::RobotLinkData>>;
 using ImageData = ImageFrame;
@@ -221,7 +220,7 @@ struct LogData {
 #if WEBCFACE_SYSTEM_DLLEXPORT
 extern template class SyncDataStore2<std::string, int>; // test用
 extern template class SyncDataStore2<MutableNumVector, int>;
-extern template class SyncDataStore2<std::shared_ptr<TextData>, int>;
+extern template class SyncDataStore2<ValAdaptor, int>;
 extern template class SyncDataStore2<std::shared_ptr<FuncData>, int>;
 extern template class SyncDataStore2<std::shared_ptr<message::ViewData>, int>;
 extern template class SyncDataStore2<std::shared_ptr<RobotModelData>, int>;

--- a/client/include/webcface/log.h
+++ b/client/include/webcface/log.h
@@ -45,14 +45,22 @@ class LogLine : private LogLineData {
     LogLine(const LogLineData &ll) : LogLineData(ll) {}
     int level() const { return level_; }
     std::chrono::system_clock::time_point time() const { return time_; }
-    const std::string &message() const { return message_.decode(); };
+    /*!
+     * * ver2.10〜 StringViewに変更
+     *
+     */
+    StringView message() const { return message_.decode(); };
 };
 class LogLineW : private LogLineData {
   public:
     LogLineW(const LogLineData &ll) : LogLineData(ll) {}
     int level() const { return level_; }
     std::chrono::system_clock::time_point time() const { return time_; }
-    const std::wstring &message() const { return message_.decodeW(); };
+    /*!
+     * * ver2.10〜 WStringViewに変更
+     *
+     */
+    WStringView message() const { return message_.decodeW(); };
 };
 
 /*!
@@ -77,11 +85,11 @@ class WEBCFACE_DLL Log : protected Field {
     /*!
      * \brief Clientが保持するログの行数を設定する。
      * \since ver2.1
-     * 
+     *
      * * この行数以上のログが送られてきたら古いログから順に削除され、get()で取得できなくなる。
      * * デフォルトは1000
      * * 負の値を設定すると無制限に保持する。
-     * 
+     *
      */
     static void WEBCFACE_CALL keepLines(int n);
 
@@ -113,7 +121,8 @@ class WEBCFACE_DLL Log : protected Field {
      *
      */
     template <typename T>
-    [[deprecated]] void appendListener(T &&callback) const {
+    [[deprecated]]
+    void appendListener(T &&callback) const {
         onChange(std::forward<T>(callback));
     }
 
@@ -173,45 +182,25 @@ class WEBCFACE_DLL Log : protected Field {
      * \brief ログを1行追加
      * \since ver2.0
      *
-     * sync()時にサーバーに送られる。コンソールへの出力などはされない
+     * * sync()時にサーバーに送られる。コンソールへの出力などはされない
+     * * ver2.10〜 String型に変更
      *
      */
-    const Log &append(int level, std::string_view message) const {
+    const Log &append(int level, String message) const {
         return append({level, std::chrono::system_clock::now(),
-                       SharedString::encode(message)});
+                       static_cast<SharedString &>(message)});
     }
     /*!
      * \brief ログを1行追加
      * \since ver2.0
      *
-     * sync()時にサーバーに送られる。コンソールへの出力などはされない
+     * * sync()時にサーバーに送られる。コンソールへの出力などはされない
+     * * ver2.10〜 String型に変更
      *
      */
     const Log &append(int level, std::chrono::system_clock::time_point time,
-                      std::string_view message) const {
-        return append({level, time, SharedString::encode(message)});
-    }
-    /*!
-     * \brief ログを1行追加 (wstring)
-     * \since ver2.0
-     *
-     * sync()時にサーバーに送られる。コンソールへの出力などはされない
-     *
-     */
-    const Log &append(int level, std::wstring_view message) const {
-        return append({level, std::chrono::system_clock::now(),
-                       SharedString::encode(message)});
-    }
-    /*!
-     * \brief ログを1行追加 (wstring)
-     * \since ver2.0
-     *
-     * sync()時にサーバーに送られる。コンソールへの出力などはされない
-     *
-     */
-    const Log &append(int level, std::chrono::system_clock::time_point time,
-                      std::wstring_view message) const {
-        return append({level, time, SharedString::encode(message)});
+                      String message) const {
+        return append({level, time, static_cast<SharedString &>(message)});
     }
 
     /*!

--- a/client/include/webcface/log.h
+++ b/client/include/webcface/log.h
@@ -186,7 +186,7 @@ class WEBCFACE_DLL Log : protected Field {
      * * ver2.10〜 String型に変更
      *
      */
-    const Log &append(int level, String message) const {
+    const Log &append(int level, StringInitializer message) const {
         return append({level, std::chrono::system_clock::now(),
                        static_cast<SharedString &>(message)});
     }
@@ -199,7 +199,7 @@ class WEBCFACE_DLL Log : protected Field {
      *
      */
     const Log &append(int level, std::chrono::system_clock::time_point time,
-                      String message) const {
+                      StringInitializer message) const {
         return append({level, time, static_cast<SharedString &>(message)});
     }
 

--- a/client/include/webcface/log.h
+++ b/client/include/webcface/log.h
@@ -49,7 +49,7 @@ class LogLine : private LogLineData {
      * * ver2.10〜 StringViewに変更
      *
      */
-    StringView message() const { return message_.decode(); };
+    StringView message() const { return message_.decodeShare(); };
 };
 class LogLineW : private LogLineData {
   public:
@@ -60,7 +60,7 @@ class LogLineW : private LogLineData {
      * * ver2.10〜 WStringViewに変更
      *
      */
-    WStringView message() const { return message_.decodeW(); };
+    WStringView message() const { return message_.decodeShareW(); };
 };
 
 /*!

--- a/client/include/webcface/member.h
+++ b/client/include/webcface/member.h
@@ -36,7 +36,7 @@ class WEBCFACE_DLL Member : protected Field {
      * ver2.10〜 std::stringの参照から StringView に変更
      *
      */
-    StringView name() const { return member_.decode(); }
+    StringView name() const { return member_.decodeShare(); }
     /*!
      * \brief Member名 (wstring)
      * \since ver2.0
@@ -44,7 +44,7 @@ class WEBCFACE_DLL Member : protected Field {
      * ver2.10〜 std::wstringの参照から WStringView に変更
      *
      */
-    WStringView nameW() const { return member_.decodeW(); }
+    WStringView nameW() const { return member_.decodeShareW(); }
 
     using Field::child;
     using Field::operator[];

--- a/client/include/webcface/member.h
+++ b/client/include/webcface/member.h
@@ -33,13 +33,18 @@ class WEBCFACE_DLL Member : protected Field {
     /*!
      * \brief Member名
      *
+     * ver2.10〜 std::stringの参照から StringView に変更
+     *
      */
-    const std::string &name() const { return member_.decode(); }
+    StringView name() const { return member_.decode(); }
     /*!
      * \brief Member名 (wstring)
      * \since ver2.0
+     *
+     * ver2.10〜 std::wstringの参照から WStringView に変更
+     *
      */
-    const std::wstring &nameW() const { return member_.decodeW(); }
+    WStringView nameW() const { return member_.decodeW(); }
 
     using Field::child;
     using Field::operator[];
@@ -58,15 +63,8 @@ class WEBCFACE_DLL Member : protected Field {
      * \since ver2.4
      */
     template <WEBCFACE_COMPLETE(Log)>
-    Log_ log(std::string_view name) const {
-        return this->child(name);
-    }
-    /*!
-     * \since ver2.4
-     */
-    template <WEBCFACE_COMPLETE(Log)>
-    Log_ log(std::wstring_view name) const {
-        return this->child(name);
+    Log_ log(String name) const {
+        return this->child(static_cast<SharedString &>(name));
     }
     /*!
      * ver2.4〜: nameを省略した場合 "default" として送信される。
@@ -92,34 +90,40 @@ class WEBCFACE_DLL Member : protected Field {
      * \deprecated 1.6で valueEntries() に変更
      *
      */
-    [[deprecated]] std::vector<Value> values() const;
+    [[deprecated]]
+    std::vector<Value> values() const;
     /*!
      * \brief このmemberが公開しているtextのリストを返す。
      * \deprecated 1.6で textEntries() に変更
      */
-    [[deprecated]] std::vector<Text> texts() const;
+    [[deprecated]]
+    std::vector<Text> texts() const;
     /*!
      * \brief このmemberが公開しているrobotModelのリストを返す。
      * \deprecated 1.6で robotModelEntries() に変更
      *
      */
-    [[deprecated]] std::vector<RobotModel> robotModels() const;
+    [[deprecated]]
+    std::vector<RobotModel> robotModels() const;
     /*!
      * \brief このmemberが公開しているfuncのリストを返す。
      * \deprecated 1.6で funcEntries() に変更
      *
      */
-    [[deprecated]] std::vector<Func> funcs() const;
+    [[deprecated]]
+    std::vector<Func> funcs() const;
     /*!
      * \brief このmemberが公開しているviewのリストを返す。
      * \deprecated 1.6で viewEntries() に変更
      */
-    [[deprecated]] std::vector<View> views() const;
+    [[deprecated]]
+    std::vector<View> views() const;
     /*!
      * \brief このmemberが公開しているimageのリストを返す。
      * \deprecated 1.6で imageEntries() に変更
      */
-    [[deprecated]] std::vector<Image> images() const;
+    [[deprecated]]
+    std::vector<Image> images() const;
 
     /*!
      * \brief Memberのデータが存在するかどうかを返す

--- a/client/include/webcface/member.h
+++ b/client/include/webcface/member.h
@@ -63,7 +63,7 @@ class WEBCFACE_DLL Member : protected Field {
      * \since ver2.4
      */
     template <WEBCFACE_COMPLETE(Log)>
-    Log_ log(String name) const {
+    Log_ log(StringInitializer name) const {
         return this->child(static_cast<SharedString &>(name));
     }
     /*!

--- a/client/include/webcface/robot_link.h
+++ b/client/include/webcface/robot_link.h
@@ -112,40 +112,23 @@ inline RobotJoint fixedAbsolute(const Point &origin) {
  * \param parent_name 親リンクの名前
  * \param origin 親リンクの座標系で子リンクの原点
  *
+ * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+ * 
  */
-inline RobotJoint fixedJoint(std::string_view parent_name,
+inline RobotJoint fixedJoint(const String &parent_name,
                              const Transform &origin) {
-    return RobotJoint{nullptr, SharedString::encode(parent_name),
-                      RobotJointType::fixed, origin, 0};
-}
-/*!
- * \brief 固定された関節 (wstring)
- * \since ver2.0
- * \param parent_name 親リンクの名前
- * \param origin 親リンクの座標系で子リンクの原点
- *
- */
-inline RobotJoint fixedJoint(std::wstring_view parent_name,
-                             const Transform &origin) {
-    return RobotJoint{nullptr, SharedString::encode(parent_name),
+    return RobotJoint{nullptr, parent_name,
                       RobotJointType::fixed, origin, 0};
 }
 /*!
  * \brief 固定された関節
  * \param parent_name 親リンクの名前
  * \param origin 親リンクの座標系で子リンクの原点
+ * 
+ * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+ * 
  */
-inline RobotJoint fixedJoint(std::string_view parent_name,
-                             const Point &origin) {
-    return fixedJoint(parent_name, Transform{origin, {}});
-}
-/*!
- * \brief 固定された関節 (wstring)
- * \since ver2.0
- * \param parent_name 親リンクの名前
- * \param origin 親リンクの座標系で子リンクの原点
- */
-inline RobotJoint fixedJoint(std::wstring_view parent_name,
+inline RobotJoint fixedJoint(const String &parent_name,
                              const Point &origin) {
     return fixedJoint(parent_name, Transform{origin, {}});
 }
@@ -158,30 +141,14 @@ inline RobotJoint fixedJoint(std::wstring_view parent_name,
  * \param origin 親リンクの座標系で子リンクの原点
  * \param angle 初期状態の回転角
  *
+ * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+ * 
  */
-inline RobotJoint rotationalJoint(std::string_view name,
-                                  std::string_view parent_name,
+inline RobotJoint rotationalJoint(const String &name,
+                                  const String &parent_name,
                                   const Transform &origin, double angle = 0) {
-    return RobotJoint{SharedString::encode(name),
-                      SharedString::encode(parent_name),
-                      RobotJointType::rotational, origin, angle};
-}
-/*!
- * \brief 回転関節 (wstring)
- * \since ver2.0
- *
- * originのz軸を中心に回転する関節。
- * \param name 関節の名前
- * \param parent_name 親リンクの名前
- * \param origin 親リンクの座標系で子リンクの原点
- * \param angle 初期状態の回転角
- *
- */
-inline RobotJoint rotationalJoint(std::wstring_view name,
-                                  std::wstring_view parent_name,
-                                  const Transform &origin, double angle = 0) {
-    return RobotJoint{SharedString::encode(name),
-                      SharedString::encode(parent_name),
+    return RobotJoint{name,
+                      parent_name,
                       RobotJointType::rotational, origin, angle};
 }
 /*!
@@ -193,30 +160,14 @@ inline RobotJoint rotationalJoint(std::wstring_view name,
  * \param origin 親リンクの座標系で子リンクの原点
  * \param angle 初期状態の回転角(移動距離)
  *
+ * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+ * 
  */
-inline RobotJoint prismaticJoint(std::string_view name,
-                                 std::string_view parent_name,
+inline RobotJoint prismaticJoint(const String &name,
+                                 const String &parent_name,
                                  const Transform &origin, double angle = 0) {
-    return RobotJoint{SharedString::encode(name),
-                      SharedString::encode(parent_name),
-                      RobotJointType::prismatic, origin, angle};
-}
-/*!
- * \brief 直動関節 (wstring)
- * \since ver2.0
- *
- * originのz軸方向に直線運動する関節。
- * \param name 関節の名前
- * \param parent_name 親リンクの名前
- * \param origin 親リンクの座標系で子リンクの原点
- * \param angle 初期状態の回転角(移動距離)
- *
- */
-inline RobotJoint prismaticJoint(std::wstring_view name,
-                                 std::wstring_view parent_name,
-                                 const Transform &origin, double angle = 0) {
-    return RobotJoint{SharedString::encode(name),
-                      SharedString::encode(parent_name),
+    return RobotJoint{name,
+                      parent_name,
                       RobotJointType::prismatic, origin, angle};
 }
 } // namespace robot_joints
@@ -256,22 +207,12 @@ class WEBCFACE_DLL RobotLink {
      * \param geometry リンクの形状 (表示用)
      * \param color 色 (表示用)
      *
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    RobotLink(std::string_view name, const RobotJoint &joint,
+    RobotLink(const String &name, const RobotJoint &joint,
               const Geometry &geometry, ViewColor color = ViewColor::inherit)
-        : RobotLink(SharedString::encode(name), joint, geometry, color) {}
-
-    /*!
-     * \since ver2.0
-     * \param name リンクの名前
-     * \param joint 親リンクとの接続方法
-     * \param geometry リンクの形状 (表示用)
-     * \param color 色 (表示用)
-     *
-     */
-    RobotLink(std::wstring_view name, const RobotJoint &joint,
-              const Geometry &geometry, ViewColor color = ViewColor::inherit)
-        : RobotLink(SharedString::encode(name), joint, geometry, color) {}
+        : RobotLink(static_cast<const SharedString &>(name), joint, geometry, color) {}
     /*!
      * ベースのリンクではjointを省略可能
      * (fixedAbsolute({0, 0, 0})になる)
@@ -279,22 +220,12 @@ class WEBCFACE_DLL RobotLink {
      * \param geometry リンクの形状 (表示用)
      * \param color 色 (表示用)
      *
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    RobotLink(std::string_view name, const Geometry &geometry,
+    RobotLink(const String &name, const Geometry &geometry,
               ViewColor color = ViewColor::inherit)
-        : RobotLink(name, fixedAbsolute({0, 0, 0}), geometry, color) {}
-    /*!
-     * ベースのリンクではjointを省略可能
-     * (fixedAbsolute({0, 0, 0})になる)
-     * \since ver2.0
-     * \param name リンクの名前
-     * \param geometry リンクの形状 (表示用)
-     * \param color 色 (表示用)
-     *
-     */
-    RobotLink(std::wstring_view name, const Geometry &geometry,
-              ViewColor color = ViewColor::inherit)
-        : RobotLink(name, fixedAbsolute({0, 0, 0}), geometry, color) {}
+        : RobotLink(static_cast<const SharedString &>(name), fixedAbsolute({0, 0, 0}), geometry, color) {}
 
     /*!
      * \brief 名前を取得

--- a/client/include/webcface/robot_link.h
+++ b/client/include/webcface/robot_link.h
@@ -56,13 +56,18 @@ class WEBCFACE_DLL RobotJoint {
     /*!
      * \brief jointの名前を取得
      *
+     * ver2.10〜 std::stringの参照から StringView に変更
+     * 
      */
-    const std::string &name() const;
+    StringView name() const;
     /*!
      * \brief jointの名前を取得 (wstring)
      * \since ver2.0
+     * 
+     * ver2.10〜 std::wstringの参照から WStringView に変更
+     * 
      */
-    const std::wstring &nameW() const;
+    WStringView nameW() const;
     /*!
      * \brief 親リンクを取得
      * \since ver2.0
@@ -230,13 +235,18 @@ class WEBCFACE_DLL RobotLink {
     /*!
      * \brief 名前を取得
      *
+     * ver2.10〜 std::stringの参照から StringView に変更
+     * 
      */
-    const std::string &name() const;
+    StringView name() const;
     /*!
      * \brief 名前を取得 (wstring)
      * \since ver2.0
+     * 
+     * ver2.10〜 std::stringの参照から StringView に変更
+     * 
      */
-    const std::wstring &nameW() const;
+    WStringView nameW() const;
     /*!
      * \brief jointを取得
      *

--- a/client/include/webcface/robot_link.h
+++ b/client/include/webcface/robot_link.h
@@ -117,10 +117,10 @@ inline RobotJoint fixedAbsolute(const Point &origin) {
  * \param parent_name 親リンクの名前
  * \param origin 親リンクの座標系で子リンクの原点
  *
- * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+ * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
  * 
  */
-inline RobotJoint fixedJoint(const String &parent_name,
+inline RobotJoint fixedJoint(const StringInitializer &parent_name,
                              const Transform &origin) {
     return RobotJoint{nullptr, parent_name,
                       RobotJointType::fixed, origin, 0};
@@ -130,10 +130,10 @@ inline RobotJoint fixedJoint(const String &parent_name,
  * \param parent_name 親リンクの名前
  * \param origin 親リンクの座標系で子リンクの原点
  * 
- * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+ * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
  * 
  */
-inline RobotJoint fixedJoint(const String &parent_name,
+inline RobotJoint fixedJoint(const StringInitializer &parent_name,
                              const Point &origin) {
     return fixedJoint(parent_name, Transform{origin, {}});
 }
@@ -146,11 +146,11 @@ inline RobotJoint fixedJoint(const String &parent_name,
  * \param origin 親リンクの座標系で子リンクの原点
  * \param angle 初期状態の回転角
  *
- * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+ * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
  * 
  */
-inline RobotJoint rotationalJoint(const String &name,
-                                  const String &parent_name,
+inline RobotJoint rotationalJoint(const StringInitializer &name,
+                                  const StringInitializer &parent_name,
                                   const Transform &origin, double angle = 0) {
     return RobotJoint{name,
                       parent_name,
@@ -165,11 +165,11 @@ inline RobotJoint rotationalJoint(const String &name,
  * \param origin 親リンクの座標系で子リンクの原点
  * \param angle 初期状態の回転角(移動距離)
  *
- * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+ * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
  * 
  */
-inline RobotJoint prismaticJoint(const String &name,
-                                 const String &parent_name,
+inline RobotJoint prismaticJoint(const StringInitializer &name,
+                                 const StringInitializer &parent_name,
                                  const Transform &origin, double angle = 0) {
     return RobotJoint{name,
                       parent_name,
@@ -212,10 +212,10 @@ class WEBCFACE_DLL RobotLink {
      * \param geometry リンクの形状 (表示用)
      * \param color 色 (表示用)
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      * 
      */
-    RobotLink(const String &name, const RobotJoint &joint,
+    RobotLink(const StringInitializer &name, const RobotJoint &joint,
               const Geometry &geometry, ViewColor color = ViewColor::inherit)
         : RobotLink(static_cast<const SharedString &>(name), joint, geometry, color) {}
     /*!
@@ -225,10 +225,10 @@ class WEBCFACE_DLL RobotLink {
      * \param geometry リンクの形状 (表示用)
      * \param color 色 (表示用)
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      * 
      */
-    RobotLink(const String &name, const Geometry &geometry,
+    RobotLink(const StringInitializer &name, const Geometry &geometry,
               ViewColor color = ViewColor::inherit)
         : RobotLink(static_cast<const SharedString &>(name), fixedAbsolute({0, 0, 0}), geometry, color) {}
 

--- a/client/include/webcface/robot_model.h
+++ b/client/include/webcface/robot_model.h
@@ -43,16 +43,12 @@ class WEBCFACE_DLL RobotModel : protected Field {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      * \since ver1.11
+     * 
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    RobotModel child(std::string_view field) const {
-        return this->Field::child(field);
-    }
-    /*!
-     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField (wstring)
-     * \since ver2.0
-     */
-    RobotModel child(std::wstring_view field) const {
-        return this->Field::child(field);
+    RobotModel child(String field) const {
+        return this->Field::child(static_cast<SharedString&>(field));
     }
     /*!
      * \since ver1.11
@@ -65,24 +61,20 @@ class WEBCFACE_DLL RobotModel : protected Field {
     /*!
      * child()と同じ
      * \since ver1.11
+     * 
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    RobotModel operator[](std::string_view field) const { return child(field); }
-    /*!
-     * child()と同じ
-     * \since ver2.0
-     */
-    RobotModel operator[](std::wstring_view field) const {
-        return child(field);
-    }
-    /*!
-     * operator[](long, const char *)と解釈されるのを防ぐための定義
-     * \since ver1.11
-     */
-    RobotModel operator[](const char *field) const { return child(field); }
-    /*!
-     * \since ver2.0
-     */
-    RobotModel operator[](const wchar_t *field) const { return child(field); }
+    RobotModel operator[](String field) const { return child(std::move(field)); }
+    // /*!
+    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
+    //  * \since ver1.11
+    //  */
+    // RobotModel operator[](const char *field) const { return child(field); }
+    // /*!
+    //  * \since ver2.0
+    //  */
+    // RobotModel operator[](const wchar_t *field) const { return child(field); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/robot_model.h
+++ b/client/include/webcface/robot_model.h
@@ -66,15 +66,6 @@ class WEBCFACE_DLL RobotModel : protected Field {
      * 
      */
     RobotModel operator[](String field) const { return child(std::move(field)); }
-    // /*!
-    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
-    //  * \since ver1.11
-    //  */
-    // RobotModel operator[](const char *field) const { return child(field); }
-    // /*!
-    //  * \since ver2.0
-    //  */
-    // RobotModel operator[](const wchar_t *field) const { return child(field); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/robot_model.h
+++ b/client/include/webcface/robot_model.h
@@ -44,10 +44,10 @@ class WEBCFACE_DLL RobotModel : protected Field {
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      * \since ver1.11
      * 
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      * 
      */
-    RobotModel child(String field) const {
+    RobotModel child(StringInitializer field) const {
         return this->Field::child(static_cast<SharedString&>(field));
     }
     /*!
@@ -62,10 +62,10 @@ class WEBCFACE_DLL RobotModel : protected Field {
      * child()と同じ
      * \since ver1.11
      * 
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      * 
      */
-    RobotModel operator[](String field) const { return child(std::move(field)); }
+    RobotModel operator[](StringInitializer field) const { return child(std::move(field)); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/text.h
+++ b/client/include/webcface/text.h
@@ -85,10 +85,11 @@ class WEBCFACE_DLL Variant : protected Field {
     /*!
      * \brief 値を取得する
      *
-     * 参照は少なくとも次のClient::sync()までは有効
+     * <del>参照は少なくとも次のClient::sync()までは有効</del>
+     * ver2.10〜 ValAdaptorをコピーで返すように変更
      *
      */
-    const ValAdaptor &get() const;
+    ValAdaptor get() const;
 
     template <typename T,
               typename std::enable_if_t<std::is_convertible_v<ValAdaptor, T>,
@@ -104,27 +105,26 @@ class WEBCFACE_DLL Variant : protected Field {
     /*!
      * \brief 文字列として返す
      *
-     * std::stringのconst参照を返す。
-     * 参照は少なくとも次のClient::sync()までは有効
+     * <del>std::stringのconst参照を返す。参照は少なくとも次のClient::sync()までは有効</del>
      *
      * \deprecated ver2.10〜
-     * 内部の仕様変更により文字列のコピーが発生する可能性がある。
+     * 内部の仕様変更によりconst参照ではなく文字列のコピーを返す。
      * コピーなしで文字列を参照するには asStringView() を使用すること。
      */
-    [[deprecated("(ver2.10〜) use asStringView() instead")]]
-    const std::string &asStringRef() const {
-        return get().asStringRef();
+    [[deprecated("(ver2.10〜) use asStringView() or asString() instead")]]
+    std::string asStringRef() const {
+        return asString();
     }
     /*!
      * \brief 文字列として返す (wstring)
      * \sa asStringRef()
      * \deprecated ver2.10〜
-     * 内部の仕様変更により文字列のコピーが発生する可能性がある。
+     * 内部の仕様変更によりconst参照ではなく文字列のコピーを返す。
      * コピーなしで文字列を参照するには asStringView() を使用すること。
      */
-    [[deprecated("(ver2.10〜) use asWStringView() instead")]]
-    const std::wstring &asWStringRef() const {
-        return get().asWStringRef();
+    [[deprecated("(ver2.10〜) use asWStringView() or asWString() instead")]]
+    std::wstring asWStringRef() const {
+        return asWString();
     }
     /*!
      * \brief null終端の文字列の参照として返す
@@ -366,22 +366,28 @@ class WEBCFACE_DLL Text : protected Variant {
      * \brief 文字列を返す
      *
      * * <del>ver1.10〜 文字列以外の型も扱うためValAdaptor型に変更</del>
-     * * ver2.0〜 stringに戻した
+     * * <del>ver2.0〜 stringに戻した</del>
+     * * ver2.10〜 StringViewに変更
+     * * 参照は少なくとも次のClient::sync()までは有効
      *
      */
-    std::optional<std::string> tryGet() const;
+    std::optional<StringView> tryGet() const;
     /*!
      * \brief 文字列を返す (wstring)
      * \since ver2.0
+     *
+     * * ver2.10〜 WStringViewに変更
+     * * 参照は少なくとも次のClient::sync()までは有効
+     *
      */
-    std::optional<std::wstring> tryGetW() const;
+    std::optional<WStringView> tryGetW() const;
     /*!
      * \brief 文字列を返す (const参照)
      *
      * * <del>ver1.10〜 文字列以外の型も扱うためValAdaptor型に変更</del>
-     * * ver2.0〜 stringに戻した
-     * * ver2.0〜 const参照に変更
-     * 参照は少なくとも次のClient::sync()までは有効
+     * * <del>ver2.0〜 stringに戻した</del>
+     * * <del>ver2.0〜 const参照に変更</del>
+     * * 参照は少なくとも次のClient::sync()までは有効
      * * ver2.10〜 StringViewに変更
      *
      */
@@ -509,12 +515,13 @@ class WEBCFACE_DLL InputRef {
     /*!
      * \brief 値を返す
      *
-     * * ver1.11からconst参照
+     * * <del>ver1.11からconst参照</del>
      *   * <del>参照は次に値を取得して別の値が返ったときまで有効</del>
-     *   * ver2.0〜: 参照は少なくとも次のClient::sync()までは有効
+     *   * <del>ver2.0〜: 参照は少なくとも次のClient::sync()までは有効</del>
+     * * ver2.10〜 ValAdaptorをコピーで返すように変更
      *
      */
-    const ValAdaptor &get() const;
+    ValAdaptor get() const;
 
     /*!
      * \brief 値を返す
@@ -537,31 +544,31 @@ class WEBCFACE_DLL InputRef {
      * \brief 文字列として返す
      * \since ver1.11
      *
-     * * std::stringのconst参照を返す。
+     * * <del>std::stringのconst参照を返す。</del>
      *   * <del>参照は次に値を取得して別の値が返ったときまで有効</del>
      *   * ver2.0〜: 参照は少なくとも次のClient::sync()までは有効
      *
      * \deprecated ver2.10〜
-     * 内部の仕様変更により文字列のコピーが発生する可能性がある。
+     * 内部の仕様変更によりconst参照ではなく文字列のコピーを返す。
      * コピーなしで文字列を参照するには asStringView()
      * を使用すること。
      */
-    [[deprecated("(ver2.10〜) use asStringView() instead")]]
-    const std::string &asStringRef() const {
-        return get().asStringRef();
+    [[deprecated("(ver2.10〜) use asStringView() or asString() instead")]]
+    std::string asStringRef() const {
+        return asString();
     }
     /*!
      * \brief 文字列として返す (wstring)
      * \since ver2.0
      * \sa asStringRef()
      * \deprecated ver2.10〜
-     * 内部の仕様変更により文字列のコピーが発生する可能性がある。
+     * 内部の仕様変更によりconst参照ではなく文字列のコピーを返す。
      * コピーなしで文字列を参照するには asWStringView()
      * を使用すること。
      */
-    [[deprecated("(ver2.10〜) use asWStringView() instead")]]
-    const std::wstring &asWStringRef() const {
-        return get().asWStringRef();
+    [[deprecated("(ver2.10〜) use asWStringView() or asWString() instead")]]
+    std::wstring asWStringRef() const {
+        return asWString();
     }
     /*!
      * \brief null終端の文字列の参照として返す

--- a/client/include/webcface/text.h
+++ b/client/include/webcface/text.h
@@ -216,15 +216,34 @@ class WEBCFACE_DLL Text : protected Variant {
      * 
      */
     Text operator[](String field) const { return child(std::move(field)); }
-    // /*!
-    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
-    //  * \since ver1.11
-    //  */
-    // Text operator[](const char *field) const { return child(field); }
-    // /*!
-    //  * \since ver2.0
-    //  */
-    // Text operator[](const wchar_t *field) const { return child(field); }
+    /*!
+     * operator[](long, const char *)と解釈されるのを防ぐための定義
+     * \since ver1.11
+     * 
+     * Variantがlongに変換可能なため。
+     * 
+     */
+    Text operator[](const char *field) const { return child(field); }
+    /*!
+     * \since ver2.0
+     */
+    Text operator[](const wchar_t *field) const { return child(field); }
+    /*!
+     * operator[](long, const char *)と解釈されるのを防ぐための定義
+     * \since ver2.10
+     */
+    template <std::size_t N>
+    Text operator[](const char (&static_str)[N]) {
+        return child(String(static_str));
+    }
+    /*!
+     * operator[](long, const wchar_t *)と解釈されるのを防ぐための定義
+     * \since ver2.10
+     */
+    template <std::size_t N>
+    Text operator[](const wchar_t (&static_str)[N]) {
+        return child(String(static_str));
+    }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/text.h
+++ b/client/include/webcface/text.h
@@ -129,17 +129,11 @@ class WEBCFACE_DLL Variant : protected Field {
     /*!
      * \brief null終端の文字列の参照として返す
      * \since ver2.10
-     *
-     * 参照は少なくとも次のClient::sync()までは有効
-     *
      */
     StringView asStringView() const { return get().asStringView(); }
     /*!
      * \brief null終端の文字列の参照として返す (wstring)
      * \since ver2.10
-     *
-     * 参照は少なくとも次のClient::sync()までは有効
-     *
      */
     WStringView asWStringView() const { return get().asWStringView(); }
     /*!
@@ -367,8 +361,8 @@ class WEBCFACE_DLL Text : protected Variant {
      *
      * * <del>ver1.10〜 文字列以外の型も扱うためValAdaptor型に変更</del>
      * * <del>ver2.0〜 stringに戻した</del>
+     * * <del>参照は少なくとも次のClient::sync()までは有効</del>
      * * ver2.10〜 StringViewに変更
-     * * 参照は少なくとも次のClient::sync()までは有効
      *
      */
     std::optional<StringView> tryGet() const;
@@ -376,8 +370,8 @@ class WEBCFACE_DLL Text : protected Variant {
      * \brief 文字列を返す (wstring)
      * \since ver2.0
      *
+     * * <del>参照は少なくとも次のClient::sync()までは有効</del>
      * * ver2.10〜 WStringViewに変更
-     * * 参照は少なくとも次のClient::sync()までは有効
      *
      */
     std::optional<WStringView> tryGetW() const;
@@ -387,7 +381,7 @@ class WEBCFACE_DLL Text : protected Variant {
      * * <del>ver1.10〜 文字列以外の型も扱うためValAdaptor型に変更</del>
      * * <del>ver2.0〜 stringに戻した</del>
      * * <del>ver2.0〜 const参照に変更</del>
-     * * 参照は少なくとも次のClient::sync()までは有効
+     * * <del>参照は少なくとも次のClient::sync()までは有効</del>
      * * ver2.10〜 StringViewに変更
      *
      */
@@ -396,7 +390,7 @@ class WEBCFACE_DLL Text : protected Variant {
      * \brief 文字列を返す (wstring const参照)
      * \since ver2.0
      *
-     * * 参照は少なくとも次のClient::sync()までは有効
+     * * <del>参照は少なくとも次のClient::sync()までは有効</del>
      * * ver2.10〜 WStringViewに変更
      *
      */
@@ -571,19 +565,13 @@ class WEBCFACE_DLL InputRef {
         return asWString();
     }
     /*!
-     * \brief null終端の文字列の参照として返す
+     * \brief null終端の文字列として返す
      * \since ver2.10
-     *
-     * 参照は少なくとも次のClient::sync()までは有効
-     *
      */
     StringView asStringView() const { return get().asStringView(); }
     /*!
-     * \brief null終端の文字列の参照として返す
+     * \brief null終端の文字列として返す
      * \since ver2.10
-     *
-     * 参照は少なくとも次のClient::sync()までは有効
-     *
      */
     WStringView asWStringView() const { return get().asWStringView(); }
     /*!

--- a/client/include/webcface/text.h
+++ b/client/include/webcface/text.h
@@ -194,16 +194,11 @@ class WEBCFACE_DLL Text : protected Variant {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    Text child(std::string_view field) const {
-        return this->Field::child(field);
-    }
-    /*!
-     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField (wstring)
-     * \since ver2.0
-     */
-    Text child(std::wstring_view field) const {
-        return this->Field::child(field);
+    Text child(String field) const {
+        return this->Field::child(static_cast<SharedString &>(field));
     }
     /*!
      * \since ver1.11
@@ -216,22 +211,20 @@ class WEBCFACE_DLL Text : protected Variant {
     /*!
      * child()と同じ
      * \since ver1.11
+     * 
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    Text operator[](std::string_view field) const { return child(field); }
-    /*!
-     * child()と同じ
-     * \since ver2.0
-     */
-    Text operator[](std::wstring_view field) const { return child(field); }
-    /*!
-     * operator[](long, const char *)と解釈されるのを防ぐための定義
-     * \since ver1.11
-     */
-    Text operator[](const char *field) const { return child(field); }
-    /*!
-     * \since ver2.0
-     */
-    Text operator[](const wchar_t *field) const { return child(field); }
+    Text operator[](String field) const { return child(std::move(field)); }
+    // /*!
+    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
+    //  * \since ver1.11
+    //  */
+    // Text operator[](const char *field) const { return child(field); }
+    // /*!
+    //  * \since ver2.0
+    //  */
+    // Text operator[](const wchar_t *field) const { return child(field); }
     /*!
      * child()と同じ
      * \since ver1.11
@@ -292,35 +285,21 @@ class WEBCFACE_DLL Text : protected Variant {
      * \brief 文字列をセットする
      *
      * (ver2.0からstd::stringをstd::string_viewに変更)
-     *
+     * (ver2.0からstd::wstring対応、ver2.10からString型に変更)
      */
-    const Text &set(std::string_view v) const {
-        this->Variant::set(ValAdaptor{v});
-        return *this;
-    }
-    /*!
-     * \brief 文字列をセットする (wstring)
-     * \since ver2.0
-     */
-    const Text &set(std::wstring_view v) const {
-        this->Variant::set(ValAdaptor{v});
+    const Text &set(String v) const {
+        this->Variant::set(ValAdaptor{std::move(v)});
         return *this;
     }
 
     /*!
      * \brief 文字列をセットする
      *
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    const Text &operator=(std::string_view v) const {
-        this->set(v);
-        return *this;
-    }
-    /*!
-     * \brief 文字列をセットする (wstring)
-     * \since ver2.0
-     */
-    const Text &operator=(std::wstring_view v) const {
-        this->set(v);
+    const Text &operator=(String v) const {
+        this->set(std::move(v));
         return *this;
     }
 

--- a/client/include/webcface/text.h
+++ b/client/include/webcface/text.h
@@ -217,10 +217,10 @@ class WEBCFACE_DLL Text : protected Variant {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      *
      */
-    Text child(String field) const {
+    Text child(StringInitializer field) const {
         return this->Field::child(static_cast<SharedString &>(field));
     }
     /*!
@@ -235,10 +235,10 @@ class WEBCFACE_DLL Text : protected Variant {
      * child()と同じ
      * \since ver1.11
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      *
      */
-    Text operator[](String field) const { return child(std::move(field)); }
+    Text operator[](StringInitializer field) const { return child(std::move(field)); }
     /*!
      * operator[](long, const char *)と解釈されるのを防ぐための定義
      * \since ver1.11
@@ -257,7 +257,7 @@ class WEBCFACE_DLL Text : protected Variant {
      */
     template <std::size_t N>
     Text operator[](const char (&static_str)[N]) {
-        return child(String(static_str));
+        return child(StringInitializer(static_str));
     }
     /*!
      * operator[](long, const wchar_t *)と解釈されるのを防ぐための定義
@@ -265,7 +265,7 @@ class WEBCFACE_DLL Text : protected Variant {
      */
     template <std::size_t N>
     Text operator[](const wchar_t (&static_str)[N]) {
-        return child(String(static_str));
+        return child(StringInitializer(static_str));
     }
     /*!
      * child()と同じ
@@ -331,7 +331,7 @@ class WEBCFACE_DLL Text : protected Variant {
      * (ver2.0からstd::stringをstd::string_viewに変更)
      * (ver2.0からstd::wstring対応、ver2.10からString型に変更)
      */
-    const Text &set(String v) const {
+    const Text &set(StringInitializer v) const {
         this->Variant::set(ValAdaptor{std::move(v)});
         return *this;
     }
@@ -339,10 +339,10 @@ class WEBCFACE_DLL Text : protected Variant {
     /*!
      * \brief 文字列をセットする
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      *
      */
-    const Text &operator=(String v) const {
+    const Text &operator=(StringInitializer v) const {
         this->set(std::move(v));
         return *this;
     }

--- a/client/include/webcface/text.h
+++ b/client/include/webcface/text.h
@@ -59,7 +59,8 @@ class WEBCFACE_DLL Variant : protected Field {
      *
      */
     template <typename T>
-    [[deprecated]] void appendListener(T &&callback) const {
+    [[deprecated]]
+    void appendListener(T &&callback) const {
         onChange(std::forward<T>(callback));
     }
 
@@ -106,13 +107,41 @@ class WEBCFACE_DLL Variant : protected Field {
      * std::stringのconst参照を返す。
      * 参照は少なくとも次のClient::sync()までは有効
      *
+     * \deprecated ver2.10〜
+     * 内部の仕様変更により文字列のコピーが発生する可能性がある。
+     * コピーなしで文字列を参照するには asStringView() を使用すること。
      */
-    const std::string &asStringRef() const { return get().asStringRef(); }
+    [[deprecated("(ver2.10〜) use asStringView() instead")]]
+    const std::string &asStringRef() const {
+        return get().asStringRef();
+    }
     /*!
      * \brief 文字列として返す (wstring)
      * \sa asStringRef()
+     * \deprecated ver2.10〜
+     * 内部の仕様変更により文字列のコピーが発生する可能性がある。
+     * コピーなしで文字列を参照するには asStringView() を使用すること。
      */
-    const std::wstring &asWStringRef() const { return get().asWStringRef(); }
+    [[deprecated("(ver2.10〜) use asWStringView() instead")]]
+    const std::wstring &asWStringRef() const {
+        return get().asWStringRef();
+    }
+    /*!
+     * \brief null終端の文字列の参照として返す
+     * \since ver2.10
+     *
+     * 参照は少なくとも次のClient::sync()までは有効
+     *
+     */
+    StringView asStringView() const { return get().asStringView(); }
+    /*!
+     * \brief null終端の文字列の参照として返す (wstring)
+     * \since ver2.10
+     *
+     * 参照は少なくとも次のClient::sync()までは有効
+     *
+     */
+    WStringView asWStringView() const { return get().asWStringView(); }
     /*!
      * \brief 文字列として返す(コピー)
      *
@@ -195,7 +224,7 @@ class WEBCFACE_DLL Text : protected Variant {
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
      * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
-     * 
+     *
      */
     Text child(String field) const {
         return this->Field::child(static_cast<SharedString &>(field));
@@ -211,17 +240,17 @@ class WEBCFACE_DLL Text : protected Variant {
     /*!
      * child()と同じ
      * \since ver1.11
-     * 
+     *
      * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
-     * 
+     *
      */
     Text operator[](String field) const { return child(std::move(field)); }
     /*!
      * operator[](long, const char *)と解釈されるのを防ぐための定義
      * \since ver1.11
-     * 
+     *
      * Variantがlongに変換可能なため。
-     * 
+     *
      */
     Text operator[](const char *field) const { return child(field); }
     /*!
@@ -250,7 +279,8 @@ class WEBCFACE_DLL Text : protected Variant {
      * \deprecated ver2.8〜
      */
     [[deprecated]]
-    Text operator[](int index) const {
+    Text
+    operator[](int index) const {
         return child(std::to_string(index));
     }
     /*!
@@ -296,7 +326,8 @@ class WEBCFACE_DLL Text : protected Variant {
      *
      */
     template <typename T>
-    [[deprecated]] void appendListener(T &&callback) const {
+    [[deprecated]]
+    void appendListener(T &&callback) const {
         onChange(std::forward<T>(callback));
     }
 
@@ -315,7 +346,7 @@ class WEBCFACE_DLL Text : protected Variant {
      * \brief 文字列をセットする
      *
      * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
-     * 
+     *
      */
     const Text &operator=(String v) const {
         this->set(std::move(v));
@@ -351,20 +382,32 @@ class WEBCFACE_DLL Text : protected Variant {
      * * ver2.0〜 stringに戻した
      * * ver2.0〜 const参照に変更
      * 参照は少なくとも次のClient::sync()までは有効
+     * * ver2.10〜 StringViewに変更
      *
      */
-    const std::string &get() const;
+    StringView get() const;
     /*!
      * \brief 文字列を返す (wstring const参照)
      * \since ver2.0
      *
-     * 参照は少なくとも次のClient::sync()までは有効
+     * * 参照は少なくとも次のClient::sync()までは有効
+     * * ver2.10〜 WStringViewに変更
      *
      */
-    const std::wstring &getW() const;
+    WStringView getW() const;
 
-    operator const std::string &() const { return get(); }
-    operator const std::wstring &() const { return getW(); }
+    /*!
+     * \since ver2.10
+     *
+     * 以前の const std::string& を置き換え
+     */
+    operator std::string_view() const { return get(); }
+    /*!
+     * \since ver2.10
+     *
+     * 以前の const std::wstring& を置き換え
+     */
+    operator std::wstring_view() const { return getW(); }
 
     /*!
      * \brief このフィールドにデータが存在すればtrue
@@ -380,7 +423,8 @@ class WEBCFACE_DLL Text : protected Variant {
      * \brief syncの時刻を返す
      * \deprecated 1.7でMember::syncTime()に変更
      */
-    [[deprecated]] std::chrono::system_clock::time_point time() const;
+    [[deprecated]]
+    std::chrono::system_clock::time_point time() const;
 
     /*!
      * \brief 値やリクエスト状態をクリア
@@ -497,14 +541,44 @@ class WEBCFACE_DLL InputRef {
      *   * <del>参照は次に値を取得して別の値が返ったときまで有効</del>
      *   * ver2.0〜: 参照は少なくとも次のClient::sync()までは有効
      *
+     * \deprecated ver2.10〜
+     * 内部の仕様変更により文字列のコピーが発生する可能性がある。
+     * コピーなしで文字列を参照するには asStringView()
+     * を使用すること。
      */
-    const std::string &asStringRef() const { return get().asStringRef(); }
+    [[deprecated("(ver2.10〜) use asStringView() instead")]]
+    const std::string &asStringRef() const {
+        return get().asStringRef();
+    }
     /*!
      * \brief 文字列として返す (wstring)
      * \since ver2.0
      * \sa asStringRef()
+     * \deprecated ver2.10〜
+     * 内部の仕様変更により文字列のコピーが発生する可能性がある。
+     * コピーなしで文字列を参照するには asWStringView()
+     * を使用すること。
      */
-    const std::wstring &asWStringRef() const { return get().asWStringRef(); }
+    [[deprecated("(ver2.10〜) use asWStringView() instead")]]
+    const std::wstring &asWStringRef() const {
+        return get().asWStringRef();
+    }
+    /*!
+     * \brief null終端の文字列の参照として返す
+     * \since ver2.10
+     *
+     * 参照は少なくとも次のClient::sync()までは有効
+     *
+     */
+    StringView asStringView() const { return get().asStringView(); }
+    /*!
+     * \brief null終端の文字列の参照として返す
+     * \since ver2.10
+     *
+     * 参照は少なくとも次のClient::sync()までは有効
+     *
+     */
+    WStringView asWStringView() const { return get().asWStringView(); }
     /*!
      * \brief 文字列として返す(コピー)
      * \since ver1.11

--- a/client/include/webcface/value.h
+++ b/client/include/webcface/value.h
@@ -30,7 +30,8 @@ class WEBCFACE_DLL ValueElementRef : protected Field {
      *
      * * 事前に Value::resize() でサイズを変更しておく必要がある
      * * データがない場合、範囲外の場合は std::out_of_range を投げる
-     *   * ver2.7以前は Value[i].set() で自動的にリサイズされていたので、異なる挙動になる
+     *   * ver2.7以前は Value[i].set()
+     * で自動的にリサイズされていたので、異なる挙動になる
      */
     const ValueElementRef &set(double v) const;
     const ValueElementRef &operator=(double v) const { return set(v); }
@@ -65,7 +66,7 @@ class WEBCFACE_DLL Value : protected Field {
         : Value(Field{base, field}) {}
 
     friend class ValueElementRef;
-    
+
     using Field::lastName;
     using Field::member;
     using Field::name;
@@ -74,7 +75,7 @@ class WEBCFACE_DLL Value : protected Field {
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
      * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
-     * 
+     *
      */
     Value child(String field) const {
         return this->Field::child(static_cast<SharedString &>(field));
@@ -90,20 +91,36 @@ class WEBCFACE_DLL Value : protected Field {
     /*!
      * child()と同じ
      * \since ver1.11
-     * 
+     *
      * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
-     * 
+     *
      */
     Value operator[](String field) const { return child(std::move(field)); }
-    // /*!
-    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
-    //  * \since ver1.11
-    //  */
-    // Value operator[](const char *field) const { return child(field); }
-    // /*!
-    //  * \since ver2.0
-    //  */
-    // Value operator[](const wchar_t *field) const { return child(field); }
+    /*!
+     * operator[](long, const char *)と解釈されるのを防ぐための定義
+     * \since ver1.11
+     */
+    Value operator[](const char *field) const { return child(field); }
+    /*!
+     * \since ver2.0
+     */
+    Value operator[](const wchar_t *field) const { return child(field); }
+    /*!
+     * operator[](long, const char *)と解釈されるのを防ぐための定義
+     * \since ver2.10
+     */
+    template <std::size_t N>
+    Value operator[](const char (&static_str)[N]) {
+        return child(String(static_str));
+    }
+    /*!
+     * operator[](long, const wchar_t *)と解釈されるのを防ぐための定義
+     * \since ver2.10
+     */
+    template <std::size_t N>
+    Value operator[](const wchar_t (&static_str)[N]) {
+        return child(String(static_str));
+    }
     /*!
      * \brief 1次元配列型データの要素を参照する
      * \since ver2.8
@@ -161,7 +178,8 @@ class WEBCFACE_DLL Value : protected Field {
      *
      */
     template <typename T>
-    [[deprecated]] void appendListener(T &&callback) const {
+    [[deprecated]]
+    void appendListener(T &&callback) const {
         onChange(std::forward<T>(callback));
     }
 
@@ -205,10 +223,11 @@ class WEBCFACE_DLL Value : protected Field {
     /*!
      * \brief 配列データのサイズを取得
      * \since ver2.8
-     * 
+     *
      * * 自身のデータの場合、現在setされているデータのサイズ、またはセットされていなければ0
      * * 他のmemberのデータの場合、すでに受信したデータのサイズ
-     *   * 受信していない場合は、get()やtryGet()と同様にリクエストを送り、0を返す
+     *   *
+     * 受信していない場合は、get()やtryGet()と同様にリクエストを送り、0を返す
      * * 配列でない数値データ1つの場合、1を返す
      */
     std::size_t size() const;
@@ -250,7 +269,7 @@ class WEBCFACE_DLL Value : protected Field {
     std::optional<double> tryGet() const;
     /*!
      * \brief 値をvectorで返す
-     * 
+     *
      * ver2.10〜 `std::vector<double>` から webcface::NumVector 型に変更
      * (NumVectorはvectorのconst参照にキャスト可能)
      *
@@ -291,7 +310,8 @@ class WEBCFACE_DLL Value : protected Field {
      * \brief syncの時刻を返す
      * \deprecated 1.7で Member::syncTime() に変更
      */
-    [[deprecated]] std::chrono::system_clock::time_point time() const;
+    [[deprecated]]
+    std::chrono::system_clock::time_point time() const;
 
     /*!
      * \brief 値やリクエスト状態をクリア

--- a/client/include/webcface/value.h
+++ b/client/include/webcface/value.h
@@ -73,16 +73,11 @@ class WEBCFACE_DLL Value : protected Field {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    Value child(std::string_view field) const {
-        return this->Field::child(field);
-    }
-    /*!
-     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField (wstring)
-     * \since ver2.0
-     */
-    Value child(std::wstring_view field) const {
-        return this->Field::child(field);
+    Value child(String field) const {
+        return this->Field::child(static_cast<SharedString &>(field));
     }
     /*!
      * \since ver1.11
@@ -95,22 +90,20 @@ class WEBCFACE_DLL Value : protected Field {
     /*!
      * child()と同じ
      * \since ver1.11
+     * 
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    Value operator[](std::string_view field) const { return child(field); }
-    /*!
-     * child()と同じ
-     * \since ver2.0
-     */
-    Value operator[](std::wstring_view field) const { return child(field); }
-    /*!
-     * operator[](long, const char *)と解釈されるのを防ぐための定義
-     * \since ver1.11
-     */
-    Value operator[](const char *field) const { return child(field); }
-    /*!
-     * \since ver2.0
-     */
-    Value operator[](const wchar_t *field) const { return child(field); }
+    Value operator[](String field) const { return child(std::move(field)); }
+    // /*!
+    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
+    //  * \since ver1.11
+    //  */
+    // Value operator[](const char *field) const { return child(field); }
+    // /*!
+    //  * \since ver2.0
+    //  */
+    // Value operator[](const wchar_t *field) const { return child(field); }
     /*!
      * \brief 1次元配列型データの要素を参照する
      * \since ver2.8

--- a/client/include/webcface/value.h
+++ b/client/include/webcface/value.h
@@ -74,10 +74,10 @@ class WEBCFACE_DLL Value : protected Field {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      *
      */
-    Value child(String field) const {
+    Value child(StringInitializer field) const {
         return this->Field::child(static_cast<SharedString &>(field));
     }
     /*!
@@ -92,10 +92,10 @@ class WEBCFACE_DLL Value : protected Field {
      * child()と同じ
      * \since ver1.11
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      *
      */
-    Value operator[](String field) const { return child(std::move(field)); }
+    Value operator[](StringInitializer field) const { return child(std::move(field)); }
     /*!
      * operator[](long, const char *)と解釈されるのを防ぐための定義
      * \since ver1.11
@@ -111,7 +111,7 @@ class WEBCFACE_DLL Value : protected Field {
      */
     template <std::size_t N>
     Value operator[](const char (&static_str)[N]) {
-        return child(String(static_str));
+        return child(StringInitializer(static_str));
     }
     /*!
      * operator[](long, const wchar_t *)と解釈されるのを防ぐための定義
@@ -119,7 +119,7 @@ class WEBCFACE_DLL Value : protected Field {
      */
     template <std::size_t N>
     Value operator[](const wchar_t (&static_str)[N]) {
-        return child(String(static_str));
+        return child(StringInitializer(static_str));
     }
     /*!
      * \brief 1次元配列型データの要素を参照する

--- a/client/include/webcface/view.h
+++ b/client/include/webcface/view.h
@@ -79,15 +79,6 @@ class WEBCFACE_DLL View : protected Field {
      * 
      */
     View operator[](String field) const { return child(std::move(field)); }
-    // /*!
-    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
-    //  * \since ver1.11
-    //  */
-    // View operator[](const char *field) const { return child(field); }
-    // /*!
-    //  * \since ver2.0
-    //  */
-    // View operator[](const wchar_t *field) const { return child(field); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/view.h
+++ b/client/include/webcface/view.h
@@ -57,10 +57,10 @@ class WEBCFACE_DLL View : protected Field {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      * 
      */
-    View child(String field) const {
+    View child(StringInitializer field) const {
         return this->Field::child(static_cast<SharedString &>(field));
     }
     /*!
@@ -75,10 +75,10 @@ class WEBCFACE_DLL View : protected Field {
      * child()と同じ
      * \since ver1.11
      * 
-     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * ver2.0〜 wstring対応, ver2.10〜 StringInitializer 型で置き換え
      * 
      */
-    View operator[](String field) const { return child(std::move(field)); }
+    View operator[](StringInitializer field) const { return child(std::move(field)); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/include/webcface/view.h
+++ b/client/include/webcface/view.h
@@ -57,16 +57,11 @@ class WEBCFACE_DLL View : protected Field {
     /*!
      * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField
      *
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    View child(std::string_view field) const {
-        return this->Field::child(field);
-    }
-    /*!
-     * \brief 「(thisの名前).(追加の名前)」を新しい名前とするField (wstring)
-     * \since ver2.0
-     */
-    View child(std::wstring_view field) const {
-        return this->Field::child(field);
+    View child(String field) const {
+        return this->Field::child(static_cast<SharedString &>(field));
     }
     /*!
      * \since ver1.11
@@ -79,22 +74,20 @@ class WEBCFACE_DLL View : protected Field {
     /*!
      * child()と同じ
      * \since ver1.11
+     * 
+     * ver2.0〜 wstring対応, ver2.10〜 String 型で置き換え
+     * 
      */
-    View operator[](std::string_view field) const { return child(field); }
-    /*!
-     * child()と同じ
-     * \since ver2.0
-     */
-    View operator[](std::wstring_view field) const { return child(field); }
-    /*!
-     * operator[](long, const char *)と解釈されるのを防ぐための定義
-     * \since ver1.11
-     */
-    View operator[](const char *field) const { return child(field); }
-    /*!
-     * \since ver2.0
-     */
-    View operator[](const wchar_t *field) const { return child(field); }
+    View operator[](String field) const { return child(std::move(field)); }
+    // /*!
+    //  * operator[](long, const char *)と解釈されるのを防ぐための定義
+    //  * \since ver1.11
+    //  */
+    // View operator[](const char *field) const { return child(field); }
+    // /*!
+    //  * \since ver2.0
+    //  */
+    // View operator[](const wchar_t *field) const { return child(field); }
     /*!
      * child()と同じ
      * \since ver1.11

--- a/client/src/c_wcf/c_wcf_internal.h
+++ b/client/src/c_wcf/c_wcf_internal.h
@@ -143,7 +143,11 @@ auto resultToCVal(const ValAdaptor &result_val) {
         CharType<CharT>::funcValList().at(result);
     result->as_int = result_val_ref;
     result->as_double = result_val_ref;
-    result->as_str = result_val_ref;
+    if constexpr (std::is_same_v<CharT, char>) {
+        result->as_str = result_val_ref.asStringView().c_str();
+    } else {
+        result->as_str = result_val_ref.asWStringView().c_str();
+    }
     return result;
 }
 

--- a/client/src/canvas2d.cc
+++ b/client/src/canvas2d.cc
@@ -43,7 +43,7 @@ void internal::DataSetBuffer<TemporalCanvas2DComponent>::onSync() {
         std::shared_ptr<internal::TemporalCanvas2DComponentData> msg_data =
             this->components_[i].lockTmp(data, target_.field_, &idx_next);
         cb->components.emplace(
-            msg_data->id.u8String(),
+            std::string(msg_data->id.u8StringView()),
             std::static_pointer_cast<message::Canvas2DComponentData>(msg_data));
         cb->data_ids.push_back(msg_data->id);
     }
@@ -80,8 +80,8 @@ std::optional<std::vector<Canvas2DComponent>> Canvas2D::tryGet() const {
         std::vector<Canvas2DComponent> v;
         v.reserve((*vb)->data_ids.size());
         for (const auto &id : (*vb)->data_ids) {
-            v.emplace_back((*vb)->components.at(id.u8String()), this->data_w,
-                           id);
+            v.emplace_back((*vb)->components.find(id.u8StringView())->second,
+                           this->data_w, id);
         }
         return v;
     } else {

--- a/client/src/canvas3d.cc
+++ b/client/src/canvas3d.cc
@@ -39,7 +39,7 @@ void internal::DataSetBuffer<TemporalCanvas3DComponent>::onSync() {
         std::shared_ptr<internal::TemporalCanvas3DComponentData> msg_data =
             components_[i].lockTmp(data, target_.field_, &idx_next);
         components_p->components.emplace(
-            msg_data->id.u8String(),
+            std::string(msg_data->id.u8StringView()),
             std::static_pointer_cast<message::Canvas3DComponentData>(msg_data));
         components_p->data_ids.push_back(msg_data->id);
     }
@@ -76,8 +76,8 @@ std::optional<std::vector<Canvas3DComponent>> Canvas3D::tryGet() const {
         std::vector<Canvas3DComponent> v;
         v.reserve((*vb)->data_ids.size());
         for (const auto &id : (*vb)->data_ids) {
-            v.emplace_back((*vb)->components.at(id.u8String()), this->data_w,
-                           id);
+            v.emplace_back((*vb)->components.find(id.u8StringView())->second,
+                           this->data_w, id);
         }
         return v;
     } else {

--- a/client/src/client_msg_recv.cc
+++ b/client/src/client_msg_recv.cc
@@ -160,7 +160,7 @@ void internal::ClientData::onRecv(
             }
             for (const auto &d : r.data_diff) {
                 auto id = SharedString::fromU8String(d.first);
-                vb_prev->components[id.u8String()] = d.second;
+                vb_prev->components[std::string(id.u8StringView())] = d.second;
             }
             auto cl = findFromMap2(this->view_change_event.shared_lock().get(),
                                    member, field);
@@ -191,7 +191,7 @@ void internal::ClientData::onRecv(
             }
             for (const auto &d : r.data_diff) {
                 auto id = SharedString::fromU8String(d.first);
-                vv_prev->components[id.u8String()] = d.second;
+                vv_prev->components[std::string(id.u8StringView())] = d.second;
             }
             auto cl = findFromMap2(
                 this->canvas3d_change_event.shared_lock().get(), member, field);
@@ -224,7 +224,7 @@ void internal::ClientData::onRecv(
             }
             for (const auto &d : r.data_diff) {
                 auto id = SharedString::fromU8String(d.first);
-                vv_prev->components[id.u8String()] = d.second;
+                vv_prev->components[std::string(id.u8StringView())] = d.second;
             }
             auto cl = findFromMap2(
                 this->canvas2d_change_event.shared_lock().get(), member, field);

--- a/client/src/client_msg_sync.cc
+++ b/client/src/client_msg_sync.cc
@@ -205,11 +205,12 @@ std::string internal::ClientData::packSyncData(std::stringstream &buffer,
             v_diff;
         for (const auto &id : p.second->data_ids) {
             if (v_prev == data.view_prev.end() ||
-                v_prev->second->components.count(id.u8String()) == 0 ||
-                *v_prev->second->components.at(id.u8String()) !=
-                    *p.second->components.at(id.u8String())) {
-                v_diff.emplace(id.u8String(),
-                               p.second->components.at(id.u8String()));
+                v_prev->second->components.count(id.u8StringView()) == 0 ||
+                *(v_prev->second->components.find(id.u8StringView())->second) !=
+                    *(p.second->components.find(id.u8StringView())->second)) {
+                v_diff.emplace(
+                    std::string(id.u8StringView()),
+                    p.second->components.find(id.u8StringView())->second);
             }
         }
         std::optional<std::vector<SharedString>> v_ids_changed = std::nullopt;
@@ -229,11 +230,12 @@ std::string internal::ClientData::packSyncData(std::stringstream &buffer,
             v_diff;
         for (const auto &id : p.second->data_ids) {
             if (v_prev == data.canvas3d_prev.end() ||
-                v_prev->second->components.count(id.u8String()) == 0 ||
-                *v_prev->second->components.at(id.u8String()) !=
-                    *p.second->components.at(id.u8String())) {
-                v_diff.emplace(id.u8String(),
-                               p.second->components.at(id.u8String()));
+                v_prev->second->components.count(id.u8StringView()) == 0 ||
+                *(v_prev->second->components.find(id.u8StringView())->second) !=
+                    *(p.second->components.find(id.u8StringView())->second)) {
+                v_diff.emplace(
+                    std::string(id.u8StringView()),
+                    p.second->components.find(id.u8StringView())->second);
             }
         }
         std::optional<std::vector<SharedString>> v_ids_changed = std::nullopt;
@@ -253,11 +255,12 @@ std::string internal::ClientData::packSyncData(std::stringstream &buffer,
             v_diff;
         for (const auto &id : p.second->data_ids) {
             if (v_prev == data.canvas2d_prev.end() ||
-                v_prev->second->components.count(id.u8String()) == 0 ||
-                *v_prev->second->components.at(id.u8String()) !=
-                    *p.second->components.at(id.u8String())) {
-                v_diff.emplace(id.u8String(),
-                               p.second->components.at(id.u8String()));
+                v_prev->second->components.count(id.u8StringView()) == 0 ||
+                *(v_prev->second->components.find(id.u8StringView())->second) !=
+                    *(p.second->components.find(id.u8StringView())->second)) {
+                v_diff.emplace(
+                    std::string(id.u8StringView()),
+                    p.second->components.find(id.u8StringView())->second);
             }
         }
         std::optional<std::vector<SharedString>> v_ids_changed;
@@ -324,8 +327,8 @@ getLoggerBuf(const std::shared_ptr<internal::ClientData> &data,
 std::streambuf *Client::loggerStreamBuf() const {
     return getLoggerBuf(data, message::Log::defaultLogName());
 }
-std::streambuf *Client::loggerStreamBuf(std::string_view name) const {
-    return getLoggerBuf(data, SharedString::encode(name));
+std::streambuf *Client::loggerStreamBuf(const String &name) const {
+    return getLoggerBuf(data, name);
 }
 // \private
 static std::wstreambuf *
@@ -341,8 +344,8 @@ getLoggerBufW(const std::shared_ptr<internal::ClientData> &data,
 std::wstreambuf *Client::loggerWStreamBuf() const {
     return getLoggerBufW(data, message::Log::defaultLogName());
 }
-std::wstreambuf *Client::loggerWStreamBuf(std::wstring_view name) const {
-    return getLoggerBufW(data, SharedString::encode(name));
+std::wstreambuf *Client::loggerWStreamBuf(const String &name) const {
+    return getLoggerBufW(data, name);
 }
 // \private
 static std::ostream &
@@ -358,8 +361,8 @@ getLoggerOS(const std::shared_ptr<internal::ClientData> &data,
 std::ostream &Client::loggerOStream() const {
     return getLoggerOS(data, message::Log::defaultLogName());
 }
-std::ostream &Client::loggerOStream(std::string_view name) const {
-    return getLoggerOS(data, SharedString::encode(name));
+std::ostream &Client::loggerOStream(const String &name) const {
+    return getLoggerOS(data, name);
 }
 // \private
 static std::wostream &
@@ -375,8 +378,8 @@ getLoggerWOS(const std::shared_ptr<internal::ClientData> &data,
 std::wostream &Client::loggerWOStream() const {
     return getLoggerWOS(data, message::Log::defaultLogName());
 }
-std::wostream &Client::loggerWOStream(std::wstring_view name) const {
-    return getLoggerWOS(data, SharedString::encode(name));
+std::wostream &Client::loggerWOStream(const String &name) const {
+    return getLoggerWOS(data, name);
 }
 const std::string &Client::serverVersion() const {
     return data->svr_version.shared_lock().get();

--- a/client/src/client_msg_sync.cc
+++ b/client/src/client_msg_sync.cc
@@ -201,7 +201,8 @@ std::string internal::ClientData::packSyncData(std::stringstream &buffer,
     }
     for (const auto &p : data.view_data) {
         auto v_prev = data.view_prev.find(p.first);
-        std::map<std::string, std::shared_ptr<message::ViewComponentData>>
+        std::map<std::string, std::shared_ptr<message::ViewComponentData>,
+                 std::less<>>
             v_diff;
         for (const auto &id : p.second->data_ids) {
             if (v_prev == data.view_prev.end() ||
@@ -226,7 +227,8 @@ std::string internal::ClientData::packSyncData(std::stringstream &buffer,
     }
     for (const auto &p : data.canvas3d_data) {
         auto v_prev = data.canvas3d_prev.find(p.first);
-        std::map<std::string, std::shared_ptr<message::Canvas3DComponentData>>
+        std::map<std::string, std::shared_ptr<message::Canvas3DComponentData>,
+                 std::less<>>
             v_diff;
         for (const auto &id : p.second->data_ids) {
             if (v_prev == data.canvas3d_prev.end() ||
@@ -251,7 +253,8 @@ std::string internal::ClientData::packSyncData(std::stringstream &buffer,
     }
     for (const auto &p : data.canvas2d_data) {
         auto v_prev = data.canvas2d_prev.find(p.first);
-        std::map<std::string, std::shared_ptr<message::Canvas2DComponentData>>
+        std::map<std::string, std::shared_ptr<message::Canvas2DComponentData>,
+                 std::less<>>
             v_diff;
         for (const auto &id : p.second->data_ids) {
             if (v_prev == data.canvas2d_prev.end() ||

--- a/client/src/client_msg_sync.cc
+++ b/client/src/client_msg_sync.cc
@@ -330,7 +330,7 @@ getLoggerBuf(const std::shared_ptr<internal::ClientData> &data,
 std::streambuf *Client::loggerStreamBuf() const {
     return getLoggerBuf(data, message::Log::defaultLogName());
 }
-std::streambuf *Client::loggerStreamBuf(const String &name) const {
+std::streambuf *Client::loggerStreamBuf(const StringInitializer &name) const {
     return getLoggerBuf(data, name);
 }
 // \private
@@ -347,7 +347,7 @@ getLoggerBufW(const std::shared_ptr<internal::ClientData> &data,
 std::wstreambuf *Client::loggerWStreamBuf() const {
     return getLoggerBufW(data, message::Log::defaultLogName());
 }
-std::wstreambuf *Client::loggerWStreamBuf(const String &name) const {
+std::wstreambuf *Client::loggerWStreamBuf(const StringInitializer &name) const {
     return getLoggerBufW(data, name);
 }
 // \private
@@ -364,7 +364,7 @@ getLoggerOS(const std::shared_ptr<internal::ClientData> &data,
 std::ostream &Client::loggerOStream() const {
     return getLoggerOS(data, message::Log::defaultLogName());
 }
-std::ostream &Client::loggerOStream(const String &name) const {
+std::ostream &Client::loggerOStream(const StringInitializer &name) const {
     return getLoggerOS(data, name);
 }
 // \private
@@ -381,7 +381,7 @@ getLoggerWOS(const std::shared_ptr<internal::ClientData> &data,
 std::wostream &Client::loggerWOStream() const {
     return getLoggerWOS(data, message::Log::defaultLogName());
 }
-std::wostream &Client::loggerWOStream(const String &name) const {
+std::wostream &Client::loggerWOStream(const StringInitializer &name) const {
     return getLoggerWOS(data, name);
 }
 const std::string &Client::serverVersion() const {

--- a/client/src/client_threading.cc
+++ b/client/src/client_threading.cc
@@ -35,7 +35,7 @@ internal::ClientData::ClientData(const SharedString &name,
     static auto stderr_sink =
         std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
     logger_internal = std::make_shared<spdlog::logger>(
-        "webcface_internal(" + name.decode() + ")", stderr_sink);
+        strJoin<char>("webcface_internal(", name.decode(), ")"), stderr_sink);
     if (std::getenv("WEBCFACE_TRACE") != nullptr) {
         logger_internal->set_level(spdlog::level::trace);
     } else if (std::getenv("WEBCFACE_VERBOSE") != nullptr) {

--- a/client/src/client_ws.cc
+++ b/client/src/client_ws.cc
@@ -68,10 +68,11 @@ void init(const std::shared_ptr<internal::ClientData> &data) {
         }
         switch (attempt) {
         case 2:
-            data->current_curl_path =
-                data->host.decode() + ':' + std::to_string(data->port);
-            curl_easy_setopt(handle, CURLOPT_URL,
-                             ("ws://" + data->host.decode() + "/").c_str());
+            data->current_curl_path = strJoin<char>(data->host.decode(), ":",
+                                                    std::to_string(data->port));
+            curl_easy_setopt(
+                handle, CURLOPT_URL,
+                strJoin<char>("ws://", data->host.decode(), "/").c_str());
             break;
         case 1:
             if (data->host.decode() != "127.0.0.1") {
@@ -82,8 +83,9 @@ void init(const std::shared_ptr<internal::ClientData> &data) {
                     internal::unixSocketPathWSLInterop(data->port).string();
                 curl_easy_setopt(handle, CURLOPT_UNIX_SOCKET_PATH,
                                  data->current_curl_path.c_str());
-                curl_easy_setopt(handle, CURLOPT_URL,
-                                 ("ws://" + data->host.decode() + "/").c_str());
+                curl_easy_setopt(
+                    handle, CURLOPT_URL,
+                    strJoin<char>("ws://", data->host.decode(), "/").c_str());
                 break;
             }
             if (internal::detectWSL2()) {
@@ -106,8 +108,9 @@ void init(const std::shared_ptr<internal::ClientData> &data) {
                 internal::unixSocketPath(data->port).string();
             curl_easy_setopt(handle, CURLOPT_UNIX_SOCKET_PATH,
                              data->current_curl_path.c_str());
-            curl_easy_setopt(handle, CURLOPT_URL,
-                             ("ws://" + data->host.decode() + "/").c_str());
+            curl_easy_setopt(
+                handle, CURLOPT_URL,
+                strJoin<char>("ws://", data->host.decode(), "/").c_str());
             break;
         }
         data->logger_internal->debug("trying {}...", data->current_curl_path);

--- a/client/src/component_canvas2d.cc
+++ b/client/src/component_canvas2d.cc
@@ -81,7 +81,7 @@ bool Canvas2DComponent::operator==(const Canvas2DComponent &other) const {
            *msg_data == *other.msg_data;
 }
 
-TemporalCanvas2DComponent &TemporalCanvas2DComponent::id(String id) {
+TemporalCanvas2DComponent &TemporalCanvas2DComponent::id(StringInitializer id) {
     msg_data->id = std::move(id);
     return *this;
 }
@@ -135,7 +135,7 @@ WStringView Canvas2DComponent::textW() const {
     checkData();
     return msg_data->text.decodeW();
 }
-TemporalCanvas2DComponent &TemporalCanvas2DComponent::text(String text) & {
+TemporalCanvas2DComponent &TemporalCanvas2DComponent::text(StringInitializer text) & {
     msg_data->text = std::move(text);
     return *this;
 }

--- a/client/src/component_canvas2d.cc
+++ b/client/src/component_canvas2d.cc
@@ -8,8 +8,8 @@ WEBCFACE_NS_BEGIN
 static inline std::string internalCanvas2DId(int type, int idx) {
     return ".." + std::to_string(type) + "." + std::to_string(idx);
 }
-StringView Canvas2DComponent::id() const { return id_.decode(); }
-WStringView Canvas2DComponent::idW() const { return id_.decodeW(); }
+StringView Canvas2DComponent::id() const { return id_.decodeShare(); }
+WStringView Canvas2DComponent::idW() const { return id_.decodeShareW(); }
 
 Canvas2DComponent::Canvas2DComponent() = default;
 Canvas2DComponent::Canvas2DComponent(
@@ -129,11 +129,11 @@ TemporalCanvas2DComponent &TemporalCanvas2DComponent::strokeWidth(double s) & {
 }
 StringView Canvas2DComponent::text() const {
     checkData();
-    return msg_data->text.decode();
+    return msg_data->text.decodeShare();
 }
 WStringView Canvas2DComponent::textW() const {
     checkData();
-    return msg_data->text.decodeW();
+    return msg_data->text.decodeShareW();
 }
 TemporalCanvas2DComponent &TemporalCanvas2DComponent::text(StringInitializer text) & {
     msg_data->text = std::move(text);

--- a/client/src/component_canvas2d.cc
+++ b/client/src/component_canvas2d.cc
@@ -8,8 +8,8 @@ WEBCFACE_NS_BEGIN
 static inline std::string internalCanvas2DId(int type, int idx) {
     return ".." + std::to_string(type) + "." + std::to_string(idx);
 }
-std::string Canvas2DComponent::id() const { return id_.decode(); }
-std::wstring Canvas2DComponent::idW() const { return id_.decodeW(); }
+StringView Canvas2DComponent::id() const { return id_.decode(); }
+WStringView Canvas2DComponent::idW() const { return id_.decodeW(); }
 
 Canvas2DComponent::Canvas2DComponent() = default;
 Canvas2DComponent::Canvas2DComponent(
@@ -66,9 +66,9 @@ TemporalCanvas2DComponent::lockTmp(
     }
     if (msg_data->on_click_func_tmp && *msg_data->on_click_func_tmp) {
         Func on_click{Field{data, data->self_member_name},
-                      SharedString::fromU8String("..c2" + view_name.u8String() +
-                                                 "/" +
-                                                 msg_data->id.u8String())};
+                      SharedString::fromU8String(
+                          strJoin<char>("..c2", view_name.u8StringView(), "/",
+                                        msg_data->id.u8StringView()))};
         on_click.set(std::move(*msg_data->on_click_func_tmp));
         this->onClick(on_click);
     }
@@ -81,12 +81,8 @@ bool Canvas2DComponent::operator==(const Canvas2DComponent &other) const {
            *msg_data == *other.msg_data;
 }
 
-TemporalCanvas2DComponent &TemporalCanvas2DComponent::id(std::string_view id) {
-    msg_data->id = SharedString::encode(id);
-    return *this;
-}
-TemporalCanvas2DComponent &TemporalCanvas2DComponent::id(std::wstring_view id) {
-    msg_data->id = SharedString::encode(id);
+TemporalCanvas2DComponent &TemporalCanvas2DComponent::id(String id) {
+    msg_data->id = std::move(id);
     return *this;
 }
 
@@ -131,22 +127,16 @@ TemporalCanvas2DComponent &TemporalCanvas2DComponent::strokeWidth(double s) & {
     msg_data->stroke_width = s;
     return *this;
 }
-std::string Canvas2DComponent::text() const {
+StringView Canvas2DComponent::text() const {
     checkData();
     return msg_data->text.decode();
 }
-TemporalCanvas2DComponent &
-TemporalCanvas2DComponent::text(std::string_view text) & {
-    msg_data->text = SharedString::encode(text);
-    return *this;
-}
-std::wstring Canvas2DComponent::textW() const {
+WStringView Canvas2DComponent::textW() const {
     checkData();
     return msg_data->text.decodeW();
 }
-TemporalCanvas2DComponent &
-TemporalCanvas2DComponent::text(std::wstring_view text) & {
-    msg_data->text = SharedString::encode(text);
+TemporalCanvas2DComponent &TemporalCanvas2DComponent::text(String text) & {
+    msg_data->text = std::move(text);
     return *this;
 }
 std::optional<Geometry> Canvas2DComponent::geometry() const {

--- a/client/src/component_canvas3d.cc
+++ b/client/src/component_canvas3d.cc
@@ -71,7 +71,7 @@ bool Canvas3DComponent::operator==(const Canvas3DComponent &other) const {
            *msg_data == *other.msg_data;
 }
 
-TemporalCanvas3DComponent &TemporalCanvas3DComponent::id(String id) {
+TemporalCanvas3DComponent &TemporalCanvas3DComponent::id(StringInitializer id) {
     msg_data->id = std::move(id);
     return *this;
 }

--- a/client/src/component_canvas3d.cc
+++ b/client/src/component_canvas3d.cc
@@ -8,8 +8,8 @@ WEBCFACE_NS_BEGIN
 static inline std::string internalCanvas3DId(int type, int idx) {
     return ".." + std::to_string(type) + "." + std::to_string(idx);
 }
-StringView Canvas3DComponent::id() const { return id_.decode(); }
-WStringView Canvas3DComponent::idW() const { return id_.decodeW(); }
+StringView Canvas3DComponent::id() const { return id_.decodeShare(); }
+WStringView Canvas3DComponent::idW() const { return id_.decodeShareW(); }
 
 Canvas3DComponent::Canvas3DComponent() = default;
 

--- a/client/src/component_canvas3d.cc
+++ b/client/src/component_canvas3d.cc
@@ -8,8 +8,8 @@ WEBCFACE_NS_BEGIN
 static inline std::string internalCanvas3DId(int type, int idx) {
     return ".." + std::to_string(type) + "." + std::to_string(idx);
 }
-std::string Canvas3DComponent::id() const { return id_.decode(); }
-std::wstring Canvas3DComponent::idW() const { return id_.decodeW(); }
+StringView Canvas3DComponent::id() const { return id_.decode(); }
+WStringView Canvas3DComponent::idW() const { return id_.decodeW(); }
 
 Canvas3DComponent::Canvas3DComponent() = default;
 
@@ -71,12 +71,8 @@ bool Canvas3DComponent::operator==(const Canvas3DComponent &other) const {
            *msg_data == *other.msg_data;
 }
 
-TemporalCanvas3DComponent &TemporalCanvas3DComponent::id(std::string_view id) {
-    msg_data->id = SharedString::encode(id);
-    return *this;
-}
-TemporalCanvas3DComponent &TemporalCanvas3DComponent::id(std::wstring_view id) {
-    msg_data->id = SharedString::encode(id);
+TemporalCanvas3DComponent &TemporalCanvas3DComponent::id(String id) {
+    msg_data->id = std::move(id);
     return *this;
 }
 
@@ -140,7 +136,7 @@ TemporalCanvas3DComponent::robotModel(const RobotModel &field) & {
 }
 
 TemporalCanvas3DComponent &TemporalCanvas3DComponent::angles(
-    const std::unordered_map<std::string, double> &angles) & {
+    const std::map<std::string, double, std::less<>> &angles) & {
     if (msg_data->field_member && msg_data->field_field &&
         msg_data->type ==
             static_cast<int>(Canvas3DComponentType::robot_model)) {
@@ -150,8 +146,9 @@ TemporalCanvas3DComponent &TemporalCanvas3DComponent::angles(
         auto model = rm.get();
         for (std::size_t ji = 0; ji < model.size(); ji++) {
             auto j = model[ji].joint();
-            if (angles.count(j.name())) {
-                msg_data->anglesAt(ji) = angles.at(j.name());
+            auto it = angles.find(j.name());
+            if (it != angles.end()) {
+                msg_data->anglesAt(ji) = it->second;
             }
         }
         return *this;
@@ -161,7 +158,7 @@ TemporalCanvas3DComponent &TemporalCanvas3DComponent::angles(
     }
 }
 TemporalCanvas3DComponent &TemporalCanvas3DComponent::angles(
-    const std::unordered_map<std::wstring, double> &angles) & {
+    const std::map<std::wstring, double, std::less<>> &angles) & {
     if (msg_data->field_member && msg_data->field_field &&
         msg_data->type ==
             static_cast<int>(Canvas3DComponentType::robot_model)) {
@@ -171,8 +168,9 @@ TemporalCanvas3DComponent &TemporalCanvas3DComponent::angles(
         auto model = rm.get();
         for (std::size_t ji = 0; ji < model.size(); ji++) {
             auto j = model[ji].joint();
-            if (angles.count(j.nameW())) {
-                msg_data->anglesAt(ji) = angles.at(j.nameW());
+            auto it = angles.find(j.nameW());
+            if (it != angles.end()) {
+                msg_data->anglesAt(ji) = it->second;
             }
         }
         return *this;
@@ -182,8 +180,7 @@ TemporalCanvas3DComponent &TemporalCanvas3DComponent::angles(
     }
 }
 TemporalCanvas3DComponent &
-TemporalCanvas3DComponent::angle(const std::string &joint_name,
-                                 double angle) & {
+TemporalCanvas3DComponent::angle(std::string_view joint_name, double angle) & {
     if (msg_data->field_member && msg_data->field_field &&
         msg_data->type ==
             static_cast<int>(Canvas3DComponentType::robot_model)) {
@@ -203,8 +200,7 @@ TemporalCanvas3DComponent::angle(const std::string &joint_name,
     }
 }
 TemporalCanvas3DComponent &
-TemporalCanvas3DComponent::angle(const std::wstring &joint_name,
-                                 double angle) & {
+TemporalCanvas3DComponent::angle(std::wstring_view joint_name, double angle) & {
     if (msg_data->field_member && msg_data->field_field &&
         msg_data->type ==
             static_cast<int>(Canvas3DComponentType::robot_model)) {

--- a/client/src/component_view.cc
+++ b/client/src/component_view.cc
@@ -253,7 +253,7 @@ ViewComponentType ViewComponent::type() const {
     checkData();
     return static_cast<ViewComponentType>(msg_data->type);
 }
-TemporalViewComponent &TemporalViewComponent::id(String id) {
+TemporalViewComponent &TemporalViewComponent::id(StringInitializer id) {
     msg_data->id = std::move(id);
     return *this;
 }
@@ -265,7 +265,7 @@ WStringView ViewComponent::textW() const {
     checkData();
     return msg_data->text.decodeW();
 }
-TemporalViewComponent &TemporalViewComponent::text(String text) & {
+TemporalViewComponent &TemporalViewComponent::text(StringInitializer text) & {
     msg_data->text = std::move(text);
     return *this;
 }

--- a/client/src/component_view.cc
+++ b/client/src/component_view.cc
@@ -54,8 +54,8 @@ ViewColor colorFromRGB(double r, double g, double b) {
 static inline std::string internalViewId(int type, int idx) {
     return ".." + std::to_string(type) + "." + std::to_string(idx);
 }
-StringView ViewComponent::id() const { return id_.decode(); }
-WStringView ViewComponent::idW() const { return id_.decodeW(); }
+StringView ViewComponent::id() const { return id_.decodeShare(); }
+WStringView ViewComponent::idW() const { return id_.decodeShareW(); }
 
 ViewComponent::ViewComponent() = default;
 ViewComponent::ViewComponent(const ViewComponent &other)
@@ -166,17 +166,17 @@ CComponent ViewComponent::cDataT() const {
     CComponent vcc;
     vcc.type = static_cast<wcfViewComponentType>(msg_data->type);
     if constexpr (v_index == 0) {
-        vcc.text = msg_data->text.decode().c_str();
+        vcc.text = msg_data->text.decode().data();
     } else {
-        vcc.text = msg_data->text.decodeW().c_str();
+        vcc.text = msg_data->text.decodeW().data();
     }
     if (msg_data->on_click_member && msg_data->on_click_field) {
         if constexpr (v_index == 0) {
-            vcc.on_click_member = msg_data->on_click_member->decode().c_str();
-            vcc.on_click_field = msg_data->on_click_field->decode().c_str();
+            vcc.on_click_member = msg_data->on_click_member->decode().data();
+            vcc.on_click_field = msg_data->on_click_field->decode().data();
         } else {
-            vcc.on_click_member = msg_data->on_click_member->decodeW().c_str();
-            vcc.on_click_field = msg_data->on_click_field->decodeW().c_str();
+            vcc.on_click_member = msg_data->on_click_member->decodeW().data();
+            vcc.on_click_field = msg_data->on_click_field->decodeW().data();
         }
     } else {
         vcc.on_click_member = nullptr;
@@ -184,11 +184,11 @@ CComponent ViewComponent::cDataT() const {
     }
     if (msg_data->text_ref_member && msg_data->text_ref_field) {
         if constexpr (v_index == 0) {
-            vcc.text_ref_member = msg_data->text_ref_member->decode().c_str();
-            vcc.text_ref_field = msg_data->text_ref_field->decode().c_str();
+            vcc.text_ref_member = msg_data->text_ref_member->decode().data();
+            vcc.text_ref_field = msg_data->text_ref_field->decode().data();
         } else {
-            vcc.text_ref_member = msg_data->text_ref_member->decodeW().c_str();
-            vcc.text_ref_field = msg_data->text_ref_field->decodeW().c_str();
+            vcc.text_ref_member = msg_data->text_ref_member->decodeW().data();
+            vcc.text_ref_field = msg_data->text_ref_field->decodeW().data();
         }
     } else {
         vcc.text_ref_member = nullptr;
@@ -259,11 +259,11 @@ TemporalViewComponent &TemporalViewComponent::id(StringInitializer id) {
 }
 StringView ViewComponent::text() const {
     checkData();
-    return msg_data->text.decode();
+    return msg_data->text.decodeShare();
 }
 WStringView ViewComponent::textW() const {
     checkData();
-    return msg_data->text.decodeW();
+    return msg_data->text.decodeShareW();
 }
 TemporalViewComponent &TemporalViewComponent::text(StringInitializer text) & {
     msg_data->text = std::move(text);

--- a/client/src/data_store2.cc
+++ b/client/src/data_store2.cc
@@ -20,11 +20,9 @@ namespace internal {
  */
 template <typename T>
 static bool shouldSend(const T &prev, const T &current) {
-    if constexpr (std::is_same_v<T, MutableNumVector>) {
-        return prev != current;
-    } else if constexpr (std::is_same_v<T, std::shared_ptr<TextData>>) {
-        return *prev != *current;
-    } else if constexpr (std::is_same_v<T, std::string>) {
+    if constexpr (std::is_same_v<T, MutableNumVector> ||
+                  std::is_same_v<T, ValAdaptor> ||
+                  std::is_same_v<T, std::string>) {
         return prev != current;
     } else if constexpr (std::is_same_v<T, std::shared_ptr<FuncData>>) {
         // Funcは内容が変更されても2回目以降送信しない
@@ -268,7 +266,7 @@ StrMap2<unsigned int> SyncDataStore2<T, ReqT>::transferReq() {
 
 template class SyncDataStore2<std::string, int>; // test用
 template class SyncDataStore2<MutableNumVector, int>;
-template class SyncDataStore2<std::shared_ptr<TextData>, int>;
+template class SyncDataStore2<ValAdaptor, int>;
 template class SyncDataStore2<std::shared_ptr<FuncData>, int>;
 template class SyncDataStore2<std::shared_ptr<message::ViewData>, int>;
 template class SyncDataStore2<std::shared_ptr<RobotModelData>, int>;

--- a/client/src/data_store2.cc
+++ b/client/src/data_store2.cc
@@ -152,8 +152,8 @@ std::optional<T> SyncDataStore2<T, ReqT>::getRecv(const SharedString &from,
     std::lock_guard lock(mtx);
     if (from == self_member_name) {
         // emplace_backしているので後ろが最新
-        for(int i = static_cast<int>(data_send.size()) - 1; i >= 0; i--){
-            if(data_send[i].first == name){
+        for (int i = static_cast<int>(data_send.size()) - 1; i >= 0; i--) {
+            if (data_send[i].first == name) {
                 return data_send[i].second;
             }
         }
@@ -207,15 +207,17 @@ SyncDataStore2<T, ReqT>::getReq(unsigned int req_id,
         for (const auto &r2 : r.second) {
             if (r2.second == req_id) {
                 if (!sub_field.empty() &&
-                    sub_field.u8String()[0] != field_separator) {
-                    return std::make_pair(r.first, SharedString::fromU8String(
-                                                       r2.first.u8String() +
-                                                       field_separator +
-                                                       sub_field.u8String()));
+                    sub_field.u8StringView()[0] != field_separator) {
+                    return std::make_pair(
+                        r.first,
+                        SharedString::fromU8String(
+                            strJoin(r2.first.u8StringView(), field_separator_sv,
+                                    sub_field.u8StringView())));
                 } else {
-                    return std::make_pair(r.first, SharedString::fromU8String(
-                                                       r2.first.u8String() +
-                                                       sub_field.u8String()));
+                    return std::make_pair(
+                        r.first, SharedString::fromU8String(
+                                     strJoin(r2.first.u8StringView(),
+                                             sub_field.u8StringView())));
                 }
             }
         }

--- a/client/src/exception.cc
+++ b/client/src/exception.cc
@@ -4,22 +4,22 @@
 WEBCFACE_NS_BEGIN
 
 FuncNotFound::FuncNotFound(const FieldBase &base)
-    : std::runtime_error("Func(\"" + base.field_.decode() +
-                         "\") does not exist in member(\"" +
-                         base.member_.decode() +
-                         "\"), "
-                         "or client not connected to server") {}
+    : std::runtime_error(strJoin<char>("Func(\"", base.field_.decode(),
+                                       "\") does not exist in member(\"",
+                                       base.member_.decode(),
+                                       "\"), "
+                                       "or client not connected to server")) {}
 
 Rejection::Rejection(const FieldBase &base, const std::string &message)
-    : std::runtime_error("member(\"" + base.member_.decode() + "\").func(\"" +
-                         base.field_.decode() +
-                         "\") rejected: " + message) {}
+    : std::runtime_error(strJoin<char>("member(\"", base.member_.decode(),
+                                       "\").func(\"", base.field_.decode(),
+                                       "\") rejected: ", message)) {}
 
 SanityError::SanityError(const char *message) : std::runtime_error(message) {}
 
 Intrusion::Intrusion(const FieldBase &base)
-    : std::invalid_argument("Cannot modify data of member(\"" +
-                            base.member_.decode() + "\")") {}
+    : std::invalid_argument(strJoin<char>("Cannot modify data of member(\"",
+                                          base.member_.decode(), "\")")) {}
 
 PromiseError::PromiseError(const char *message) : std::runtime_error(message) {}
 

--- a/client/src/field.cc
+++ b/client/src/field.cc
@@ -46,7 +46,7 @@ Field Field::child(const SharedString &field) const {
         return *this;
     } else {
         return Field{*this, SharedString::fromU8String(strJoin(
-                                this->field_.u8StringView(), field_separator,
+                                this->field_.u8StringView(), field_separator_sv,
                                 field.u8StringView()))};
     }
 }
@@ -56,7 +56,7 @@ template <typename S>
 static bool hasChildrenT(const Field *this_, S &store) {
     auto keys = store.getEntry(*this_);
     auto prefix_with_sep =
-        strJoin(this_->field_.u8StringView(), field_separator);
+        strJoin(this_->field_.u8StringView(), field_separator_sv);
     for (const auto &f : keys) {
         // mapはkeyでソートされているので
         if (this_->field_.empty() || f.startsWith(prefix_with_sep)) {
@@ -91,7 +91,7 @@ static void entries(std::vector<V> &ret, const Field *this_, S &store,
     std::size_t prefix_len = 0;
     if (!this_->field_.empty()) {
         prefix_with_sep =
-            strJoin(this_->field_.u8StringView(), field_separator);
+            strJoin(this_->field_.u8StringView(), field_separator_sv);
         prefix_len = prefix_with_sep.size();
     }
     for (auto f : keys) {

--- a/client/src/func_info.cc
+++ b/client/src/func_info.cc
@@ -47,13 +47,13 @@ void Arg::mergeConfig(const Arg &other) {
     }
 }
 
-const std::string &Arg::name() const {
+StringView Arg::name() const {
     return this->msg_data ? this->msg_data->name_.decode()
-                          : SharedString::emptyStr();
+                          : SharedString::emptyStrView();
 }
-const std::wstring &Arg::nameW() const {
+WStringView Arg::nameW() const {
     return this->msg_data ? this->msg_data->name_.decodeW()
-                          : SharedString::emptyStrW();
+                          : SharedString::emptyStrViewW();
 }
 ValType Arg::type() const { return this->type_; }
 Arg &Arg::type(ValType type) {

--- a/client/src/func_info.cc
+++ b/client/src/func_info.cc
@@ -48,12 +48,10 @@ void Arg::mergeConfig(const Arg &other) {
 }
 
 StringView Arg::name() const {
-    return this->msg_data ? this->msg_data->name_.decode()
-                          : SharedString::emptyStrView();
+    return this->msg_data ? this->msg_data->name_.decode() : StringView{};
 }
 WStringView Arg::nameW() const {
-    return this->msg_data ? this->msg_data->name_.decodeW()
-                          : SharedString::emptyStrViewW();
+    return this->msg_data ? this->msg_data->name_.decodeW() : WStringView{};
 }
 ValType Arg::type() const { return this->type_; }
 Arg &Arg::type(ValType type) {

--- a/client/src/func_info.cc
+++ b/client/src/func_info.cc
@@ -48,10 +48,11 @@ void Arg::mergeConfig(const Arg &other) {
 }
 
 StringView Arg::name() const {
-    return this->msg_data ? this->msg_data->name_.decode() : StringView{};
+    return this->msg_data ? this->msg_data->name_.decodeShare() : StringView{};
 }
 WStringView Arg::nameW() const {
-    return this->msg_data ? this->msg_data->name_.decodeW() : WStringView{};
+    return this->msg_data ? this->msg_data->name_.decodeShareW()
+                          : WStringView{};
 }
 ValType Arg::type() const { return this->type_; }
 Arg &Arg::type(ValType type) {

--- a/client/src/func_info.cc
+++ b/client/src/func_info.cc
@@ -112,7 +112,7 @@ std::ostream &operator<<(std::ostream &os, const Arg &arg) {
             if (j > 0) {
                 os << ", ";
             }
-            os << static_cast<std::string>(arg.option()[j]);
+            os << arg.option()[j].asStringView();
         }
         os << "}";
     }

--- a/client/src/func_result.cc
+++ b/client/src/func_result.cc
@@ -99,7 +99,7 @@ void CallHandle::reject(const ValAdaptor &message) const {
             data->is_error = true;
             data->rejection = message;
             data->result_p.set_exception(std::make_exception_ptr(
-                Rejection(data->base, message.asStringRef())));
+                Rejection(data->base, std::string(message.asStringView()))));
             data->callFinishEvent();
             data->cond.notify_all();
         } else {
@@ -115,8 +115,9 @@ bool CallHandle::assertArgsNum(std::size_t expected) const {
         if (args().size() == expected) {
             return true;
         } else {
-            reject(name() + "() requires " + std::to_string(expected) +
-                   " arguments, but received " + std::to_string(args().size()));
+            reject(strJoin(name(), "() requires ", std::to_string(expected),
+                           " arguments, but received ",
+                           std::to_string(args().size())));
             return false;
         }
     } else {
@@ -238,18 +239,18 @@ ValAdaptor Promise::response() const {
         throw invalidPromise();
     }
 }
-const std::string &Promise::rejection() const {
+StringView Promise::rejection() const {
     if (data) {
         std::lock_guard lock(data->m);
-        return data->rejection.asStringRef();
+        return data->rejection.asStringView();
     } else {
         throw invalidPromise();
     }
 }
-const std::wstring &Promise::rejectionW() const {
+WStringView Promise::rejectionW() const {
     if (data) {
         std::lock_guard lock(data->m);
-        return data->rejection.asWStringRef();
+        return data->rejection.asWStringView();
     } else {
         throw invalidPromise();
     }
@@ -296,7 +297,11 @@ std::vector<CVal> &internal::PromiseData::initCArgs() {
             CVal cv;
             cv.as_int = a;
             cv.as_double = a;
-            cv.as_str = a;
+            if constexpr (v_index == 1) {
+                cv.as_str = a.asStringView().c_str();
+            } else {
+                cv.as_str = a.asWStringView().c_str();
+            }
             c_args.push_back(cv);
         }
         this->c_args_.emplace<v_index>(std::move(c_args));

--- a/client/src/robot_link.cc
+++ b/client/src/robot_link.cc
@@ -87,18 +87,18 @@ void internal::RobotLinkData::lockJoints(
 
 StringView RobotJoint::name() const {
     if (msg_data) {
-        return msg_data->joint_name.decode();
+        return msg_data->joint_name.decodeShare();
     } else if (temp_data) {
-        return temp_data->name.decode();
+        return temp_data->name.decodeShare();
     } else {
         return StringView{};
     }
 }
 WStringView RobotJoint::nameW() const {
     if (msg_data) {
-        return msg_data->joint_name.decodeW();
+        return msg_data->joint_name.decodeShareW();
     } else if (temp_data) {
-        return temp_data->name.decodeW();
+        return temp_data->name.decodeShareW();
     } else {
         return WStringView{};
     }
@@ -141,14 +141,14 @@ double RobotJoint::angle() const {
 
 StringView RobotLink::name() const {
     if (msg_data) {
-        return msg_data->name.decode();
+        return msg_data->name.decodeShare();
     } else {
         return StringView{};
     }
 }
 WStringView RobotLink::nameW() const {
     if (msg_data) {
-        return msg_data->name.decodeW();
+        return msg_data->name.decodeShareW();
     } else {
         return WStringView{};
     }

--- a/client/src/robot_link.cc
+++ b/client/src/robot_link.cc
@@ -85,22 +85,22 @@ void internal::RobotLinkData::lockJoints(
     }
 }
 
-const std::string &RobotJoint::name() const {
+StringView RobotJoint::name() const {
     if (msg_data) {
         return msg_data->joint_name.decode();
     } else if (temp_data) {
         return temp_data->name.decode();
     } else {
-        return SharedString::emptyStr();
+        return SharedString::emptyStrView();
     }
 }
-const std::wstring &RobotJoint::nameW() const {
+WStringView RobotJoint::nameW() const {
     if (msg_data) {
         return msg_data->joint_name.decodeW();
     } else if (temp_data) {
         return temp_data->name.decodeW();
     } else {
-        return SharedString::emptyStrW();
+        return SharedString::emptyStrViewW();
     }
 }
 std::optional<RobotLink> RobotJoint::parent() const {
@@ -139,18 +139,18 @@ double RobotJoint::angle() const {
     }
 }
 
-const std::string &RobotLink::name() const {
+StringView RobotLink::name() const {
     if (msg_data) {
         return msg_data->name.decode();
     } else {
-        return SharedString::emptyStr();
+        return SharedString::emptyStrView();
     }
 }
-const std::wstring &RobotLink::nameW() const {
+WStringView RobotLink::nameW() const {
     if (msg_data) {
         return msg_data->name.decodeW();
     } else {
-        return SharedString::emptyStrW();
+        return SharedString::emptyStrViewW();
     }
 }
 RobotJoint RobotLink::joint() const { return RobotJoint(msg_data); }

--- a/client/src/robot_link.cc
+++ b/client/src/robot_link.cc
@@ -91,7 +91,7 @@ StringView RobotJoint::name() const {
     } else if (temp_data) {
         return temp_data->name.decode();
     } else {
-        return SharedString::emptyStrView();
+        return StringView{};
     }
 }
 WStringView RobotJoint::nameW() const {
@@ -100,7 +100,7 @@ WStringView RobotJoint::nameW() const {
     } else if (temp_data) {
         return temp_data->name.decodeW();
     } else {
-        return SharedString::emptyStrViewW();
+        return WStringView{};
     }
 }
 std::optional<RobotLink> RobotJoint::parent() const {
@@ -143,14 +143,14 @@ StringView RobotLink::name() const {
     if (msg_data) {
         return msg_data->name.decode();
     } else {
-        return SharedString::emptyStrView();
+        return StringView{};
     }
 }
 WStringView RobotLink::nameW() const {
     if (msg_data) {
         return msg_data->name.decodeW();
     } else {
-        return SharedString::emptyStrViewW();
+        return WStringView{};
     }
 }
 RobotJoint RobotLink::joint() const { return RobotJoint(msg_data); }

--- a/client/src/text.cc
+++ b/client/src/text.cc
@@ -99,7 +99,7 @@ StringView Text::get() const {
     if (v) {
         return v->asStringView();
     } else {
-        return SharedString::emptyStrView();
+        return StringView{};
     }
 }
 std::optional<WStringView> Text::tryGetW() const {
@@ -117,7 +117,7 @@ WStringView Text::getW() const {
     if (v) {
         return v->asWStringView();
     } else {
-        return SharedString::emptyStrViewW();
+        return WStringView{};
     }
 }
 

--- a/client/src/text.cc
+++ b/client/src/text.cc
@@ -49,7 +49,7 @@ const Variant &Variant::request() const {
 
 const Variant &Variant::set(const ValAdaptor &v) const {
     auto data = setCheck();
-    data->text_store.setSend(*this, std::make_shared<ValAdaptor>(v));
+    data->text_store.setSend(*this, v);
     auto change_event =
         internal::findFromMap2(data->text_change_event.shared_lock().get(),
                                this->member_, this->field_);
@@ -70,7 +70,7 @@ std::optional<ValAdaptor> Variant::tryGet() const {
     auto v = dataLock()->text_store.getRecv(*this);
     request();
     if (v) {
-        return **v;
+        return *v;
     } else {
         return std::nullopt;
     }
@@ -79,7 +79,7 @@ ValAdaptor Variant::get() const {
     auto v = dataLock()->text_store.getRecv(*this);
     request();
     if (v) {
-        return **v;
+        return *v;
     } else {
         return ValAdaptor::emptyVal();
     }
@@ -88,7 +88,7 @@ std::optional<StringView> Text::tryGet() const {
     auto v = dataLock()->text_store.getRecv(*this);
     request();
     if (v) {
-        return (*v)->asStringView();
+        return v->asStringView();
     } else {
         return std::nullopt;
     }
@@ -97,7 +97,7 @@ StringView Text::get() const {
     auto v = dataLock()->text_store.getRecv(*this);
     request();
     if (v) {
-        return (*v)->asStringView();
+        return v->asStringView();
     } else {
         return SharedString::emptyStrView();
     }
@@ -106,7 +106,7 @@ std::optional<WStringView> Text::tryGetW() const {
     auto v = dataLock()->text_store.getRecv(*this);
     request();
     if (v) {
-        return (*v)->asWStringView();
+        return v->asWStringView();
     } else {
         return std::nullopt;
     }
@@ -115,7 +115,7 @@ WStringView Text::getW() const {
     auto v = dataLock()->text_store.getRecv(*this);
     request();
     if (v) {
-        return (*v)->asWStringView();
+        return v->asWStringView();
     } else {
         return SharedString::emptyStrViewW();
     }

--- a/client/src/text.cc
+++ b/client/src/text.cc
@@ -18,7 +18,7 @@ Variant::Variant(const Field &base) : Field(base) {}
 InputRef::InputRef() : state(std::make_shared<internal::InputRefState>()) {}
 void InputRef::lockTo(const Variant &target) { state->field = target; }
 Variant &InputRef::lockedField() const { return state->field; }
-const ValAdaptor &InputRef::get() const {
+ValAdaptor InputRef::get() const {
     if (lockedField().expired()) {
         return ValAdaptor::emptyVal();
     } else {
@@ -75,7 +75,7 @@ std::optional<ValAdaptor> Variant::tryGet() const {
         return std::nullopt;
     }
 }
-const ValAdaptor &Variant::get() const {
+ValAdaptor Variant::get() const {
     auto v = dataLock()->text_store.getRecv(*this);
     request();
     if (v) {
@@ -84,40 +84,40 @@ const ValAdaptor &Variant::get() const {
         return ValAdaptor::emptyVal();
     }
 }
-std::optional<std::string> Text::tryGet() const {
+std::optional<StringView> Text::tryGet() const {
     auto v = dataLock()->text_store.getRecv(*this);
     request();
     if (v) {
-        return (*v)->asString();
+        return (*v)->asStringView();
     } else {
         return std::nullopt;
     }
 }
-const std::string &Text::get() const {
+StringView Text::get() const {
     auto v = dataLock()->text_store.getRecv(*this);
     request();
     if (v) {
-        return (*v)->asStringRef();
+        return (*v)->asStringView();
     } else {
-        return SharedString::emptyStr();
+        return SharedString::emptyStrView();
     }
 }
-std::optional<std::wstring> Text::tryGetW() const {
+std::optional<WStringView> Text::tryGetW() const {
     auto v = dataLock()->text_store.getRecv(*this);
     request();
     if (v) {
-        return (*v)->asWString();
+        return (*v)->asWStringView();
     } else {
         return std::nullopt;
     }
 }
-const std::wstring &Text::getW() const {
+WStringView Text::getW() const {
     auto v = dataLock()->text_store.getRecv(*this);
     request();
     if (v) {
-        return (*v)->asWStringRef();
+        return (*v)->asWStringView();
     } else {
-        return SharedString::emptyStrW();
+        return SharedString::emptyStrViewW();
     }
 }
 

--- a/common/include/webcface/common/encoding.h
+++ b/common/include/webcface/common/encoding.h
@@ -162,7 +162,7 @@ class WEBCFACE_DLL SharedString {
   public:
     SharedString() : data() {}
     SharedString(std::nullptr_t) : data() {}
-    explicit SharedString(std::shared_ptr<internal::SharedStringData> &&data);
+    explicit SharedString(std::shared_ptr<internal::SharedStringData> data);
 
     static SharedString WEBCFACE_CALL fromU8String(std::string u8s);
     static SharedString WEBCFACE_CALL fromU8StringStatic(std::string_view u8s);

--- a/common/include/webcface/common/encoding.h
+++ b/common/include/webcface/common/encoding.h
@@ -60,7 +60,11 @@ template <typename CharT>
 class TStringView : public std::basic_string_view<CharT> {
     std::shared_ptr<const internal::SharedStringData> s_data;
 
+    static inline CharT empty_buf[1] = {0};
+
   public:
+    TStringView() : std::basic_string_view<CharT>(empty_buf, 0) {}
+
     TStringView(const CharT *data, std::size_t size,
                 std::shared_ptr<const internal::SharedStringData> s_data)
         : std::basic_string_view<CharT>(data, size), s_data(std::move(s_data)) {
@@ -168,13 +172,7 @@ class WEBCFACE_DLL SharedString {
     WStringView decodeW() const;
 
     static const std::string &emptyStr();
-    static inline StringView emptyStrView() {
-        return StringView(emptyStr().c_str(), 0, nullptr);
-    }
     static const std::wstring &emptyStrW();
-    static inline WStringView emptyStrViewW() {
-        return WStringView(emptyStrW().c_str(), 0, nullptr);
-    }
 
     bool empty() const;
     bool startsWith(std::string_view str) const;

--- a/common/include/webcface/common/encoding.h
+++ b/common/include/webcface/common/encoding.h
@@ -150,6 +150,10 @@ using WStringView = TStringView<wchar_t>;
  * * ver2.10〜
  * staticな生文字列ポインタをstring_viewとして保持することを可能にした。
  * その場合string_viewの範囲外だがNULL終端であることが保証される。
+ * * ver2.10〜 u8StringView(), decode(), decodeW()
+ * はただのstring_viewだが、data()がnull終端文字列であることは保証される。
+ * u8StringViewShare(), decodeShare(), decodeShareW()
+ * はshared_ptrのコピーを含みちょっと遅い。
  *
  */
 class WEBCFACE_DLL SharedString {
@@ -167,9 +171,12 @@ class WEBCFACE_DLL SharedString {
     static SharedString WEBCFACE_CALL encode(std::wstring ws);
     static SharedString WEBCFACE_CALL encodeStatic(std::wstring_view ws);
 
-    StringView u8StringView() const;
-    StringView decode() const;
-    WStringView decodeW() const;
+    std::string_view u8StringView() const;
+    StringView u8StringViewShare() const;
+    std::string_view decode() const;
+    StringView decodeShare() const;
+    std::wstring_view decodeW() const;
+    WStringView decodeShareW() const;
 
     static const std::string &emptyStr();
     static const std::wstring &emptyStrW();
@@ -181,9 +188,15 @@ class WEBCFACE_DLL SharedString {
                         std::size_t len = std::string::npos) const;
     std::size_t find(char c, std::size_t pos = 0) const;
 
-    bool operator==(const SharedString &other) const;
-    bool operator<=(const SharedString &other) const;
-    bool operator>=(const SharedString &other) const;
+    bool operator==(const SharedString &other) const {
+        return this->u8StringView() == other.u8StringView();
+    }
+    bool operator<=(const SharedString &other) const {
+        return this->u8StringView() <= other.u8StringView();
+    }
+    bool operator>=(const SharedString &other) const{
+        return this->u8StringView() >= other.u8StringView();
+    }
     bool operator!=(const SharedString &other) const {
         return !(*this == other);
     }

--- a/common/include/webcface/common/encoding.h
+++ b/common/include/webcface/common/encoding.h
@@ -72,6 +72,49 @@ class TStringView : public std::basic_string_view<CharT> {
     const CharT *c_str() const { return this->data(); }
 
     operator const CharT *() const { return this->data(); }
+
+    template <typename T,
+              std::enable_if_t<
+                  std::is_convertible_v<T, std::basic_string_view<CharT>>,
+                  std::nullptr_t> = nullptr>
+    bool operator==(const T &other) const {
+        return *this == std::basic_string_view<CharT>(other);
+    }
+    template <typename T,
+              std::enable_if_t<
+                  std::is_convertible_v<T, std::basic_string_view<CharT>>,
+                  std::nullptr_t> = nullptr>
+    bool operator!=(const T &other) const {
+        return *this != std::basic_string_view<CharT>(other);
+    }
+    template <typename T,
+              std::enable_if_t<
+                  std::is_convertible_v<T, std::basic_string_view<CharT>>,
+                  std::nullptr_t> = nullptr>
+    bool operator<=(const T &other) const {
+        return *this <= std::basic_string_view<CharT>(other);
+    }
+    template <typename T,
+              std::enable_if_t<
+                  std::is_convertible_v<T, std::basic_string_view<CharT>>,
+                  std::nullptr_t> = nullptr>
+    bool operator>=(const T &other) const {
+        return *this >= std::basic_string_view<CharT>(other);
+    }
+    template <typename T,
+              std::enable_if_t<
+                  std::is_convertible_v<T, std::basic_string_view<CharT>>,
+                  std::nullptr_t> = nullptr>
+    bool operator<(const T &other) const {
+        return *this < std::basic_string_view<CharT>(other);
+    }
+    template <typename T,
+              std::enable_if_t<
+                  std::is_convertible_v<T, std::basic_string_view<CharT>>,
+                  std::nullptr_t> = nullptr>
+    bool operator>(const T &other) const {
+        return *this > std::basic_string_view<CharT>(other);
+    }
 };
 
 using StringView = TStringView<char>;

--- a/common/include/webcface/common/encoding.h
+++ b/common/include/webcface/common/encoding.h
@@ -66,6 +66,8 @@ class TStringView : public std::basic_string_view<CharT> {
      *
      */
     const CharT *c_str() const { return this->data(); }
+
+    operator const CharT *() const { return this->data(); }
 };
 
 using StringView = TStringView<char>;

--- a/common/include/webcface/common/encoding.h
+++ b/common/include/webcface/common/encoding.h
@@ -123,7 +123,7 @@ using WStringView = TStringView<wchar_t>;
 /*!
  * \brief u8stringとstringとwstringをshared_ptrで持ち共有する
  * \since ver2.0
- * \sa String
+ * \sa StringInitializer
  *
  * * 初期状態ではdataがnullptr、またはu8stringのみ値を持ちstringとwstringは空
  * * コピーするとdataのポインタ(shared_ptr)のみをコピーし、
@@ -201,13 +201,13 @@ class WEBCFACE_DLL SharedString {
  * * 生文字列リテラルを渡した場合に限り、コピーせずポインタで保持する。
  *
  */
-class String : public SharedString {
+class StringInitializer : public SharedString {
   public:
-    String() : SharedString() {}
+    StringInitializer() : SharedString() {}
     // move
-    String(std::string &&s)
+    StringInitializer(std::string &&s)
         : SharedString(SharedString::encode(std::move(s))) {}
-    String(std::wstring &&s)
+    StringInitializer(std::wstring &&s)
         : SharedString(SharedString::encode(std::move(s))) {}
     // copy
     template <typename T,
@@ -215,7 +215,8 @@ class String : public SharedString {
                   std::conjunction_v<std::negation<std::is_void<T>>,
                                      std::is_constructible<std::string, T>>,
                   nullptr_t> = nullptr>
-    String(const T &s) : SharedString(SharedString::encode(std::string(s))) {}
+    StringInitializer(const T &s)
+        : SharedString(SharedString::encode(std::string(s))) {}
     template <typename T,
               typename std::enable_if_t<
                   std::conjunction_v<
@@ -223,15 +224,16 @@ class String : public SharedString {
                       std::negation<std::is_constructible<std::string, T>>,
                       std::is_constructible<std::wstring, T>>,
                   nullptr_t> = nullptr>
-    String(const T &s) : SharedString(SharedString::encode(std::wstring(s))) {}
+    StringInitializer(const T &s)
+        : SharedString(SharedString::encode(std::wstring(s))) {}
     // c-string ptr
     template <std::size_t N>
-    String(const char (&static_str)[N])
+    StringInitializer(const char (&static_str)[N])
         : SharedString(
               SharedString::encodeStatic(std::string_view(static_str, N - 1))) {
     }
     template <std::size_t N>
-    String(const wchar_t (&static_str)[N])
+    StringInitializer(const wchar_t (&static_str)[N])
         : SharedString(SharedString::encodeStatic(
               std::wstring_view(static_str, N - 1))) {}
 };
@@ -240,7 +242,7 @@ class String : public SharedString {
  * \brief string_viewやconst char*同士を連結しstringを返す
  * \since ver2.10
  *
- * String, SharedString, TerminatedStringView
+ * StringInitializer, SharedString, TStringView
  * などと同じヘッダーにあるが、それらとはなんの関係もない。
  *
  */

--- a/common/include/webcface/common/encoding.h
+++ b/common/include/webcface/common/encoding.h
@@ -62,6 +62,8 @@ WEBCFACE_DLL std::string WEBCFACE_CALL toNarrow(std::wstring_view name_ref);
  * usingUTF8(true)の場合なにもせずそのままコピーする。
  * * utf-8→string: windowsでusingUTF8(false)の場合はANSIに、
  * それ以外の場合なにもせずそのままコピーする。
+ * * ver2.10〜 staticな生文字列ポインタをstring_viewとして保持することを可能にした。
+ * その場合string_viewの範囲外だがNULL終端であることが保証される。
  *
  */
 class WEBCFACE_DLL SharedString {
@@ -72,15 +74,16 @@ class WEBCFACE_DLL SharedString {
     SharedString(std::nullptr_t) : data() {}
     explicit SharedString(std::shared_ptr<internal::SharedStringData> &&data);
 
-    static SharedString WEBCFACE_CALL fromU8String(std::string_view u8s);
-    static SharedString WEBCFACE_CALL encode(std::string_view s);
-    static SharedString WEBCFACE_CALL
-    encode(std::wstring_view ws, std::string_view s = std::string_view());
+    static SharedString WEBCFACE_CALL fromU8String(std::string u8s);
+    static SharedString WEBCFACE_CALL fromU8StringStatic(const char *u8s, std::size_t N);
+    static SharedString WEBCFACE_CALL encode(std::string s);
+    static SharedString WEBCFACE_CALL encodeStatic(const char *s, std::size_t N);
+    static SharedString WEBCFACE_CALL encode(std::wstring ws);
+    static SharedString WEBCFACE_CALL encodeStatic(const wchar_t *ws, std::size_t N);
 
-    const std::string &u8String() const;
     std::string_view u8StringView() const;
-    const std::string &decode() const;
-    const std::wstring &decodeW() const;
+    std::string_view decode() const;
+    std::wstring_view decodeW() const;
 
     static const std::string &emptyStr();
     static const std::wstring &emptyStrW();

--- a/common/include/webcface/common/encoding.h
+++ b/common/include/webcface/common/encoding.h
@@ -78,42 +78,48 @@ class TStringView : public std::basic_string_view<CharT> {
                   std::is_convertible_v<T, std::basic_string_view<CharT>>,
                   std::nullptr_t> = nullptr>
     bool operator==(const T &other) const {
-        return *this == std::basic_string_view<CharT>(other);
+        return static_cast<std::basic_string_view<CharT>>(*this) ==
+               std::basic_string_view<CharT>(other);
     }
     template <typename T,
               std::enable_if_t<
                   std::is_convertible_v<T, std::basic_string_view<CharT>>,
                   std::nullptr_t> = nullptr>
     bool operator!=(const T &other) const {
-        return *this != std::basic_string_view<CharT>(other);
+        return static_cast<std::basic_string_view<CharT>>(*this) !=
+               std::basic_string_view<CharT>(other);
     }
     template <typename T,
               std::enable_if_t<
                   std::is_convertible_v<T, std::basic_string_view<CharT>>,
                   std::nullptr_t> = nullptr>
     bool operator<=(const T &other) const {
-        return *this <= std::basic_string_view<CharT>(other);
+        return static_cast<std::basic_string_view<CharT>>(*this) <=
+               std::basic_string_view<CharT>(other);
     }
     template <typename T,
               std::enable_if_t<
                   std::is_convertible_v<T, std::basic_string_view<CharT>>,
                   std::nullptr_t> = nullptr>
     bool operator>=(const T &other) const {
-        return *this >= std::basic_string_view<CharT>(other);
+        return static_cast<std::basic_string_view<CharT>>(*this) >=
+               std::basic_string_view<CharT>(other);
     }
     template <typename T,
               std::enable_if_t<
                   std::is_convertible_v<T, std::basic_string_view<CharT>>,
                   std::nullptr_t> = nullptr>
     bool operator<(const T &other) const {
-        return *this < std::basic_string_view<CharT>(other);
+        return static_cast<std::basic_string_view<CharT>>(*this) <
+               std::basic_string_view<CharT>(other);
     }
     template <typename T,
               std::enable_if_t<
                   std::is_convertible_v<T, std::basic_string_view<CharT>>,
                   std::nullptr_t> = nullptr>
     bool operator>(const T &other) const {
-        return *this > std::basic_string_view<CharT>(other);
+        return static_cast<std::basic_string_view<CharT>>(*this) >
+               std::basic_string_view<CharT>(other);
     }
 };
 

--- a/common/include/webcface/common/encoding.h
+++ b/common/include/webcface/common/encoding.h
@@ -188,15 +188,9 @@ class WEBCFACE_DLL SharedString {
                         std::size_t len = std::string::npos) const;
     std::size_t find(char c, std::size_t pos = 0) const;
 
-    bool operator==(const SharedString &other) const {
-        return this->u8StringView() == other.u8StringView();
-    }
-    bool operator<=(const SharedString &other) const {
-        return this->u8StringView() <= other.u8StringView();
-    }
-    bool operator>=(const SharedString &other) const{
-        return this->u8StringView() >= other.u8StringView();
-    }
+    bool operator==(const SharedString &other) const;
+    bool operator<=(const SharedString &other) const;
+    bool operator>=(const SharedString &other) const;
     bool operator!=(const SharedString &other) const {
         return !(*this == other);
     }

--- a/common/include/webcface/common/encoding.h
+++ b/common/include/webcface/common/encoding.h
@@ -220,7 +220,7 @@ class StringInitializer : public SharedString {
               typename std::enable_if_t<
                   std::conjunction_v<std::negation<std::is_void<T>>,
                                      std::is_constructible<std::string, T>>,
-                  nullptr_t> = nullptr>
+                  std::nullptr_t> = nullptr>
     StringInitializer(const T &s)
         : SharedString(SharedString::encode(std::string(s))) {}
     template <typename T,
@@ -229,7 +229,7 @@ class StringInitializer : public SharedString {
                       std::negation<std::is_void<T>>,
                       std::negation<std::is_constructible<std::string, T>>,
                       std::is_constructible<std::wstring, T>>,
-                  nullptr_t> = nullptr>
+                  std::nullptr_t> = nullptr>
     StringInitializer(const T &s)
         : SharedString(SharedString::encode(std::wstring(s))) {}
     // c-string ptr

--- a/common/include/webcface/common/internal/message/canvas2d.h
+++ b/common/include/webcface/common/internal/message/canvas2d.h
@@ -47,7 +47,7 @@ struct Canvas2DComponentData {
 };
 struct Canvas2DData {
     double width = 0, height = 0;
-    std::map<std::string, std::shared_ptr<Canvas2DComponentData>> components;
+    std::map<std::string, std::shared_ptr<Canvas2DComponentData>, std::less<>> components;
     std::vector<SharedString> data_ids;
     Canvas2DData() = default;
     Canvas2DData(double width, double height)

--- a/common/include/webcface/common/internal/message/canvas2d.h
+++ b/common/include/webcface/common/internal/message/canvas2d.h
@@ -47,7 +47,8 @@ struct Canvas2DComponentData {
 };
 struct Canvas2DData {
     double width = 0, height = 0;
-    std::map<std::string, std::shared_ptr<Canvas2DComponentData>, std::less<>> components;
+    std::map<std::string, std::shared_ptr<Canvas2DComponentData>, std::less<>>
+        components;
     std::vector<SharedString> data_ids;
     Canvas2DData() = default;
     Canvas2DData(double width, double height)
@@ -57,13 +58,15 @@ struct Canvas2DData {
 struct Canvas2D : public MessageBase<MessageKind::canvas2d> {
     SharedString field;
     double width, height;
-    std::map<std::string, std::shared_ptr<Canvas2DComponentData>> data_diff;
+    std::map<std::string, std::shared_ptr<Canvas2DComponentData>, std::less<>>
+        data_diff;
     std::optional<std::vector<SharedString>> data_ids;
     Canvas2D() = default;
-    Canvas2D(
-        const SharedString &field, double width, double height,
-        std::map<std::string, std::shared_ptr<Canvas2DComponentData>> data_diff,
-        std::optional<std::vector<SharedString>> data_ids)
+    Canvas2D(const SharedString &field, double width, double height,
+             std::map<std::string, std::shared_ptr<Canvas2DComponentData>,
+                      std::less<>>
+                 data_diff,
+             std::optional<std::vector<SharedString>> data_ids)
         : field(field), width(width), height(height),
           data_diff(std::move(data_diff)), data_ids(std::move(data_ids)) {}
     MSGPACK_DEFINE_MAP(MSGPACK_NVP("f", field), MSGPACK_NVP("w", width),
@@ -124,13 +127,14 @@ struct Res<Canvas2D>
     unsigned int req_id = 0;
     SharedString sub_field;
     double width = 0, height = 0;
-    std::map<std::string, std::shared_ptr<Canvas2DComponentData>> data_diff;
+    std::map<std::string, std::shared_ptr<Canvas2DComponentData>, std::less<>>
+        data_diff;
     std::optional<std::vector<SharedString>> data_ids;
     Res() = default;
     Res(unsigned int req_id, const SharedString &sub_field, double width,
         double height,
-        const std::map<std::string, std::shared_ptr<Canvas2DComponentData>>
-            &data_diff,
+        const std::map<std::string, std::shared_ptr<Canvas2DComponentData>,
+                       std::less<>> &data_diff,
         const std::optional<std::vector<SharedString>> &data_ids)
         : req_id(req_id), sub_field(sub_field), width(width), height(height),
           data_diff(data_diff), data_ids(data_ids) {}

--- a/common/include/webcface/common/internal/message/canvas3d.h
+++ b/common/include/webcface/common/internal/message/canvas3d.h
@@ -42,19 +42,22 @@ struct Canvas3DComponentData {
                        MSGPACK_NVP("ff", field_field), MSGPACK_NVP("a", angles))
 };
 struct Canvas3DData {
-    std::map<std::string, std::shared_ptr<Canvas3DComponentData>, std::less<>> components;
+    std::map<std::string, std::shared_ptr<Canvas3DComponentData>, std::less<>>
+        components;
     std::vector<SharedString> data_ids;
     Canvas3DData() = default;
 };
 struct Canvas3D : public MessageBase<MessageKind::canvas3d> {
     SharedString field;
-    std::map<std::string, std::shared_ptr<Canvas3DComponentData>> data_diff;
+    std::map<std::string, std::shared_ptr<Canvas3DComponentData>, std::less<>>
+        data_diff;
     std::optional<std::vector<SharedString>> data_ids;
     Canvas3D() = default;
-    Canvas3D(
-        const SharedString &field,
-        std::map<std::string, std::shared_ptr<Canvas3DComponentData>> data_diff,
-        std::optional<std::vector<SharedString>> data_ids)
+    Canvas3D(const SharedString &field,
+             std::map<std::string, std::shared_ptr<Canvas3DComponentData>,
+                      std::less<>>
+                 data_diff,
+             std::optional<std::vector<SharedString>> data_ids)
         : field(field), data_diff(std::move(data_diff)),
           data_ids(std::move(data_ids)) {}
     MSGPACK_DEFINE_MAP(MSGPACK_NVP("f", field), MSGPACK_NVP("d", data_diff),
@@ -89,12 +92,13 @@ struct Res<Canvas3D>
     : public MessageBase<MessageKind::canvas3d + MessageKind::res> {
     unsigned int req_id = 0;
     SharedString sub_field;
-    std::map<std::string, std::shared_ptr<Canvas3DComponentData>> data_diff;
+    std::map<std::string, std::shared_ptr<Canvas3DComponentData>, std::less<>>
+        data_diff;
     std::optional<std::vector<SharedString>> data_ids;
     Res() = default;
     Res(unsigned int req_id, const SharedString &sub_field,
-        const std::map<std::string, std::shared_ptr<Canvas3DComponentData>>
-            &data_diff,
+        const std::map<std::string, std::shared_ptr<Canvas3DComponentData>,
+                       std::less<>> &data_diff,
         const std::optional<std::vector<SharedString>> &data_ids)
         : req_id(req_id), sub_field(sub_field), data_diff(data_diff),
           data_ids(data_ids) {}

--- a/common/include/webcface/common/internal/message/canvas3d.h
+++ b/common/include/webcface/common/internal/message/canvas3d.h
@@ -42,7 +42,7 @@ struct Canvas3DComponentData {
                        MSGPACK_NVP("ff", field_field), MSGPACK_NVP("a", angles))
 };
 struct Canvas3DData {
-    std::map<std::string, std::shared_ptr<Canvas3DComponentData>> components;
+    std::map<std::string, std::shared_ptr<Canvas3DComponentData>, std::less<>> components;
     std::vector<SharedString> data_ids;
     Canvas3DData() = default;
 };

--- a/common/include/webcface/common/internal/message/pack.h
+++ b/common/include/webcface/common/internal/message/pack.h
@@ -92,7 +92,7 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
         template <typename Stream>
         msgpack::packer<Stream> &operator()(msgpack::packer<Stream> &o,
                                             const webcface::SharedString &v) {
-            o.pack(v.u8String());
+            o.pack(v.u8StringView());
             return o;
         }
     };
@@ -143,7 +143,7 @@ MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
                 break;
             case webcface::ValType::string_:
             default:
-                o.pack(v.asU8StringRef());
+                o.pack(v.asU8StringView());
                 break;
             }
             return o;

--- a/common/include/webcface/common/internal/message/text.h
+++ b/common/include/webcface/common/internal/message/text.h
@@ -12,7 +12,7 @@ namespace message {
 
 struct Text : public MessageBase<MessageKind::text> {
     SharedString field;
-    std::shared_ptr<ValAdaptor> data;
+    ValAdaptor data;
     MSGPACK_DEFINE_MAP(MSGPACK_NVP("f", field), MSGPACK_NVP("d", data))
 };
 
@@ -20,10 +20,10 @@ template <>
 struct Res<Text> : public MessageBase<MessageKind::text + MessageKind::res> {
     unsigned int req_id = 0;
     SharedString sub_field;
-    std::shared_ptr<ValAdaptor> data;
+    ValAdaptor data;
     Res() = default;
     Res(unsigned int req_id, const SharedString &sub_field,
-        const std::shared_ptr<ValAdaptor> &data)
+        const ValAdaptor &data)
         : req_id(req_id), sub_field(sub_field), data(data) {}
     MSGPACK_DEFINE_MAP(MSGPACK_NVP("i", req_id), MSGPACK_NVP("f", sub_field),
                        MSGPACK_NVP("d", data))

--- a/common/include/webcface/common/internal/message/view.h
+++ b/common/include/webcface/common/internal/message/view.h
@@ -63,7 +63,8 @@ struct ViewComponentData {
  *
  */
 struct ViewData {
-    std::map<std::string, std::shared_ptr<message::ViewComponentData>, std::less<>>
+    std::map<std::string, std::shared_ptr<message::ViewComponentData>,
+             std::less<>>
         components;
     std::vector<SharedString> data_ids;
 };
@@ -93,11 +94,13 @@ struct ViewOld : public MessageBase<MessageKind::view_old> {
 };
 struct View : public MessageBase<MessageKind::view> {
     SharedString field;
-    std::map<std::string, std::shared_ptr<ViewComponentData>> data_diff;
+    std::map<std::string, std::shared_ptr<ViewComponentData>, std::less<>>
+        data_diff;
     std::optional<std::vector<SharedString>> data_ids;
     View() = default;
     View(const SharedString &field,
-         std::map<std::string, std::shared_ptr<ViewComponentData>> data_diff,
+         std::map<std::string, std::shared_ptr<ViewComponentData>, std::less<>>
+             data_diff,
          std::optional<std::vector<SharedString>> data_ids)
         : field(field), data_diff(std::move(data_diff)),
           data_ids(std::move(data_ids)) {}
@@ -126,12 +129,13 @@ template <>
 struct Res<View> : public MessageBase<MessageKind::view + MessageKind::res> {
     unsigned int req_id = 0;
     SharedString sub_field;
-    std::map<std::string, std::shared_ptr<ViewComponentData>> data_diff;
+    std::map<std::string, std::shared_ptr<ViewComponentData>, std::less<>>
+        data_diff;
     std::optional<std::vector<SharedString>> data_ids;
     Res() = default;
     Res(unsigned int req_id, const SharedString &sub_field,
-        const std::map<std::string, std::shared_ptr<ViewComponentData>>
-            &data_diff,
+        const std::map<std::string, std::shared_ptr<ViewComponentData>,
+                       std::less<>> &data_diff,
         const std::optional<std::vector<SharedString>> &data_ids)
         : req_id(req_id), sub_field(sub_field), data_diff(data_diff),
           data_ids(data_ids) {}

--- a/common/include/webcface/common/internal/message/view.h
+++ b/common/include/webcface/common/internal/message/view.h
@@ -63,7 +63,7 @@ struct ViewComponentData {
  *
  */
 struct ViewData {
-    std::map<std::string, std::shared_ptr<message::ViewComponentData>>
+    std::map<std::string, std::shared_ptr<message::ViewComponentData>, std::less<>>
         components;
     std::vector<SharedString> data_ids;
 };

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -113,16 +113,16 @@ class WEBCFACE_DLL ValAdaptor {
 
     /*!
      * ver2.10〜: std::string_view, std::wstring_view, const char*, const
-     * wchar_t* を受け取るコンストラクタを String に置き換え
+     * wchar_t* を受け取るコンストラクタを StringInitializer に置き換え
      *
      */
-    explicit ValAdaptor(String str);
+    explicit ValAdaptor(StringInitializer str);
     /*!
      * ver2.10〜: std::string_view, std::wstring_view, const char*, const
-     * wchar_t* を受け取るコンストラクタを String に置き換え
+     * wchar_t* を受け取るコンストラクタを StringInitializer に置き換え
      *
      */
-    ValAdaptor &operator=(String str);
+    ValAdaptor &operator=(StringInitializer str);
 
     /*!
      * ver2.10〜: const char*

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -335,7 +335,9 @@ class WEBCFACE_DLL ValAdaptor {
      */
     template <typename T>
     T as() const {
-        return T(*this);
+        // ↓ MSVCでなぜかコンパイルできない
+        // return static_cast<T>(*this);
+        return this->operator T();
     }
     /*!
      * \brief 数値型への変換

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -380,6 +380,11 @@ inline std::ostream &operator<<(std::ostream &os, const ValAdaptor &a) {
 }
 
 /*!
+ * \since ver2.10
+ */
+using ValAdapter = ValAdaptor;
+
+/*!
  * \brief ValAdaptorのリストから任意の型のタプルに変換する
  *
  */

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -166,15 +166,14 @@ class WEBCFACE_DLL ValAdaptor {
      * \brief 文字列として返す
      * \since ver1.10
      *
-     * std::stringのconst参照を返す。
-     * 参照はこのValAdaptorが破棄されるまで有効
+     * <del>std::stringのconst参照を返す。参照はこのValAdaptorが破棄されるまで有効</del>
      *
      * \deprecated ver2.10〜
-     * 内部の仕様変更により文字列のコピーが発生する可能性がある。
+     * 互換性のために残しているが、内部の仕様変更によりstringのconst参照ではなく文字列のコピーが返る。
      * コピーなしで文字列を参照するには asStringView() を使用すること。
      */
-    [[deprecated("(ver2.10〜) use asStringView() instead")]]
-    const std::string &asStringRef() const;
+    [[deprecated("(ver2.10〜) use asStringView() or asString() instead")]]
+    std::string asStringRef() const { return asString(); }
     /*!
      * \brief null終端の文字列の参照として返す
      * \since ver2.10
@@ -192,12 +191,12 @@ class WEBCFACE_DLL ValAdaptor {
      * \since ver2.0
      * \sa asStringRef()
      * \deprecated ver2.10〜
-     * 内部の仕様変更により文字列のコピーが発生する可能性がある。
+     * 互換性のために残しているが、内部の仕様変更によりwstringのconst参照ではなく文字列のコピーが返る。
      * コピーなしで文字列を参照するには asWStringView()
      * を使用すること。
      */
-    [[deprecated("(ver2.10〜) use asWStringView() instead")]]
-    const std::wstring &asWStringRef() const;
+    [[deprecated("(ver2.10〜) use asWStringView() or asWString() instead")]]
+    std::wstring asWStringRef() const { return asWString(); }
     /*!
      * \brief null終端の文字列の参照として返す (wstring)
      * \since ver2.10
@@ -209,12 +208,6 @@ class WEBCFACE_DLL ValAdaptor {
      * はそれをwstringに変換したうえでその参照を返す。
      */
     WStringView asWStringView() const;
-    /*!
-     * \since ver2.0
-     * \deprecated ver2.10〜
-     */
-    [[deprecated("(ver2.10〜) use asU8StringView() instead")]]
-    const std::string &asU8StringRef() const;
     /*!
      * \since ver2.10
      */
@@ -240,14 +233,6 @@ class WEBCFACE_DLL ValAdaptor {
      * \since ver2.10
      */
     operator std::wstring_view() const { return asWStringView(); }
-    /*!
-     * \since ver2.0
-     */
-    operator const char *() const { return asStringView().c_str(); }
-    /*!
-     * \since ver2.0
-     */
-    operator const wchar_t *() const { return asWStringView().c_str(); }
 
     /*!
      * \brief 実数として返す

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -267,7 +267,7 @@ class WEBCFACE_DLL ValAdaptor {
      *
      */
     template <typename T, typename std::enable_if_t<
-                              std::is_convertible_v<StringView, T> &&
+                              !std::is_convertible_v<StringView, T> &&
                                   std::is_convertible_v<WStringView, T>,
                               std::nullptr_t> = nullptr>
     operator T() const {

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -132,9 +132,17 @@ class WEBCFACE_DLL ValAdaptor {
     template <typename Bool, typename std::enable_if_t<
                                  std::is_same_v<Bool, bool>, bool> = true>
     explicit ValAdaptor(Bool value);
-    template <typename Bool, typename std::enable_if_t<
-                                 std::is_same_v<Bool, bool>, bool> = true>
-    ValAdaptor &operator=(Bool v);
+    /*!
+     * ver2.10〜: const char*
+     * などのポインタがboolに変換されるのを防ぐためテンプレート化
+     *
+     * テンプレート引数にenable_if_tを入れるとMSVCでコンパイルエラーになったので、
+     * ここでは戻り値をSFINAEにしている
+     *
+     */
+    template <typename Bool>
+    auto operator=(Bool v)
+        -> std::enable_if_t<std::is_same_v<Bool, bool>, ValAdaptor &>;
 
     explicit ValAdaptor(std::int64_t value);
     ValAdaptor &operator=(std::int64_t v);
@@ -359,7 +367,7 @@ class WEBCFACE_DLL ValAdaptor {
 };
 
 extern template ValAdaptor::ValAdaptor(bool value);
-extern template ValAdaptor &ValAdaptor::operator= <bool, true>(bool v);
+extern template ValAdaptor &ValAdaptor::operator= <bool>(bool v);
 
 
 template <typename T,

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -129,11 +129,13 @@ class WEBCFACE_DLL ValAdaptor {
      * などのポインタがboolに変換されるのを防ぐためテンプレート化
      *
      */
-    template <typename Bool, typename std::enable_if_t<std::is_same_v<Bool, bool>,
-                                                    std::nullptr_t> = nullptr>
+    template <typename Bool,
+              typename std::enable_if_t<std::is_same_v<Bool, bool>,
+                                        std::nullptr_t> = nullptr>
     explicit ValAdaptor(Bool value);
-    template <typename Bool, typename std::enable_if_t<std::is_same_v<Bool, bool>,
-                                                    std::nullptr_t> = nullptr>
+    template <typename Bool,
+              typename std::enable_if_t<std::is_same_v<Bool, bool>,
+                                        std::nullptr_t> = nullptr>
     ValAdaptor &operator=(Bool v);
 
     explicit ValAdaptor(std::int64_t value);
@@ -243,19 +245,6 @@ class WEBCFACE_DLL ValAdaptor {
     std::wstring asWString() const { return std::wstring(asWStringView()); }
 
     /*!
-     * <del>ver1.10〜: const参照</del>
-     * ver2.10〜: コピー
-     *
-     */
-    operator std::string() const { return asString(); }
-    /*!
-     * \since ver2.0
-     *
-     * ver2.10〜: const参照ではなくコピーに変更
-     *
-     */
-    operator std::wstring() const { return asWString(); }
-    /*!
      * \since ver2.10
      */
     operator std::string_view() const { return asStringView(); }
@@ -264,6 +253,21 @@ class WEBCFACE_DLL ValAdaptor {
      */
     operator std::wstring_view() const { return asWStringView(); }
     /*!
+     * <del>ver1.10〜: const参照</del>
+     * ver2.10〜: コピーにし、かつexplicitに変更
+     * ただしFuncに登録する関数の引数としてstd::stringを用いる際には暗黙的にstatic_castされる
+     *
+     */
+    explicit operator std::string() const { return asString(); }
+    /*!
+     * \since ver2.0
+     *
+     * ver2.10〜: const参照ではなくコピーにし、かつexplicitに変更
+     * ただしFuncに登録する関数の引数としてstd::wstringを用いる際には暗黙的にstatic_castされる
+     *
+     */
+    explicit operator std::wstring() const { return asWString(); }
+    /*!
      * \since ver2.0
      */
     operator const char *() const { return asStringView().c_str(); }
@@ -271,6 +275,7 @@ class WEBCFACE_DLL ValAdaptor {
      * \since ver2.0
      */
     operator const wchar_t *() const { return asWStringView().c_str(); }
+
     /*!
      * \brief 実数として返す
      * \since ver2.0

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -222,7 +222,7 @@ class WEBCFACE_DLL ValAdaptor {
     /*!
      * \since ver2.10
      */
-    StringView asU8StringView() const;
+    std::string_view asU8StringView() const;
     /*!
      * \brief 文字列として返す(コピー)
      * \since ver1.10

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -129,13 +129,11 @@ class WEBCFACE_DLL ValAdaptor {
      * などのポインタがboolに変換されるのを防ぐためテンプレート化
      *
      */
-    template <typename Bool,
-              typename std::enable_if_t<std::is_same_v<Bool, bool>,
-                                        std::nullptr_t> = nullptr>
+    template <typename Bool, typename std::enable_if_t<
+                                 std::is_same_v<Bool, bool>, bool> = true>
     explicit ValAdaptor(Bool value);
-    template <typename Bool,
-              typename std::enable_if_t<std::is_same_v<Bool, bool>,
-                                        std::nullptr_t> = nullptr>
+    template <typename Bool, typename std::enable_if_t<
+                                 std::is_same_v<Bool, bool>, bool> = true>
     ValAdaptor &operator=(Bool v);
 
     explicit ValAdaptor(std::int64_t value);
@@ -144,18 +142,14 @@ class WEBCFACE_DLL ValAdaptor {
     explicit ValAdaptor(double value);
     ValAdaptor &operator=(double v);
 
-    template <typename T,
-              typename std::enable_if_t<!std::is_same_v<T, bool> &&
-                                            std::is_integral_v<T>,
-                                        std::nullptr_t> = nullptr,
-              std::nullptr_t = nullptr>
+    template <typename T, typename std::enable_if_t<!std::is_same_v<T, bool> &&
+                                                        std::is_integral_v<T>,
+                                                    std::nullptr_t> = nullptr>
     explicit ValAdaptor(T value)
         : ValAdaptor(static_cast<std::int64_t>(value)) {}
-    template <typename T,
-              typename std::enable_if_t<!std::is_same_v<T, bool> &&
-                                            std::is_integral_v<T>,
-                                        std::nullptr_t> = nullptr,
-              std::nullptr_t = nullptr>
+    template <typename T, typename std::enable_if_t<!std::is_same_v<T, bool> &&
+                                                        std::is_integral_v<T>,
+                                                    std::nullptr_t> = nullptr>
     ValAdaptor &operator=(T v) {
         return *this = static_cast<std::int64_t>(v);
     }
@@ -365,7 +359,7 @@ class WEBCFACE_DLL ValAdaptor {
 };
 
 extern template ValAdaptor::ValAdaptor(bool value);
-extern template ValAdaptor &ValAdaptor::operator= <bool, nullptr>(bool v);
+extern template ValAdaptor &ValAdaptor::operator= <bool, true>(bool v);
 
 
 template <typename T,

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -386,7 +386,7 @@ bool operator!=(const T &other, const ValAdaptor &val) {
 }
 
 inline std::ostream &operator<<(std::ostream &os, const ValAdaptor &a) {
-    return os << static_cast<std::string>(a);
+    return os << a.asStringView();
 }
 
 /*!

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -96,6 +96,9 @@ class WEBCFACE_DLL ValAdaptor {
 
     enum ValVariant { DOUBLEV = 0, INT64V = 1 };
 
+    void initStr() const;
+    void initWStr() const;
+
   public:
     ValAdaptor();
 
@@ -108,32 +111,18 @@ class WEBCFACE_DLL ValAdaptor {
      */
     ValAdaptor &operator=(const SharedString &str);
 
-    explicit ValAdaptor(std::string_view str);
-    ValAdaptor &operator=(std::string_view str);
-    explicit ValAdaptor(const char *str) : ValAdaptor(std::string_view(str)) {}
-    ValAdaptor &operator=(const char *str) {
-        return *this = std::string_view(str);
-    }
-
     /*!
-     * \since ver2.0
+     * ver2.10〜: std::string_view, std::wstring_view, const char*, const
+     * wchar_t* を受け取るコンストラクタを String に置き換え
+     *
      */
-    explicit ValAdaptor(std::wstring_view str);
+    explicit ValAdaptor(String str);
     /*!
-     * \since ver2.0
+     * ver2.10〜: std::string_view, std::wstring_view, const char*, const
+     * wchar_t* を受け取るコンストラクタを String に置き換え
+     *
      */
-    ValAdaptor &operator=(std::wstring_view str);
-    /*!
-     * \since ver2.0
-     */
-    explicit ValAdaptor(const wchar_t *str)
-        : ValAdaptor(std::wstring_view(str)) {}
-    /*!
-     * \since ver2.0
-     */
-    ValAdaptor &operator=(const wchar_t *str) {
-        return *this = std::wstring_view(str);
-    }
+    ValAdaptor &operator=(String str);
 
     explicit ValAdaptor(bool value);
     ValAdaptor &operator=(bool v);
@@ -180,49 +169,108 @@ class WEBCFACE_DLL ValAdaptor {
      * std::stringのconst参照を返す。
      * 参照はこのValAdaptorが破棄されるまで有効
      *
+     * \deprecated ver2.10〜
+     * 内部の仕様変更により文字列のコピーが発生する可能性がある。
+     * コピーなしで文字列を参照するには asStringView() を使用すること。
+     */
+    [[deprecated("(ver2.10〜) use asStringView() instead")]] const std::string &
+    asStringRef() const;
+    /*!
+     * \brief 文字列として返す
+     * \since ver2.10
+     *
+     * 参照はこのValAdaptorが破棄されるまで有効
+     *
      * as_strにstringが格納されていた場合はそれをそのまま返す。
      * そうでない場合(u8string, wstring, double, int64が格納されている場合)
      * はそれをstringに変換したうえでその参照を返す。
      *
      */
-    const std::string &asStringRef() const;
+    std::string_view asStringView() const;
     /*!
      * \brief 文字列として返す (wstring)
      * \since ver2.0
      * \sa asStringRef()
+     * \deprecated ver2.10〜
+     * 内部の仕様変更により文字列のコピーが発生する可能性がある。
+     * コピーなしで文字列を参照するには asWStringView() を使用すること。
      */
-    const std::wstring &asWStringRef() const;
+    [[deprecated(
+        "(ver2.10〜) use asWStringView() instead")]] const std::wstring &
+    asWStringRef() const;
+    /*!
+     * \brief 文字列として返す (wstring)
+     * \since ver2.10
+     *
+     * 参照はこのValAdaptorが破棄されるまで有効
+     *
+     * as_strにwstringが格納されていた場合はそれをそのまま返す。
+     * そうでない場合(u8string, string, double, int64が格納されている場合)
+     * はそれをwstringに変換したうえでその参照を返す。
+     */
+    std::wstring_view asWStringView() const;
     /*!
      * \since ver2.0
+     * \deprecated ver2.10〜
      */
-    const std::string &asU8StringRef() const;
+    [[deprecated(
+        "(ver2.10〜) use asU8StringView() instead")]] const std::string &
+    asU8StringRef() const;
+    /*!
+     * \since ver2.10
+     */
+    std::string_view asU8StringView() const;
     /*!
      * \brief 文字列として返す(コピー)
      * \since ver1.10
      */
-    std::string asString() const { return asStringRef(); }
+    std::string asString() const { return std::string(asStringView()); }
     /*!
      * \brief 文字列として返す(コピー) (wstring)
      * \since ver2.0
      */
-    std::wstring asWString() const { return asWStringRef(); }
+    std::wstring asWString() const { return std::wstring(asWStringView()); }
+    /*!
+     * \brief null終端の文字列を返す
+     * \since ver2.10
+     *
+     * ポインタはこのValAdaptorが破棄されるまで有効
+     *
+     * as_strにstringが格納されていた場合はそれをそのまま返す。
+     * そうでない場合(u8string, string, double, int64が格納されている場合)
+     * はそれをstringに変換したうえでその参照を返す。
+     */
+    const char *asCStr() const;
+    /*!
+     * \brief null終端の文字列を返す (wstring)
+     * \since ver2.0
+     *
+     * ポインタはこのValAdaptorが破棄されるまで有効
+     *
+     * as_strにwstringが格納されていた場合はそれをそのまま返す。
+     * そうでない場合(u8string, string, double, int64が格納されている場合)
+     * はそれをwstringに変換したうえでその参照を返す。
+     */
+    const wchar_t *asWCStr() const;
 
     /*!
-     * ver1.10〜: const参照
+     * \since ver2.10
+     *
+     * 以前の const std::string& を置き換え
      */
-    operator const std::string &() const { return asStringRef(); }
+    operator std::string_view() const { return asStringView(); }
+    /*!
+     * \since ver2.10
+     */
+    operator std::wstring_view() const { return asWStringView(); }
     /*!
      * \since ver2.0
      */
-    operator const std::wstring &() const { return asWStringRef(); }
+    operator const char *() const { return asCStr(); }
     /*!
      * \since ver2.0
      */
-    operator const char *() const { return asStringRef().c_str(); }
-    /*!
-     * \since ver2.0
-     */
-    operator const wchar_t *() const { return asWStringRef().c_str(); }
+    operator const wchar_t *() const { return asWCStr(); }
 
     /*!
      * \brief 実数として返す

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -194,10 +194,8 @@ class WEBCFACE_DLL ValAdaptor {
         return asString();
     }
     /*!
-     * \brief null終端の文字列の参照として返す
+     * \brief null終端の文字列を返す
      * \since ver2.10
-     *
-     * 参照はこのValAdaptorが破棄されるまで有効
      *
      * as_strにstringが格納されていた場合はそれをそのまま返す。
      * そうでない場合(u8string, wstring, double, int64が格納されている場合)
@@ -219,10 +217,8 @@ class WEBCFACE_DLL ValAdaptor {
         return asWString();
     }
     /*!
-     * \brief null終端の文字列の参照として返す (wstring)
+     * \brief null終端の文字列を返す (wstring)
      * \since ver2.10
-     *
-     * 参照はこのValAdaptorが破棄されるまで有効
      *
      * as_strにwstringが格納されていた場合はそれをそのまま返す。
      * そうでない場合(u8string, string, double, int64が格納されている場合)
@@ -246,10 +242,16 @@ class WEBCFACE_DLL ValAdaptor {
 
     /*!
      * \since ver2.10
+     *
+     * 参照はこのValAdaptorが破棄されるまでは有効
+     *
      */
     operator std::string_view() const { return asStringView(); }
     /*!
      * \since ver2.10
+     *
+     * 参照はこのValAdaptorが破棄されるまでは有効
+     *
      */
     operator std::wstring_view() const { return asWStringView(); }
     /*!
@@ -269,10 +271,16 @@ class WEBCFACE_DLL ValAdaptor {
     explicit operator std::wstring() const { return asWString(); }
     /*!
      * \since ver2.0
+     *
+     * 参照はこのValAdaptorが破棄されるまでは有効
+     *
      */
     operator const char *() const { return asStringView().c_str(); }
     /*!
      * \since ver2.0
+     *
+     * 参照はこのValAdaptorが破棄されるまでは有効
+     *
      */
     operator const wchar_t *() const { return asWStringView().c_str(); }
 

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -171,13 +171,12 @@ class WEBCFACE_DLL ValAdaptor {
      *
      * \deprecated ver2.10〜
      * 内部の仕様変更により文字列のコピーが発生する可能性がある。
-     * コピーなしで文字列を参照するには asStringView() または asCStr()
-     * を使用すること。
+     * コピーなしで文字列を参照するには asStringView() を使用すること。
      */
-    [[deprecated("(ver2.10〜) use asStringView() or asCStr() instead")]]
+    [[deprecated("(ver2.10〜) use asStringView() instead")]]
     const std::string &asStringRef() const;
     /*!
-     * \brief 文字列として返す
+     * \brief null終端の文字列の参照として返す
      * \since ver2.10
      *
      * 参照はこのValAdaptorが破棄されるまで有効
@@ -187,7 +186,7 @@ class WEBCFACE_DLL ValAdaptor {
      * はそれをstringに変換したうえでその参照を返す。
      *
      */
-    std::string_view asStringView() const;
+    StringView asStringView() const;
     /*!
      * \brief 文字列として返す (wstring)
      * \since ver2.0
@@ -197,10 +196,10 @@ class WEBCFACE_DLL ValAdaptor {
      * コピーなしで文字列を参照するには asWStringView() または asWCStr()
      * を使用すること。
      */
-    [[deprecated("(ver2.10〜) use asWStringView() or asWCStr() instead")]]
+    [[deprecated("(ver2.10〜) use asWStringView() instead")]]
     const std::wstring &asWStringRef() const;
     /*!
-     * \brief 文字列として返す (wstring)
+     * \brief null終端の文字列の参照として返す (wstring)
      * \since ver2.10
      *
      * 参照はこのValAdaptorが破棄されるまで有効
@@ -209,7 +208,7 @@ class WEBCFACE_DLL ValAdaptor {
      * そうでない場合(u8string, string, double, int64が格納されている場合)
      * はそれをwstringに変換したうえでその参照を返す。
      */
-    std::wstring_view asWStringView() const;
+    WStringView asWStringView() const;
     /*!
      * \since ver2.0
      * \deprecated ver2.10〜
@@ -219,7 +218,7 @@ class WEBCFACE_DLL ValAdaptor {
     /*!
      * \since ver2.10
      */
-    std::string_view asU8StringView() const;
+    StringView asU8StringView() const;
     /*!
      * \brief 文字列として返す(コピー)
      * \since ver1.10
@@ -230,28 +229,6 @@ class WEBCFACE_DLL ValAdaptor {
      * \since ver2.0
      */
     std::wstring asWString() const { return std::wstring(asWStringView()); }
-    /*!
-     * \brief null終端の文字列を返す
-     * \since ver2.10
-     *
-     * ポインタはこのValAdaptorが破棄されるまで有効
-     *
-     * as_strにstringが格納されていた場合はそれをそのまま返す。
-     * そうでない場合(u8string, string, double, int64が格納されている場合)
-     * はそれをstringに変換したうえでその参照を返す。
-     */
-    const char *asCStr() const;
-    /*!
-     * \brief null終端の文字列を返す (wstring)
-     * \since ver2.0
-     *
-     * ポインタはこのValAdaptorが破棄されるまで有効
-     *
-     * as_strにwstringが格納されていた場合はそれをそのまま返す。
-     * そうでない場合(u8string, string, double, int64が格納されている場合)
-     * はそれをwstringに変換したうえでその参照を返す。
-     */
-    const wchar_t *asWCStr() const;
 
     /*!
      * \since ver2.10
@@ -266,11 +243,11 @@ class WEBCFACE_DLL ValAdaptor {
     /*!
      * \since ver2.0
      */
-    operator const char *() const { return asCStr(); }
+    operator const char *() const { return asStringView().c_str(); }
     /*!
      * \since ver2.0
      */
-    operator const wchar_t *() const { return asWCStr(); }
+    operator const wchar_t *() const { return asWStringView().c_str(); }
 
     /*!
      * \brief 実数として返す

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -171,10 +171,11 @@ class WEBCFACE_DLL ValAdaptor {
      *
      * \deprecated ver2.10〜
      * 内部の仕様変更により文字列のコピーが発生する可能性がある。
-     * コピーなしで文字列を参照するには asStringView() を使用すること。
+     * コピーなしで文字列を参照するには asStringView() または asCStr()
+     * を使用すること。
      */
-    [[deprecated("(ver2.10〜) use asStringView() instead")]] const std::string &
-    asStringRef() const;
+    [[deprecated("(ver2.10〜) use asStringView() or asCStr() instead")]]
+    const std::string &asStringRef() const;
     /*!
      * \brief 文字列として返す
      * \since ver2.10
@@ -193,11 +194,11 @@ class WEBCFACE_DLL ValAdaptor {
      * \sa asStringRef()
      * \deprecated ver2.10〜
      * 内部の仕様変更により文字列のコピーが発生する可能性がある。
-     * コピーなしで文字列を参照するには asWStringView() を使用すること。
+     * コピーなしで文字列を参照するには asWStringView() または asWCStr()
+     * を使用すること。
      */
-    [[deprecated(
-        "(ver2.10〜) use asWStringView() instead")]] const std::wstring &
-    asWStringRef() const;
+    [[deprecated("(ver2.10〜) use asWStringView() or asWCStr() instead")]]
+    const std::wstring &asWStringRef() const;
     /*!
      * \brief 文字列として返す (wstring)
      * \since ver2.10
@@ -213,9 +214,8 @@ class WEBCFACE_DLL ValAdaptor {
      * \since ver2.0
      * \deprecated ver2.10〜
      */
-    [[deprecated(
-        "(ver2.10〜) use asU8StringView() instead")]] const std::string &
-    asU8StringRef() const;
+    [[deprecated("(ver2.10〜) use asU8StringView() instead")]]
+    const std::string &asU8StringRef() const;
     /*!
      * \since ver2.10
      */
@@ -298,8 +298,8 @@ class WEBCFACE_DLL ValAdaptor {
      *
      */
     template <typename T>
-    [[deprecated("use asDouble(), asInt() or asLLong() instead")]] double
-    as() const {
+    [[deprecated("use asDouble(), asInt() or asLLong() instead")]]
+    double as() const {
         return static_cast<T>(asDouble());
     }
     /*!

--- a/common/include/webcface/common/val_adaptor.h
+++ b/common/include/webcface/common/val_adaptor.h
@@ -193,7 +193,7 @@ class WEBCFACE_DLL ValAdaptor {
      * \sa asStringRef()
      * \deprecated ver2.10〜
      * 内部の仕様変更により文字列のコピーが発生する可能性がある。
-     * コピーなしで文字列を参照するには asWStringView() または asWCStr()
+     * コピーなしで文字列を参照するには asWStringView()
      * を使用すること。
      */
     [[deprecated("(ver2.10〜) use asWStringView() instead")]]

--- a/common/src/encoding.cc
+++ b/common/src/encoding.cc
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <mutex>
 #include <cassert>
+#include <variant>
 
 #if WEBCFACE_SYSTEM_WCHAR_WINDOWS
 #include <windows.h>

--- a/common/src/encoding.cc
+++ b/common/src/encoding.cc
@@ -79,12 +79,14 @@ void encodeWsToU8s(const std::shared_ptr<internal::SharedStringData> &data) {
 #else
     static_assert(sizeof(wchar_t) == 4, "Assuming wchar_t is utf-32 on Unix");
     assert(data->u8s.empty() && data->u8sv.empty());
-    utf8::utf32to8(name.cbegin(), name.cend(), std::back_inserter(data->u8s));
+    utf8::utf32to8(data->wsv.cbegin(), data->wsv.cend(),
+                   std::back_inserter(data->u8s));
     data->u8sv = data->u8s;
 #endif
 }
 /// \private
-void encodeSToWs(const std::shared_ptr<internal::SharedStringData> &data) {
+void encodeSToWs(
+    [[maybe_unused]] const std::shared_ptr<internal::SharedStringData> &data) {
 #if WEBCFACE_SYSTEM_WCHAR_WINDOWS
     auto length =
         MultiByteToWideChar(CP_ACP, 0, data->sv.data(),
@@ -167,17 +169,17 @@ SharedString SharedString::encodeStatic(std::wstring_view name) {
 }
 
 bool SharedString::operator==(const SharedString &other) const {
-    if(empty()) {
+    if (empty()) {
         return other.empty();
-    }else if(other.empty()){
+    } else if (other.empty()) {
         return false; // return empty();
-    }else{
+    } else {
         // data != nullptr
-        if(!data->wsv.empty() || !other.data->wsv.empty()){
+        if (!data->wsv.empty() || !other.data->wsv.empty()) {
             return decodeW() == other.decodeW();
-        }else if(!data->u8sv.empty() || !other.data->u8sv.empty()){
+        } else if (!data->u8sv.empty() || !other.data->u8sv.empty()) {
             return u8StringView() == other.u8StringView();
-        }else{
+        } else {
             return decode() == other.decode();
         }
     }
@@ -185,7 +187,7 @@ bool SharedString::operator==(const SharedString &other) const {
 bool SharedString::operator<=(const SharedString &other) const {
     return u8StringView() <= other.u8StringView();
 }
-bool SharedString::operator>=(const SharedString &other) const{
+bool SharedString::operator>=(const SharedString &other) const {
     return u8StringView() >= other.u8StringView();
 }
 
@@ -285,7 +287,8 @@ void decodeU8sToWs(const std::shared_ptr<internal::SharedStringData> &data) {
     data->wsv = data->ws;
 #endif
 }
-void decodeWsToS(const std::shared_ptr<internal::SharedStringData> &data) {
+void decodeWsToS(
+    [[maybe_unused]] const std::shared_ptr<internal::SharedStringData> &data) {
 #if WEBCFACE_SYSTEM_WCHAR_WINDOWS
     auto length_acp = WideCharToMultiByte(CP_ACP, 0, data->wsv.data(),
                                           static_cast<int>(data->wsv.size()),

--- a/common/src/encoding.cc
+++ b/common/src/encoding.cc
@@ -2,12 +2,26 @@
 #include <utf8.h>
 #include <cstring>
 #include <mutex>
+#include <cassert>
 
 #if WEBCFACE_SYSTEM_WCHAR_WINDOWS
 #include <windows.h>
 #endif
 
 WEBCFACE_NS_BEGIN
+
+template <typename CharT>
+TStringView<CharT>::TStringView(const CharT *data, std::size_t size,
+                                const std::basic_string<CharT> *container)
+    : std::basic_string_view<CharT>(data, size), c_str_(data),
+      container_(container) {
+    assert(data[size] == static_cast<CharT>(0));
+    if (container_) {
+        assert(container->c_str() == data);
+    }
+}
+template class WEBCFACE_DLL_INSTANCE_DEF TStringView<char>;
+template class WEBCFACE_DLL_INSTANCE_DEF TStringView<wchar_t>;
 
 namespace internal {
 

--- a/common/src/encoding.cc
+++ b/common/src/encoding.cc
@@ -96,7 +96,7 @@ std::pair<std::string, std::wstring> encodeImpl(std::string_view name) {
                         static_cast<int>(result_utf16.size()),
                         result_utf8.data(),
                         static_cast<int>(result_utf8.size()), nullptr, nullptr);
-    return { result_utf8, result_utf16 }
+    return { result_utf8, result_utf16 };
 }
 #endif
 
@@ -297,16 +297,18 @@ std::wstring toWide(std::string_view name_ref) {
 
 #if WEBCFACE_SYSTEM_WCHAR_WINDOWS
 void decodeImpl(const std::shared_ptr<internal::SharedStringData> &data) {
-    auto result_utf16 = decodeW();
-    auto length_acp = WideCharToMultiByte(CP_ACP, 0, result_utf16.data(),
-                                          static_cast<int>(result_utf16.size()),
+    if (data->wsv.empty()) {
+        decodeImplW(data);
+    }
+    auto length_acp = WideCharToMultiByte(CP_ACP, 0, data->wsv.data(),
+                                          static_cast<int>(data->wsv.size()),
                                           nullptr, 0, nullptr, nullptr);
     std::string result_acp(length_acp, '\0');
-    WideCharToMultiByte(CP_ACP, 0, result_utf16.data(),
-                        static_cast<int>(result_utf16.size()),
+    WideCharToMultiByte(CP_ACP, 0, data->wsv.data(),
+                        static_cast<int>(data->wsv.size()),
                         result_acp.data(), static_cast<int>(result_acp.size()),
                         nullptr, nullptr);
-    data->s std::move(result_acp);
+    data->s = std::move(result_acp);
     data->sv = data->s;
 }
 #endif

--- a/common/src/fmt.cc
+++ b/common/src/fmt.cc
@@ -133,12 +133,12 @@ static std::string fmtValAdaptor(const webcface::ValAdaptor &v) {
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Text) {
     return fmt::format_to(ctx.out(), "{}-Text('{}', {})", msg_kind,
-                          m.field.decode(), fmtValAdaptor(*m.data));
+                          m.field.decode(), fmtValAdaptor(m.data));
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Res<webcface::message::Text>) {
     return fmt::format_to(ctx.out(), "{}-TextRes(req_id={} + '{}', {})",
                           msg_kind, m.req_id, m.sub_field.decode(),
-                          fmtValAdaptor(*m.data));
+                          fmtValAdaptor(m.data));
 }
 WEBCFACE_MESSAGE_FMT_DEF_ENTRY(Text)
 WEBCFACE_MESSAGE_FMT_DEF_REQ(Text)

--- a/common/src/fmt.cc
+++ b/common/src/fmt.cc
@@ -28,22 +28,21 @@
         webcface::message::Entry<webcface::message::Type>) {                   \
         return fmt::format_to(ctx.out(),                                       \
                               "{}-" #Type "Entry('{}' from member_id={})",     \
-                              msg_kind, m.field.decode().std(), m.member_id);  \
+                              msg_kind, m.field.decode(), m.member_id);        \
     }
 #define WEBCFACE_MESSAGE_FMT_DEF_REQ(Type)                                     \
     WEBCFACE_MESSAGE_FMT_DEF(                                                  \
         webcface::message::Req<webcface::message::Type>) {                     \
         return fmt::format_to(                                                 \
             ctx.out(), "{}-" #Type "Req('{}' from member '{}' as req_id={})",  \
-            msg_kind, m.field.decode().std(), m.member.decode().std(),         \
-            m.req_id);                                                         \
+            msg_kind, m.field.decode(), m.member.decode(), m.req_id);          \
     }
 
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::SyncInit) {
     return fmt::format_to(ctx.out(),
                           "{}-SyncInit('{}', member_id={}, lib_name='{}', "
                           "lib_ver='{}', addr='{}')",
-                          msg_kind, m.member_name.decode().std(), m.member_id,
+                          msg_kind, m.member_name.decode(), m.member_id,
                           m.lib_name, m.lib_ver, m.addr);
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::SyncInitEnd) {
@@ -98,11 +97,11 @@ static std::string fmtValue(const std::vector<double> &v) {
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Value) {
     return fmt::format_to(ctx.out(), "{}-Value('{}', {})", msg_kind,
-                          m.field.decode().std(), fmtValue(*m.data));
+                          m.field.decode(), fmtValue(*m.data));
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Res<webcface::message::Value>) {
     return fmt::format_to(ctx.out(), "{}-ValueRes(req_id={} + '{}', {})",
-                          msg_kind, m.req_id, m.sub_field.decode().std(),
+                          msg_kind, m.req_id, m.sub_field.decode(),
                           fmtValue(*m.data));
 }
 WEBCFACE_MESSAGE_FMT_DEF_ENTRY(Value)
@@ -130,11 +129,11 @@ static std::string fmtValAdaptor(const webcface::ValAdaptor &v) {
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Text) {
     return fmt::format_to(ctx.out(), "{}-Text('{}', {})", msg_kind,
-                          m.field.decode().std(), fmtValAdaptor(*m.data));
+                          m.field.decode(), fmtValAdaptor(*m.data));
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Res<webcface::message::Text>) {
     return fmt::format_to(ctx.out(), "{}-TextRes(req_id={} + '{}', {})",
-                          msg_kind, m.req_id, m.sub_field.decode().std(),
+                          msg_kind, m.req_id, m.sub_field.decode(),
                           fmtValAdaptor(*m.data));
 }
 WEBCFACE_MESSAGE_FMT_DEF_ENTRY(Text)
@@ -142,20 +141,20 @@ WEBCFACE_MESSAGE_FMT_DEF_REQ(Text)
 
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::RobotModel) {
     return fmt::format_to(ctx.out(), "{}-RobotModel('{}', size={})", msg_kind,
-                          m.field.decode().std(), m.data.size());
+                          m.field.decode(), m.data.size());
 }
 WEBCFACE_MESSAGE_FMT_DEF(
     webcface::message::Res<webcface::message::RobotModel>) {
     return fmt::format_to(
         ctx.out(), "{}-RobotModelRes(req_id={} + '{}', size={})", msg_kind,
-        m.req_id, m.sub_field.decode().std(), m.data.size());
+        m.req_id, m.sub_field.decode(), m.data.size());
 }
 WEBCFACE_MESSAGE_FMT_DEF_ENTRY(RobotModel)
 WEBCFACE_MESSAGE_FMT_DEF_REQ(RobotModel)
 
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Log) {
     return fmt::format_to(ctx.out(), "{}-Log('{}', {} lines)", msg_kind,
-                          m.field.decode().std(), m.log->size());
+                          m.field.decode(), m.log->size());
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::LogDefault) {
     return fmt::format_to(ctx.out(), "{}-LogDefault(member_id={}, {} lines)",
@@ -163,7 +162,7 @@ WEBCFACE_MESSAGE_FMT_DEF(webcface::message::LogDefault) {
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::LogReqDefault) {
     return fmt::format_to(ctx.out(), "{}-LogReqDefault(from '{}')", msg_kind,
-                          m.member.decode().std());
+                          m.member.decode());
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::LogEntryDefault) {
     return fmt::format_to(ctx.out(), "{}-LogEntryDefault(member_id={})",
@@ -171,7 +170,7 @@ WEBCFACE_MESSAGE_FMT_DEF(webcface::message::LogEntryDefault) {
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Res<webcface::message::Log>) {
     return fmt::format_to(ctx.out(), "{}-LogRes(req_id={} + '{}', {} lines)",
-                          msg_kind, m.req_id, m.sub_field.decode().std(),
+                          msg_kind, m.req_id, m.sub_field.decode(),
                           m.log->size());
 }
 WEBCFACE_MESSAGE_FMT_DEF_ENTRY(Log)
@@ -180,7 +179,7 @@ WEBCFACE_MESSAGE_FMT_DEF_REQ(Log)
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Image) {
     return fmt::format_to(
         ctx.out(), "{}-Image('{}', {} x {}, {} bytes, color={}, compress={})",
-        msg_kind, m.field.decode().std(), m.width_, m.height_,
+        msg_kind, m.field.decode(), m.width_, m.height_,
         m.data_ ? m.data_->size() : 0, toInt(m.color_mode_),
         toInt(m.cmp_mode_));
 }
@@ -188,8 +187,8 @@ WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Res<webcface::message::Image>) {
     return fmt::format_to(ctx.out(),
                           "{}-ImageRes(req_id={} + '{}', {} x {}, {} bytes, "
                           "color={}, compress={})",
-                          msg_kind, m.req_id, m.sub_field.decode().std(),
-                          m.width_, m.height_, m.data_ ? m.data_->size() : 0,
+                          msg_kind, m.req_id, m.sub_field.decode(), m.width_,
+                          m.height_, m.data_ ? m.data_->size() : 0,
                           toInt(m.color_mode_), toInt(m.cmp_mode_));
 }
 WEBCFACE_MESSAGE_FMT_DEF_ENTRY(Image)
@@ -197,80 +196,77 @@ WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Req<webcface::message::Image>) {
     return fmt::format_to(ctx.out(),
                           "{}-ImageReq('{}' from member '{}' as req_id={}, {} "
                           "x {}, color={}, cmp={}, q={}, r={})",
-                          msg_kind, m.field.decode().std(),
-                          m.member.decode().std(), m.req_id, m.rows, m.cols,
-                          toInt(m.color_mode), toInt(m.cmp_mode), m.quality,
-                          m.frame_rate);
+                          msg_kind, m.field.decode(), m.member.decode(),
+                          m.req_id, m.rows, m.cols, toInt(m.color_mode),
+                          toInt(m.cmp_mode), m.quality, m.frame_rate);
 }
 
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::View) {
     return fmt::format_to(ctx.out(), "{}-View('{}', {} diffs)", msg_kind,
-                          m.field.decode().std(), m.data_diff.size());
+                          m.field.decode(), m.data_diff.size());
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Res<webcface::message::View>) {
     return fmt::format_to(ctx.out(), "{}-ViewRes(req_id={} + '{}', {} diffs)",
-                          msg_kind, m.req_id, m.sub_field.decode().std(),
+                          msg_kind, m.req_id, m.sub_field.decode(),
                           m.data_diff.size());
 }
 WEBCFACE_MESSAGE_FMT_DEF_ENTRY(View)
 WEBCFACE_MESSAGE_FMT_DEF_REQ(View)
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::ViewOld) {
     return fmt::format_to(ctx.out(), "{}-ViewOld('{}', {} diffs, length={})",
-                          msg_kind, m.field.decode().std(), m.data_diff.size(),
+                          msg_kind, m.field.decode(), m.data_diff.size(),
                           m.length);
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Res<webcface::message::ViewOld>) {
     return fmt::format_to(
         ctx.out(), "{}-ViewOldRes(req_id={} + '{}', {} diffs, length={})",
-        msg_kind, m.req_id, m.sub_field.decode().std(), m.data_diff.size(),
-        m.length);
+        msg_kind, m.req_id, m.sub_field.decode(), m.data_diff.size(), m.length);
 }
 WEBCFACE_MESSAGE_FMT_DEF_ENTRY(ViewOld)
 WEBCFACE_MESSAGE_FMT_DEF_REQ(ViewOld)
 
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Canvas3D) {
     return fmt::format_to(ctx.out(), "{}-Canvas3D('{}', {} diffs)", msg_kind,
-                          m.field.decode().std(), m.data_diff.size());
+                          m.field.decode(), m.data_diff.size());
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Res<webcface::message::Canvas3D>) {
     return fmt::format_to(
         ctx.out(), "{}-Canvas3DRes(req_id={} + '{}', {} diffs)", msg_kind,
-        m.req_id, m.sub_field.decode().std(), m.data_diff.size());
+        m.req_id, m.sub_field.decode(), m.data_diff.size());
 }
 WEBCFACE_MESSAGE_FMT_DEF_ENTRY(Canvas3D)
 WEBCFACE_MESSAGE_FMT_DEF_REQ(Canvas3D)
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Canvas3DOld) {
     return fmt::format_to(ctx.out(),
                           "{}-Canvas3DOld('{}', {} diffs, length={})", msg_kind,
-                          m.field.decode().std(), m.data_diff.size(), m.length);
+                          m.field.decode(), m.data_diff.size(), m.length);
 }
 WEBCFACE_MESSAGE_FMT_DEF(
     webcface::message::Res<webcface::message::Canvas3DOld>) {
     return fmt::format_to(
         ctx.out(), "{}-Canvas3DOldRes(req_id={} + '{}', {} diffs, length={})",
-        msg_kind, m.req_id, m.sub_field.decode().std(), m.data_diff.size(),
-        m.length);
+        msg_kind, m.req_id, m.sub_field.decode(), m.data_diff.size(), m.length);
 }
 WEBCFACE_MESSAGE_FMT_DEF_ENTRY(Canvas3DOld)
 WEBCFACE_MESSAGE_FMT_DEF_REQ(Canvas3DOld)
 
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Canvas2D) {
     return fmt::format_to(ctx.out(), "{}-Canvas2D('{}', {} x {}, {} diffs)",
-                          msg_kind, m.field.decode().std(), m.width, m.height,
+                          msg_kind, m.field.decode(), m.width, m.height,
                           m.data_diff.size());
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Res<webcface::message::Canvas2D>) {
     return fmt::format_to(ctx.out(),
                           "{}-Canvas2DRes(req_id={} + '{}', {} x {}, {} diffs)",
-                          msg_kind, m.req_id, m.sub_field.decode().std(),
-                          m.width, m.height, m.data_diff.size());
+                          msg_kind, m.req_id, m.sub_field.decode(), m.width,
+                          m.height, m.data_diff.size());
 }
 WEBCFACE_MESSAGE_FMT_DEF_ENTRY(Canvas2D)
 WEBCFACE_MESSAGE_FMT_DEF_REQ(Canvas2D)
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Canvas2DOld) {
     return fmt::format_to(ctx.out(),
                           "{}-Canvas2DOld('{}', {} x {}, {} diffs, length={})",
-                          msg_kind, m.field.decode().std(), m.width, m.height,
+                          msg_kind, m.field.decode(), m.width, m.height,
                           m.data_diff.size(), m.length);
 }
 WEBCFACE_MESSAGE_FMT_DEF(
@@ -278,7 +274,7 @@ WEBCFACE_MESSAGE_FMT_DEF(
     return fmt::format_to(
         ctx.out(),
         "{}-Canvas2DOldRes(req_id={} + '{}', {} x {}, {} diffs, length={})",
-        msg_kind, m.req_id, m.sub_field.decode().std(), m.width, m.height,
+        msg_kind, m.req_id, m.sub_field.decode(), m.width, m.height,
         m.data_diff.size(), m.length);
 }
 WEBCFACE_MESSAGE_FMT_DEF_ENTRY(Canvas2DOld)
@@ -288,7 +284,7 @@ WEBCFACE_MESSAGE_FMT_DEF(webcface::message::FuncInfo) {
     return fmt::format_to(
         ctx.out(),
         "{}-FuncInfo('{}' from member_id={}, index={}, {} args, return={})",
-        msg_kind, m.field.decode().std(), m.member_id, m.index, m.args.size(),
+        msg_kind, m.field.decode(), m.member_id, m.index, m.args.size(),
         webcface::valTypeStr(m.return_type));
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Call) {
@@ -296,8 +292,7 @@ WEBCFACE_MESSAGE_FMT_DEF(webcface::message::Call) {
                           "{}-Call(caller_id={} from member_id={}, to '{}' of "
                           "member_id={}, {} args)",
                           msg_kind, m.caller_id, m.caller_member_id,
-                          m.field.decode().std(), m.target_member_id,
-                          m.args.size());
+                          m.field.decode(), m.target_member_id, m.args.size());
 }
 WEBCFACE_MESSAGE_FMT_DEF(webcface::message::CallResponse) {
     return fmt::format_to(

--- a/common/src/val_adaptor.cc
+++ b/common/src/val_adaptor.cc
@@ -17,10 +17,10 @@ ValAdaptor &ValAdaptor::operator=(const SharedString &str) {
     return *this;
 }
 
-ValAdaptor::ValAdaptor(String str)
+ValAdaptor::ValAdaptor(StringInitializer str)
     : as_str(std::move(static_cast<SharedString &>(str))),
       type(ValType::string_) {}
-ValAdaptor &ValAdaptor::operator=(String str) {
+ValAdaptor &ValAdaptor::operator=(StringInitializer str) {
     as_str = std::move(static_cast<SharedString &>(str));
     type = ValType::string_;
     return *this;

--- a/common/src/val_adaptor.cc
+++ b/common/src/val_adaptor.cc
@@ -89,21 +89,21 @@ void ValAdaptor::initWStr() const {
 }
 StringView ValAdaptor::asStringView() const {
     initStr();
-    return as_str.decode();
+    return as_str.decodeShare();
 }
 WStringView ValAdaptor::asWStringView() const {
     initWStr();
-    return as_str.decodeW();
+    return as_str.decodeShareW();
 }
 
-StringView ValAdaptor::asU8StringView() const {
+std::string_view ValAdaptor::asU8StringView() const {
     initStr();
     return as_str.u8StringView();
 }
 
 double ValAdaptor::asDouble() const {
     if (type == ValType::string_) {
-        return std::atof(asU8StringView().c_str());
+        return std::atof(asU8StringView().data());
     } else {
         switch (as_val.index()) {
         case DOUBLEV:
@@ -115,7 +115,7 @@ double ValAdaptor::asDouble() const {
 }
 int ValAdaptor::asInt() const {
     if (type == ValType::string_) {
-        return std::atoi(asU8StringView().c_str());
+        return std::atoi(asU8StringView().data());
     } else {
         switch (as_val.index()) {
         case DOUBLEV:
@@ -127,7 +127,7 @@ int ValAdaptor::asInt() const {
 }
 long long ValAdaptor::asLLong() const {
     if (type == ValType::string_) {
-        return std::atoll(asU8StringView().c_str());
+        return std::atoll(asU8StringView().data());
     } else {
         switch (as_val.index()) {
         case DOUBLEV:

--- a/common/src/val_adaptor.cc
+++ b/common/src/val_adaptor.cc
@@ -27,18 +27,18 @@ ValAdaptor &ValAdaptor::operator=(StringInitializer str) {
 }
 
 template <typename Bool,
-          typename std::enable_if_t<std::is_same_v<Bool, bool>, std::nullptr_t>>
+          typename std::enable_if_t<std::is_same_v<Bool, bool>, bool>>
 ValAdaptor::ValAdaptor(Bool value)
     : as_val(static_cast<std::int64_t>(value)), type(ValType::bool_) {}
 template <typename Bool,
-          typename std::enable_if_t<std::is_same_v<Bool, bool>, std::nullptr_t>>
+          typename std::enable_if_t<std::is_same_v<Bool, bool>, bool>>
 ValAdaptor &ValAdaptor::operator=(Bool v) {
     as_val.emplace<INT64V>(v);
     type = ValType::bool_;
     return *this;
 }
 template WEBCFACE_DLL ValAdaptor::ValAdaptor(bool value);
-template WEBCFACE_DLL ValAdaptor &ValAdaptor::operator= <bool, nullptr>(bool v);
+template WEBCFACE_DLL ValAdaptor &ValAdaptor::operator= <bool, true>(bool v);
 
 ValAdaptor::ValAdaptor(std::int64_t value)
     : as_val(value), type(ValType::int_) {}

--- a/common/src/val_adaptor.cc
+++ b/common/src/val_adaptor.cc
@@ -1,5 +1,6 @@
 #include "webcface/common/val_adaptor.h"
 #include <cassert>
+#include <cstdlib>
 
 WEBCFACE_NS_BEGIN
 ValAdaptor::ValAdaptor() : type(ValType::none_) {}
@@ -124,11 +125,7 @@ const std::string &ValAdaptor::asU8StringRef() const {
 
 double ValAdaptor::asDouble() const {
     if (type == ValType::string_) {
-        try {
-            return std::stod(asU8StringView().c_str());
-        } catch (...) {
-            return 0;
-        }
+        return std::atof(asU8StringView().c_str());
     } else {
         switch (as_val.index()) {
         case DOUBLEV:
@@ -140,11 +137,7 @@ double ValAdaptor::asDouble() const {
 }
 int ValAdaptor::asInt() const {
     if (type == ValType::string_) {
-        try {
-            return std::stoi(asU8StringView().c_str());
-        } catch (...) {
-            return 0;
-        }
+        return std::atoi(asU8StringView().c_str());
     } else {
         switch (as_val.index()) {
         case DOUBLEV:
@@ -156,11 +149,7 @@ int ValAdaptor::asInt() const {
 }
 long long ValAdaptor::asLLong() const {
     if (type == ValType::string_) {
-        try {
-            return std::stoll(asU8StringView().c_str());
-        } catch (...) {
-            return 0;
-        }
+        return std::atoll(asU8StringView().c_str());
     } else {
         switch (as_val.index()) {
         case DOUBLEV:

--- a/common/src/val_adaptor.cc
+++ b/common/src/val_adaptor.cc
@@ -30,15 +30,15 @@ template <typename Bool,
           typename std::enable_if_t<std::is_same_v<Bool, bool>, bool>>
 ValAdaptor::ValAdaptor(Bool value)
     : as_val(static_cast<std::int64_t>(value)), type(ValType::bool_) {}
-template <typename Bool,
-          typename std::enable_if_t<std::is_same_v<Bool, bool>, bool>>
-ValAdaptor &ValAdaptor::operator=(Bool v) {
+template <typename Bool>
+auto ValAdaptor::operator=(Bool v)
+    -> std::enable_if_t<std::is_same_v<Bool, bool>, ValAdaptor &> {
     as_val.emplace<INT64V>(v);
     type = ValType::bool_;
     return *this;
 }
 template WEBCFACE_DLL ValAdaptor::ValAdaptor(bool value);
-template WEBCFACE_DLL ValAdaptor &ValAdaptor::operator= <bool, true>(bool v);
+template WEBCFACE_DLL ValAdaptor &ValAdaptor::operator= <bool>(bool v);
 
 ValAdaptor::ValAdaptor(std::int64_t value)
     : as_val(value), type(ValType::int_) {}

--- a/common/src/val_adaptor.cc
+++ b/common/src/val_adaptor.cc
@@ -1,4 +1,5 @@
 #include "webcface/common/val_adaptor.h"
+#include <cassert>
 
 WEBCFACE_NS_BEGIN
 ValAdaptor::ValAdaptor() : type(ValType::none_) {}

--- a/common/src/val_adaptor.cc
+++ b/common/src/val_adaptor.cc
@@ -80,62 +80,51 @@ void ValAdaptor::initWStr() const {
         }
     }
 }
-std::string_view ValAdaptor::asStringView() const {
+StringView ValAdaptor::asStringView() const {
     initStr();
-    return as_str.decode().std();
-}
-const char *ValAdaptor::asCStr() const {
-    initStr();
-    return as_str.decode().c_str;
+    return as_str.decode();
 }
 const std::string &ValAdaptor::asStringRef() const {
     initStr();
-    if (!as_str.decode().container) {
+    if (!as_str.decode().container()) {
         // std::stringコンテナを使用しないポインタを保持していた場合、コピーを作成して上書き
-        as_str = SharedString::fromU8String(
-            std::string(as_str.u8StringView().std()));
-        assert(as_str.decode().container);
+        as_str = SharedString::fromU8String(std::string(as_str.u8StringView()));
+        assert(as_str.decode().container());
     }
-    return *as_str.decode().container;
+    return *as_str.decode().container();
 }
-std::wstring_view ValAdaptor::asWStringView() const {
+WStringView ValAdaptor::asWStringView() const {
     initWStr();
-    return as_str.decodeW().std();
-}
-const wchar_t *ValAdaptor::asWCStr() const {
-    initWStr();
-    return as_str.decodeW().c_str;
+    return as_str.decodeW();
 }
 const std::wstring &ValAdaptor::asWStringRef() const {
     initWStr();
-    if (!as_str.decodeW().container) {
+    if (!as_str.decodeW().container()) {
         // std::stringコンテナを使用しないポインタを保持していた場合、コピーを作成して上書き
-        as_str = SharedString::fromU8String(
-            std::string(as_str.u8StringView().std()));
-        assert(as_str.decodeW().container);
+        as_str = SharedString::fromU8String(std::string(as_str.u8StringView()));
+        assert(as_str.decodeW().container());
     }
-    return *as_str.decodeW().container;
+    return *as_str.decodeW().container();
 }
 
-std::string_view ValAdaptor::asU8StringView() const {
+StringView ValAdaptor::asU8StringView() const {
     initStr();
-    return as_str.u8StringView().std();
+    return as_str.u8StringView();
 }
 const std::string &ValAdaptor::asU8StringRef() const {
     initStr();
-    if (!as_str.u8StringView().container) {
+    if (!as_str.u8StringView().container()) {
         // std::stringコンテナを使用しないポインタを保持していた場合、コピーを作成して上書き
-        as_str = SharedString::fromU8String(
-            std::string(as_str.u8StringView().std()));
-        assert(as_str.u8StringView().container);
+        as_str = SharedString::fromU8String(std::string(as_str.u8StringView()));
+        assert(as_str.u8StringView().container());
     }
-    return *as_str.u8StringView().container;
+    return *as_str.u8StringView().container();
 }
 
 double ValAdaptor::asDouble() const {
     if (type == ValType::string_) {
         try {
-            return std::stod(asCStr());
+            return std::stod(asU8StringView().c_str());
         } catch (...) {
             return 0;
         }
@@ -151,7 +140,7 @@ double ValAdaptor::asDouble() const {
 int ValAdaptor::asInt() const {
     if (type == ValType::string_) {
         try {
-            return std::stoi(asCStr());
+            return std::stoi(asU8StringView().c_str());
         } catch (...) {
             return 0;
         }
@@ -167,7 +156,7 @@ int ValAdaptor::asInt() const {
 long long ValAdaptor::asLLong() const {
     if (type == ValType::string_) {
         try {
-            return std::stoll(asCStr());
+            return std::stoll(asU8StringView().c_str());
         } catch (...) {
             return 0;
         }

--- a/common/src/val_adaptor.cc
+++ b/common/src/val_adaptor.cc
@@ -1,5 +1,4 @@
 #include "webcface/common/val_adaptor.h"
-#include <cassert>
 #include <cstdlib>
 
 WEBCFACE_NS_BEGIN
@@ -86,41 +85,14 @@ StringView ValAdaptor::asStringView() const {
     initStr();
     return as_str.decode();
 }
-const std::string &ValAdaptor::asStringRef() const {
-    initStr();
-    if (!as_str.decode().container()) {
-        // std::stringコンテナを使用しないポインタを保持していた場合、コピーを作成して上書き
-        as_str = SharedString::fromU8String(std::string(as_str.u8StringView()));
-        assert(as_str.decode().container());
-    }
-    return *as_str.decode().container();
-}
 WStringView ValAdaptor::asWStringView() const {
     initWStr();
     return as_str.decodeW();
-}
-const std::wstring &ValAdaptor::asWStringRef() const {
-    initWStr();
-    if (!as_str.decodeW().container()) {
-        // std::stringコンテナを使用しないポインタを保持していた場合、コピーを作成して上書き
-        as_str = SharedString::fromU8String(std::string(as_str.u8StringView()));
-        assert(as_str.decodeW().container());
-    }
-    return *as_str.decodeW().container();
 }
 
 StringView ValAdaptor::asU8StringView() const {
     initStr();
     return as_str.u8StringView();
-}
-const std::string &ValAdaptor::asU8StringRef() const {
-    initStr();
-    if (!as_str.u8StringView().container()) {
-        // std::stringコンテナを使用しないポインタを保持していた場合、コピーを作成して上書き
-        as_str = SharedString::fromU8String(std::string(as_str.u8StringView()));
-        assert(as_str.u8StringView().container());
-    }
-    return *as_str.u8StringView().container();
 }
 
 double ValAdaptor::asDouble() const {

--- a/common/src/val_adaptor.cc
+++ b/common/src/val_adaptor.cc
@@ -26,13 +26,19 @@ ValAdaptor &ValAdaptor::operator=(String str) {
     return *this;
 }
 
-ValAdaptor::ValAdaptor(bool value)
+template <typename Bool,
+          typename std::enable_if_t<std::is_same_v<Bool, bool>, std::nullptr_t>>
+ValAdaptor::ValAdaptor(Bool value)
     : as_val(static_cast<std::int64_t>(value)), type(ValType::bool_) {}
-ValAdaptor &ValAdaptor::operator=(bool v) {
+template <typename Bool,
+          typename std::enable_if_t<std::is_same_v<Bool, bool>, std::nullptr_t>>
+ValAdaptor &ValAdaptor::operator=(Bool v) {
     as_val.emplace<INT64V>(v);
     type = ValType::bool_;
     return *this;
 }
+template WEBCFACE_DLL ValAdaptor::ValAdaptor(bool value);
+template WEBCFACE_DLL ValAdaptor &ValAdaptor::operator= <bool, nullptr>(bool v);
 
 ValAdaptor::ValAdaptor(std::int64_t value)
     : as_val(value), type(ValType::int_) {}

--- a/docs/11_tutorial_vis.md
+++ b/docs/11_tutorial_vis.md
@@ -396,7 +396,7 @@ C++でMesonやCMakeを使わない場合、pkg-configを使ったり手動でコ
 
     * こんどは引数がある関数を作ってみます。
     ```cpp
-    int fuga(int a, const std::string &b) {
+    int fuga(int a, std::string_view b) {
         logger << "Function fuga(" << a << ", " << b << ") started" << std::endl;
         return a;
     }

--- a/docs/12_tutorial_comm.md
+++ b/docs/12_tutorial_comm.md
@@ -297,7 +297,8 @@ C++でMesonやCMakeを使わない場合、pkg-configを使ったり手動でコ
             }
 
             // "tutorial-send" が送信している "message" という名前のTextデータをリクエスト & 取得
-            std::optional<std::string> message = wcli.member("tutorial-send").text("message").tryGet();
+            // webcface::StringView は通常のstringやstring_viewやconst char*にキャストすることもできます (ver2.10〜)
+            std::optional<webcface::StringView> message = wcli.member("tutorial-send").text("message").tryGet();
             if (message.has_value()){
                 std::cout << "message = " << *message << std::endl;
             } else {
@@ -613,7 +614,7 @@ C++でMesonやCMakeを使わない場合、pkg-configを使ったり手動でコ
 
     * send.cc
     ```cpp
-    int fuga(int a, const std::string &b) {
+    int fuga(int a, std::string_view b) {
         logger << "Function fuga(" << a << ", " << b << ") started" << std::endl;
         return a;
     }

--- a/docs/52_text.md
+++ b/docs/52_text.md
@@ -125,21 +125,25 @@ wcli.text("a").set(a_instance); // Dictにキャストされる
     例えば`foo`というクライアントの`hoge`という名前のデータを取得したい場合は次のようにします。
 
     ```cpp
+    // ver2.10〜
+    std::optional<webcface::StringView> hoge = wcli.member("foo").text("hoge").tryGet();
+    // それ以前
     std::optional<std::string> hoge = wcli.member("foo").text("hoge").tryGet();
     ```
+    * <span class="since-c">2.10</span> webcface::StringView は文字列への参照をshared_ptrで保持しています。そのため文字列のコピーは発生せず、寿命が切れることもありません。
+        * std::string_view へキャストできます。
+        * std::string が必要な場合、またはver2.9以前との互換性を維持したい場合は明示的にstd::stringのコンストラクタに渡せばよいです(コピーが必要になります)
     * 値をまだ受信していない場合 tryGet() はstd::nulloptを返し、そのデータのリクエストをサーバーに送ります。
         * リクエストは <del>次にClient::sync()したときに</del>
         <span class="since-c">1.2</span>自動的に別スレッドで送信されます。
         * そのデータを受信した後([4-1. Client](./41_client.md)を参照)、再度tryGet()することで値が得られます。
     * Text::get() はstd::nulloptの代わりに空文字列を返します。
-    * また、std::string にキャストすることでも同様に値が得られます。
 
     <span class="since-c">1.7</span>
     Text::request() で明示的にリクエストを送信することもできます。
 
     <span class="since-c">2.0</span>
     ワイド文字列は tryGetW(), getW() で得られます。
-    また、std::wstring にキャストすることでも得られます。
 
     std::ostreamにTextを直接渡して表示することもできます。
     ```cpp

--- a/docs/53_func.md
+++ b/docs/53_func.md
@@ -27,7 +27,8 @@
     void hoge() {
         std::cout << "hello, world!" << std::endl;
     }
-    double fuga(int a, const std::string &b) {
+    double fuga(int a, std::string_view b) {
+        // ver2.9以前は const std::string & b
         return 3.1415;
     }
     wcli.func("hoge").set(hoge);
@@ -54,6 +55,13 @@
         return "hello";
     });
     ```
+
+    \note
+    * <span class="since-c">2.10</span>
+    WebCFaceが文字列データを管理する際 std::string を用いないようになったため、
+    std::string で文字列を受け取ると(const参照であっても)コピーが発生します。
+    std::string_view または webcface::StringView を用いると効率的です
+        * ただしver2.9以前では std::string_view 引数の関数をsetできないため、互換性を維持する必要があるなら const std::string & にしましょう
 
     <!--
     <span class="since-c">2.0</span>
@@ -499,8 +507,9 @@ Client::funcEntries()でその関数の存在を確認したりFunc::args()な�
     * その関数がまだ呼び出されていない場合はstd::nulloptが返ります。
     * 関数が呼び出された場合、 CallHandle::args() で呼び出された引数を取得できます。
         * 各引数は ValAdaptor 型で取得でき、
-        `asStringRef()`, `asString()`, `asBool()`, <del>`as<double>()`</del>,
-        <span class="since-c">2.0</span> `asWStringRef()`, `asWString()`, `asDouble()`, `asInt()`, `asLLong()`
+        <del>`asStringRef()`</del>, `asString()`, `asBool()`, <del>`as<double>()`</del>,
+        <span class="since-c">2.0</span> <del>`asWStringRef()`</del>, `asWString()`, `asDouble()`, `asInt()`, `asLLong()`,
+        <span class="since-c">2.10</span> `asStringView()`, `asWStringView()`
         で型を指定して取得できます。
         * (std::string, double, bool などの型にキャストすることでも値を得られます。)
         * listen時に指定した引数の個数と呼び出し時の個数が一致しない場合、fetchCallで取得する前に呼び出し元に例外が投げられます
@@ -683,7 +692,8 @@ Funcが登録された順番(index)は送信側のクライアントライブラ
         For, Until の場合はタイムアウトを指定します。
     * response(): 関数の戻り値です。
     webcface::ValAdaptor 型で返り、
-    `asStringRef()`, `asString()`, `asWStringRef()`, `asWString()`, `asBool()`, `asDouble()`, `asInt()`, `asLLong()`
+    <del>`asStringRef()`</del>, `asString()`, <del>`asWStringRef()`</del>, `asWString()`, `asBool()`, `asDouble()`, `asInt()`, `asLLong()`,
+    <span class="since-c">2.10</span> `asStringView()`, `asWStringView()`
     またはstatic_castにより型変換できます。
     * rejection(), rejectionW(): 関数が例外を返した場合そのエラーメッセージを表す文字列です。
     またその場合 isError() がtrueになります。
@@ -968,8 +978,10 @@ res.onResult().append([](std::shared_future<webcface::ValAdaptor> result){
 
     戻り値は webcface::ValAdaptor 型で返ります。
     整数、実数、bool、stringにキャストできます。  
-    <span class="since-c">1.10</span> また、明示的にキャストするなら `asStringRef()`(const参照), `asString()`, `asBool()`, <del>`as<整数or実数型>()`</del> も使えます。  
-    <span class="since-c">2.0</span> `asWStringRef()`, `asWString()`, `asDouble()`, `asInt()`, `asLLong()` も使えます。
+    <span class="since-c">1.10</span> また、明示的にキャストするなら <del>`asStringRef()`(const参照)</del>, `asString()`, `asBool()`, <del>`as<整数or実数型>()`</del> も使えます。  
+    <span class="since-c">2.0</span> <del>`asWStringRef()`</del>, `asWString()`, `asDouble()`, `asInt()`, `asLLong()`,
+    <span class="since-c">2.10</span> `asStringView()`, `asWStringView()`
+    も使えます。
 
     \warning
     start()を呼んで通信を開始する前にrun()を呼び出してしまうとデッドロックします。

--- a/docs/54_view.md
+++ b/docs/54_view.md
@@ -161,7 +161,7 @@ Viewに追加する各種要素をViewComponentといいます。
     引数にView(コピーまたはconst参照)を取る関数オブジェクトをViewに渡すと、その場でその関数が呼び出されます。
     複数のViewComponentを出力する処理をまとめて使いまわしたい場合に便利です。
     ```cpp
-    auto showNameAndValue(const std::string &name, int value) {
+    auto showNameAndValue(std::string_view name, int value) {
         return [=](const webcface::View &view) {
             view << name << " = " << value;
         };
@@ -441,8 +441,9 @@ viewに入力欄を表示します。
 
     <span class="since-c">1.11</span>
     InputRefの値は
-    `asStringRef()`, `asString()`, `asBool()`, <del>`as<double>()`</del> で型を指定して取得できます。  
-    <span class="since-c">2.0</span> `asWStringRef()`, `asWString()`, `asDouble()`, `asInt()`, `asLLong()` も使えます。  
+    <del>`asStringRef()`</del>, `asString()`, `asBool()`, <del>`as<double>()`</del> で型を指定して取得できます。  
+    <span class="since-c">2.0</span> <del>`asWStringRef()`</del>, `asWString()`, `asDouble()`, `asInt()`, `asLLong()` も使えます。  
+    <span class="since-c">2.10</span> `asStringView()`, `asWStringView()` も使えます。  
     (std::string, double, bool などの型にキャストすることでも値を得られます。)  
     (任意の型に対応したい場合は `get()` で webcface::ValAdaptor 型として取得できます。)
 
@@ -538,7 +539,8 @@ viewに入力欄を表示します。
     onChange() で値が入力されたときに実行する関数を設定でき、こちらでも値が取得できます。
     buttonに渡す関数と同様、関数オブジェクト、Funcオブジェクト、FuncListenerオブジェクトが使用できます。
     ```cpp
-    v << webcface::textInput("表示する文字列").id("input1").onChange([](std::string val) {
+    v << webcface::textInput("表示する文字列").id("input1").onChange([](std::string_view val) {
+        // ver2.9以前: const std::string & val
         std::cout << "input changed: " << val << std::endl;
     });
     ```

--- a/examples/func.cc
+++ b/examples/func.cc
@@ -36,8 +36,8 @@ int main() {
     });
 
     // 引数型が非対応の場合:
-    // ↓ error: no type named ArgTypesSupportedByWebCFaceFunc
-    //           in webcface::FuncArgTypesTrait<std::nullptr_t, int>
+    // ↓ error: no type named ArgTypesCheckOk in
+    //           webcface::traits::This_arg_is_not_supported_by_WebCFace_Func<std::nullptr_t>
     // wcli.func("nyan").set([](std::nullptr_t, int) {});
 
     wcli.loopSync();

--- a/examples/recv.cc
+++ b/examples/recv.cc
@@ -50,7 +50,7 @@ int main() {
         auto result = func_m.func("func2").runAsync(9, 7.1, false, "");
         result.onFinish([](const webcface::Promise &result) {
             std::cout << "func2(9, 7.1, false, \"\") = "
-                      << result.response().asStringRef() << std::endl;
+                      << result.response().asStringView() << std::endl;
         });
 
         func_m.func("func_bool").runAsync(true);

--- a/examples/tutorial-recv.cc
+++ b/examples/tutorial-recv.cc
@@ -50,7 +50,7 @@ int main() {
             std::cout << "data is null" << std::endl;
         }
 
-        std::optional<std::string> message =
+        std::optional<webcface::StringView> message =
             wcli.member("tutorial-send").text("message").tryGet();
         if (message.has_value()) {
             std::cout << "message = " << *message << std::endl;

--- a/examples/tutorial-send.cc
+++ b/examples/tutorial-send.cc
@@ -11,7 +11,7 @@ int hoge() {
     std::cout << "Function hoge started" << std::endl;
     return 42;
 }
-int fuga(int a, const std::string &b) {
+int fuga(int a, std::string_view b) {
     std::cout << "Function fuga(" << a << ", " << b << ") started" << std::endl;
     return a;
 }

--- a/examples/tutorial-vis.cc
+++ b/examples/tutorial-vis.cc
@@ -14,7 +14,7 @@ int hoge() {
     logger << "Function hoge started" << std::endl;
     return 42;
 }
-int fuga(int a, const std::string &b) {
+int fuga(int a, std::string_view b) {
     logger << "Function fuga(" << a << ", " << b << ") started" << std::endl;
     return a;
 }

--- a/server-store/include/webcface/server/member_data.h
+++ b/server-store/include/webcface/server/member_data.h
@@ -62,7 +62,7 @@ struct MemberData {
      *
      */
     internal::StrMap1<MutableNumVector> value;
-    internal::StrMap1<std::shared_ptr<ValAdaptor>> text;
+    internal::StrMap1<ValAdaptor> text;
     internal::StrMap1<std::shared_ptr<message::FuncInfo>> func;
     internal::StrMap1<message::ViewData> view;
     internal::StrMap1<message::Canvas3DData> canvas3d;

--- a/tests/c_wcf_test.cc
+++ b/tests/c_wcf_test.cc
@@ -139,7 +139,7 @@ TEST_F(CClientTest, valueSend) {
     EXPECT_EQ(wcfValueSet(wcli_, "a", 5), WCF_OK);
     EXPECT_EQ(wcfSync(wcli_), WCF_OK);
     dummy_s->waitRecv<message::Value>([&](const auto &obj) {
-        EXPECT_EQ(obj.field.u8String(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "a");
         EXPECT_EQ(obj.data.size(), 1u);
         EXPECT_EQ(obj.data.at(0), 5);
     });
@@ -149,7 +149,7 @@ TEST_F(CClientTest, valueSend) {
     EXPECT_EQ(wcfValueSetVecD(wcli_, "b", b, 3), WCF_OK);
     EXPECT_EQ(wcfSync(wcli_), WCF_OK);
     dummy_s->waitRecv<message::Value>([&](const auto &obj) {
-        EXPECT_EQ(obj.field.u8String(), "b");
+        EXPECT_EQ(obj.field.u8StringView(), "b");
         EXPECT_EQ(obj.data.size(), 3u);
         EXPECT_EQ(obj.data.at(0), 1);
         EXPECT_EQ(obj.data.at(1), 1.5);
@@ -173,17 +173,15 @@ TEST_F(CClientTest, valueReq) {
     EXPECT_EQ(value1, 0);
     EXPECT_EQ(wcfStart(wcli_), WCF_OK);
     dummy_s->waitRecv<message::Req<message::Value>>([&](const auto &obj) {
-        EXPECT_EQ(obj.member.u8String(), "a");
-        EXPECT_EQ(obj.field.u8String(), "b");
+        EXPECT_EQ(obj.member.u8StringView(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "b");
         EXPECT_EQ(obj.req_id, 1u);
     });
     dummy_s->send(message::Res<message::Value>{
-        1, ""_ss,
-        MutableNumVector(std::vector<double>{1, 1.5, 2})});
+        1, ""_ss, MutableNumVector(std::vector<double>{1, 1.5, 2})});
     EXPECT_EQ(wcfLoopSyncFor(wcli_, WEBCFACE_TEST_TIMEOUT * 1000), WCF_OK);
     dummy_s->send(message::Res<message::Value>{
-        1, "c"_ss,
-        MutableNumVector(std::vector<double>{1, 1.5, 2})});
+        1, "c"_ss, MutableNumVector(std::vector<double>{1, 1.5, 2})});
     EXPECT_EQ(wcfLoopSyncFor(wcli_, WEBCFACE_TEST_TIMEOUT * 1000), WCF_OK);
     EXPECT_EQ(wcfValueGetVecD(wcli_, "a", "b", value, 5, &size), WCF_OK);
     EXPECT_EQ(size, 3);
@@ -209,16 +207,16 @@ TEST_F(CClientTest, textSend) {
     EXPECT_EQ(wcfTextSet(wcli_, "a", "hello"), WCF_OK);
     EXPECT_EQ(wcfSync(wcli_), WCF_OK);
     dummy_s->waitRecv<message::Text>([&](const auto &obj) {
-        EXPECT_EQ(obj.field.u8String(), "a");
-        EXPECT_EQ(*obj.data, "hello");
+        EXPECT_EQ(obj.field.u8StringView(), "a");
+        EXPECT_EQ(obj.data, "hello");
     });
     dummy_s->recvClear();
 
     EXPECT_EQ(wcfTextSetN(wcli_, "b", "hellohello", 5), WCF_OK);
     EXPECT_EQ(wcfSync(wcli_), WCF_OK);
     dummy_s->waitRecv<message::Text>([&](const auto &obj) {
-        EXPECT_EQ(obj.field.u8String(), "b");
-        EXPECT_EQ(*obj.data, "hello");
+        EXPECT_EQ(obj.field.u8StringView(), "b");
+        EXPECT_EQ(obj.data, "hello");
     });
     dummy_s->recvClear();
 }
@@ -231,15 +229,13 @@ TEST_F(CClientTest, textReq) {
     EXPECT_EQ(text[0], 0);
     EXPECT_EQ(wcfStart(wcli_), WCF_OK);
     dummy_s->waitRecv<message::Req<message::Text>>([&](const auto &obj) {
-        EXPECT_EQ(obj.member.u8String(), "a");
-        EXPECT_EQ(obj.field.u8String(), "b");
+        EXPECT_EQ(obj.member.u8StringView(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "b");
         EXPECT_EQ(obj.req_id, 1u);
     });
-    dummy_s->send(message::Res<message::Text>{
-        1, ""_ss, std::make_shared<ValAdaptor>("hello")});
+    dummy_s->send(message::Res<message::Text>{1, ""_ss, ValAdaptor("hello")});
     EXPECT_EQ(wcfLoopSyncFor(wcli_, WEBCFACE_TEST_TIMEOUT * 1000), WCF_OK);
-    dummy_s->send(message::Res<message::Text>{
-        1, "c"_ss, std::make_shared<ValAdaptor>("hello")});
+    dummy_s->send(message::Res<message::Text>{1, "c"_ss, ValAdaptor("hello")});
     EXPECT_EQ(wcfLoopSyncFor(wcli_, WEBCFACE_TEST_TIMEOUT * 1000), WCF_OK);
     EXPECT_EQ(wcfTextGet(wcli_, "a", "b", text, 5, &size), WCF_OK);
     EXPECT_EQ(size, 5);
@@ -313,7 +309,7 @@ TEST_F(CClientTest, funcRun) {
         dummy_s->waitRecv<message::Call>([&](const auto &obj) {
             EXPECT_EQ(obj.caller_id, caller_id);
             EXPECT_EQ(obj.target_member_id, 0u);
-            EXPECT_EQ(obj.field.u8String(), "b");
+            EXPECT_EQ(obj.field.u8StringView(), "b");
             EXPECT_EQ(obj.args.size(), 3u);
             EXPECT_EQ(static_cast<int>(obj.args.at(0)), 42);
             EXPECT_EQ(static_cast<double>(obj.args.at(1)), 1.5);
@@ -331,7 +327,7 @@ TEST_F(CClientTest, funcRun) {
         dummy_s->waitRecv<message::Call>([&](const auto &obj) {
             EXPECT_EQ(obj.caller_id, caller_id);
             EXPECT_EQ(obj.target_member_id, 0u);
-            EXPECT_EQ(obj.field.u8String(), "b");
+            EXPECT_EQ(obj.field.u8StringView(), "b");
             EXPECT_EQ(obj.args.size(), 3u);
         });
         dummy_s->recvClear();
@@ -348,7 +344,7 @@ TEST_F(CClientTest, funcRun) {
         dummy_s->waitRecv<message::Call>([&](const auto &obj) {
             EXPECT_EQ(obj.caller_id, caller_id);
             EXPECT_EQ(obj.target_member_id, 0u);
-            EXPECT_EQ(obj.field.u8String(), "b");
+            EXPECT_EQ(obj.field.u8StringView(), "b");
             EXPECT_EQ(obj.args.size(), 3u);
         });
         dummy_s->recvClear();
@@ -371,7 +367,7 @@ TEST_F(CClientTest, funcListen) {
     wcfFuncListen(wcli_, "a", arg_types, 3, WCF_VAL_INT);
     EXPECT_EQ(wcfSync(wcli_), WCF_OK);
     dummy_s->waitRecv<message::FuncInfo>([&](const auto &obj) {
-        EXPECT_EQ(obj.field.u8String(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "a");
         EXPECT_EQ(obj.return_type, ValType::int_);
         ASSERT_EQ(obj.args.size(), 3u);
         EXPECT_EQ(obj.args.at(0)->type_, ValType::int_);
@@ -444,7 +440,7 @@ TEST_F(CClientTest, funcSet) {
     wcfFuncSet(wcli_, "a", arg_types, 3, WCF_VAL_INT, callbackFunc, &u);
     EXPECT_EQ(wcfSync(wcli_), WCF_OK);
     dummy_s->waitRecv<message::FuncInfo>([&](const auto &obj) {
-        EXPECT_EQ(obj.field.u8String(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "a");
         EXPECT_EQ(obj.return_type, ValType::int_);
         ASSERT_EQ(obj.args.size(), 3u);
         EXPECT_EQ(obj.args.at(0)->type_, ValType::int_);
@@ -495,7 +491,7 @@ TEST_F(CClientTest, funcSetAsync) {
     wcfFuncSetAsync(wcli_, "a", arg_types, 3, WCF_VAL_INT, callbackFunc, &u);
     EXPECT_EQ(wcfSync(wcli_), WCF_OK);
     dummy_s->waitRecv<message::FuncInfo>([&](const auto &obj) {
-        EXPECT_EQ(obj.field.u8String(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "a");
         EXPECT_EQ(obj.return_type, ValType::int_);
         ASSERT_EQ(obj.args.size(), 3u);
         EXPECT_EQ(obj.args.at(0)->type_, ValType::int_);
@@ -533,32 +529,32 @@ TEST_F(CClientTest, viewSend) {
     EXPECT_EQ(wcfViewSet(wcli_, "b", vc, 4), WCF_OK);
     EXPECT_EQ(wcfSync(wcli_), WCF_OK);
     dummy_s->waitRecv<message::View>([&](auto obj) {
-        EXPECT_EQ(obj.field.u8String(), "b");
+        EXPECT_EQ(obj.field.u8StringView(), "b");
         EXPECT_EQ(obj.data_ids->size(), 6u);
         EXPECT_EQ(obj.data_diff.size(), 6u);
         EXPECT_EQ(obj.data_diff["..0.0"]->type,
                   static_cast<int>(ViewComponentType::text));
-        EXPECT_EQ(obj.data_diff["..0.0"]->text.u8String(), "abc");
+        EXPECT_EQ(obj.data_diff["..0.0"]->text.u8StringView(), "abc");
         EXPECT_EQ(obj.data_diff["..1.0"]->type,
                   static_cast<int>(ViewComponentType::new_line));
         EXPECT_EQ(obj.data_diff["..0.1"]->type,
                   static_cast<int>(ViewComponentType::text));
-        EXPECT_EQ(obj.data_diff["..0.1"]->text.u8String(), "123");
+        EXPECT_EQ(obj.data_diff["..0.1"]->text.u8StringView(), "123");
 
         EXPECT_EQ(obj.data_diff["..1.1"]->type,
                   static_cast<int>(ViewComponentType::new_line));
 
         EXPECT_EQ(obj.data_diff["..2.0"]->type,
                   static_cast<int>(ViewComponentType::button));
-        EXPECT_EQ(obj.data_diff["..2.0"]->text.u8String(), "a");
+        EXPECT_EQ(obj.data_diff["..2.0"]->text.u8StringView(), "a");
         EXPECT_EQ(obj.data_diff["..2.0"]->on_click_member, self_name);
-        EXPECT_EQ(obj.data_diff["..2.0"]->on_click_field->u8String(), "c");
+        EXPECT_EQ(obj.data_diff["..2.0"]->on_click_field->u8StringView(), "c");
 
         EXPECT_EQ(obj.data_diff["..2.1"]->type,
                   static_cast<int>(ViewComponentType::button));
-        EXPECT_EQ(obj.data_diff["..2.1"]->text.u8String(), "a");
-        EXPECT_EQ(obj.data_diff["..2.1"]->on_click_member->u8String(), "b");
-        EXPECT_EQ(obj.data_diff["..2.1"]->on_click_field->u8String(), "c");
+        EXPECT_EQ(obj.data_diff["..2.1"]->text.u8StringView(), "a");
+        EXPECT_EQ(obj.data_diff["..2.1"]->on_click_member->u8StringView(), "b");
+        EXPECT_EQ(obj.data_diff["..2.1"]->on_click_field->u8StringView(), "c");
         EXPECT_EQ(obj.data_diff["..2.1"]->text_color,
                   static_cast<int>(ViewColor::red));
         EXPECT_EQ(obj.data_diff["..2.1"]->bg_color,
@@ -574,20 +570,22 @@ TEST_F(CClientTest, viewReq) {
     EXPECT_EQ(size, 0);
     EXPECT_EQ(wcfStart(wcli_), WCF_OK);
     dummy_s->waitRecv<message::Req<message::View>>([&](const auto &obj) {
-        EXPECT_EQ(obj.member.u8String(), "a");
-        EXPECT_EQ(obj.field.u8String(), "b");
+        EXPECT_EQ(obj.member.u8StringView(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "b");
         EXPECT_EQ(obj.req_id, 1u);
     });
 
-    std::map<std::string, std::shared_ptr<message::ViewComponentData>> v{
-        {"0", ViewComponents::text("a")
-                  .textColor(ViewColor::yellow)
-                  .bgColor(ViewColor::green)
-                  .component_v.lockTmp({}, ""_ss)},
-        {"1", ViewComponents::newLine().lockTmp({}, ""_ss)},
-        {"2", ViewComponents::button("a", Func{Field{{}, "x"_ss, "y"_ss}})
-                  .lockTmp({}, ""_ss)},
-    };
+    std::map<std::string, std::shared_ptr<message::ViewComponentData>,
+             std::less<>>
+        v{
+            {"0", ViewComponents::text("a")
+                      .textColor(ViewColor::yellow)
+                      .bgColor(ViewColor::green)
+                      .component_v.lockTmp({}, ""_ss)},
+            {"1", ViewComponents::newLine().lockTmp({}, ""_ss)},
+            {"2", ViewComponents::button("a", Func{Field{{}, "x"_ss, "y"_ss}})
+                      .lockTmp({}, ""_ss)},
+        };
     std::vector<SharedString> v_ids = {"0"_ss, "1"_ss, "2"_ss};
     dummy_s->send(message::Res<message::View>{1, ""_ss, v, v_ids});
     EXPECT_EQ(wcfLoopSyncFor(wcli_, WEBCFACE_TEST_TIMEOUT * 1000), WCF_OK);

--- a/tests/c_wcf_test.cc
+++ b/tests/c_wcf_test.cc
@@ -313,7 +313,7 @@ TEST_F(CClientTest, funcRun) {
             EXPECT_EQ(obj.args.size(), 3u);
             EXPECT_EQ(static_cast<int>(obj.args.at(0)), 42);
             EXPECT_EQ(static_cast<double>(obj.args.at(1)), 1.5);
-            EXPECT_EQ(static_cast<std::string>(obj.args.at(2)), "aaa");
+            EXPECT_EQ(static_cast<std::string_view>(obj.args.at(2)), "aaa");
         });
         dummy_s->recvClear();
         dummy_s->send(message::CallResponse{{}, caller_id, 1, false});

--- a/tests/c_wcf_test.cc
+++ b/tests/c_wcf_test.cc
@@ -25,7 +25,7 @@ class CClientTest : public ::testing::Test {
     void SetUp() override {
         dummy_s = std::make_shared<DummyServer>();
         wait();
-        wcli_ = wcfInit(self_name.decode().c_str(), "127.0.0.1", 17530);
+        wcli_ = wcfInit(self_name.decode().data(), "127.0.0.1", 17530);
     }
     void TearDown() override {
         wcfClose(wcli_);

--- a/tests/canvas2d_test.cc
+++ b/tests/canvas2d_test.cc
@@ -19,19 +19,19 @@ class Canvas2DTest : public ::testing::Test {
     SharedString self_name = "test"_ss;
     std::shared_ptr<internal::ClientData> data_;
     FieldBase fieldBase(const SharedString &member,
-                        std::string_view name) const {
-        return FieldBase{member, SharedString::fromU8String(name)};
+                        std::string name) const {
+        return FieldBase{member, SharedString::fromU8String(std::move(name))};
     }
-    FieldBase fieldBase(std::string_view member, std::string_view name) const {
-        return FieldBase{SharedString::fromU8String(member),
-                         SharedString::fromU8String(name)};
+    FieldBase fieldBase(std::string member, std::string name) const {
+        return FieldBase{SharedString::fromU8String(std::move(member)),
+                         SharedString::fromU8String(std::move(name))};
     }
-    Field field(const SharedString &member, std::string_view name = "") const {
-        return Field{data_, member, SharedString::fromU8String(name)};
+    Field field(const SharedString &member, std::string name = "") const {
+        return Field{data_, member, SharedString::fromU8String(std::move(name))};
     }
-    Field field(std::string_view member, std::string_view name = "") const {
-        return Field{data_, SharedString::fromU8String(member),
-                     SharedString::fromU8String(name)};
+    Field field(std::string member, std::string name = "") const {
+        return Field{data_, SharedString::fromU8String(std::move(member)),
+                     SharedString::fromU8String(std::move(name))};
     }
     template <typename T1, typename T2>
     Canvas2D canvas(const T1 &member, const T2 &name) {
@@ -85,7 +85,7 @@ TEST_F(Canvas2DTest, set) {
     canvas2d_data.reserve(canvas2d_data_base.components.size());
     for (const auto &id : canvas2d_data_base.data_ids) {
         canvas2d_data.push_back(
-            canvas2d_data_base.components.at(id.u8String()));
+            canvas2d_data_base.components.find(id.u8StringView())->second);
     }
     EXPECT_EQ(canvas2d_data[0]->type,
               static_cast<int>(Canvas2DComponentType::geometry));
@@ -94,9 +94,9 @@ TEST_F(Canvas2DTest, set) {
               static_cast<int>(GeometryType::line));
     EXPECT_EQ(canvas2d_data[0]->properties,
               (std::vector<double>{0, 0, 0, 3, 3, 0}));
-    EXPECT_EQ(canvas2d_data[0]->on_click_member->u8String(),
+    EXPECT_EQ(canvas2d_data[0]->on_click_member->u8StringView(),
               self_name.decode());
-    EXPECT_EQ(canvas2d_data[0]->on_click_field->u8String(), "f");
+    EXPECT_EQ(canvas2d_data[0]->on_click_field->u8StringView(), "f");
 
     EXPECT_EQ(canvas2d_data[1]->type,
               static_cast<int>(Canvas2DComponentType::geometry));
@@ -105,9 +105,9 @@ TEST_F(Canvas2DTest, set) {
               static_cast<int>(GeometryType::plane));
     EXPECT_EQ(canvas2d_data[1]->properties,
               (std::vector<double>{0, 0, 0, 0, 0, 0, 10, 10}));
-    EXPECT_EQ(canvas2d_data[0]->on_click_member->u8String(),
+    EXPECT_EQ(canvas2d_data[0]->on_click_member->u8StringView(),
               self_name.decode());
-    EXPECT_NE(canvas2d_data[0]->on_click_field->u8String(), "");
+    EXPECT_NE(canvas2d_data[0]->on_click_field->u8StringView(), "");
 
     v.init(1, 1);
     v.sync();

--- a/tests/canvas3d_test.cc
+++ b/tests/canvas3d_test.cc
@@ -19,19 +19,19 @@ class Canvas3DTest : public ::testing::Test {
     SharedString self_name = "test"_ss;
     std::shared_ptr<internal::ClientData> data_;
     FieldBase fieldBase(const SharedString &member,
-                        std::string_view name) const {
-        return FieldBase{member, SharedString::fromU8String(name)};
+                        std::string name) const {
+        return FieldBase{member, SharedString::fromU8String(std::move(name))};
     }
-    FieldBase fieldBase(std::string_view member, std::string_view name) const {
-        return FieldBase{SharedString::fromU8String(member),
-                         SharedString::fromU8String(name)};
+    FieldBase fieldBase(std::string member, std::string name) const {
+        return FieldBase{SharedString::fromU8String(std::move(member)),
+                         SharedString::fromU8String(std::move(name))};
     }
-    Field field(const SharedString &member, std::string_view name = "") const {
-        return Field{data_, member, SharedString::fromU8String(name)};
+    Field field(const SharedString &member, std::string name = "") const {
+        return Field{data_, member, SharedString::fromU8String(std::move(name))};
     }
-    Field field(std::string_view member, std::string_view name = "") const {
-        return Field{data_, SharedString::fromU8String(member),
-                     SharedString::fromU8String(name)};
+    Field field(std::string member, std::string name = "") const {
+        return Field{data_, SharedString::fromU8String(std::move(member)),
+                     SharedString::fromU8String(std::move(name))};
     }
     template <typename T1, typename T2>
     Canvas3D canvas(const T1 &member, const T2 &name) {
@@ -93,7 +93,7 @@ TEST_F(Canvas3DTest, set) {
     canvas3d_data.reserve(canvas3d_data_base.components.size());
     for (const auto &id : canvas3d_data_base.data_ids) {
         canvas3d_data.push_back(
-            canvas3d_data_base.components.at(id.u8String()));
+            canvas3d_data_base.components.find(id.u8StringView())->second);
     }
     EXPECT_EQ(canvas3d_data[0]->type,
               static_cast<int>(Canvas3DComponentType::geometry));
@@ -128,8 +128,8 @@ TEST_F(Canvas3DTest, set) {
     EXPECT_EQ(canvas3d_data[2]->origin_rot, (std::array<double, 3>{0, 0, 0}));
     EXPECT_EQ(canvas3d_data[2]->color, static_cast<int>(ViewColor::inherit));
     EXPECT_EQ(canvas3d_data[2]->geometry_type, std::nullopt);
-    EXPECT_EQ(canvas3d_data[2]->field_member->u8String(), self_name.decode());
-    EXPECT_EQ(canvas3d_data[2]->field_field->u8String(), "b");
+    EXPECT_EQ(canvas3d_data[2]->field_member->u8StringView(), self_name.decode());
+    EXPECT_EQ(canvas3d_data[2]->field_field->u8StringView(), "b");
     // ASSERT_EQ(canvas3d_data[2].angles_.size(), 1);
     // EXPECT_EQ(canvas3d_data[2].angles_.at(1), 123);
 

--- a/tests/client_test.cc
+++ b/tests/client_test.cc
@@ -193,8 +193,7 @@ TEST_F(ClientTest, syncThread) {
     });
     wait();
     dummy_s->send(message::Res<message::Value>{
-        1, ""_ss,
-        MutableNumVector(std::vector<double>{1, 2, 3})});
+        1, ""_ss, MutableNumVector(std::vector<double>{1, 2, 3})});
     wcli_->loopSyncFor(std::chrono::milliseconds(WEBCFACE_TEST_TIMEOUT));
     EXPECT_EQ(callback_called, 1);
 }
@@ -522,8 +521,8 @@ TEST_F(ClientTest, logReq) {
     }
     wcli_->member("a").log("b").tryGet();
     dummy_s->waitRecv<message::Req<message::Log>>([&](const auto &obj) {
-        EXPECT_EQ(obj.member.u8String(), "a");
-        EXPECT_EQ(obj.field.u8String(), "b");
+        EXPECT_EQ(obj.member.u8StringView(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "b");
         EXPECT_EQ(obj.req_id, 1u);
     });
     wcli_->member("a").log("b").onChange(callback<Log>());
@@ -551,7 +550,7 @@ TEST_F(ClientTest, logReq) {
     EXPECT_EQ(data_->log_store.getRecv("a"_ss, "b"_ss)
                   .value()
                   ->data.at(0)
-                  .message_.u8String()
+                  .message_.u8StringView()
                   .size(),
               100000u);
 

--- a/tests/client_test_2.cc
+++ b/tests/client_test_2.cc
@@ -501,7 +501,7 @@ TEST_F(ClientTest, funcCall) {
         EXPECT_EQ(obj.args[0].valType(), ValType::int_);
         EXPECT_EQ(static_cast<bool>(obj.args[1]), true);
         EXPECT_EQ(obj.args[1].valType(), ValType::bool_);
-        EXPECT_EQ(static_cast<std::string>(obj.args[2]), "a");
+        EXPECT_EQ(static_cast<std::string_view>(obj.args[2]), "a");
         EXPECT_EQ(obj.args[2].valType(), ValType::string_);
     });
     ASSERT_FALSE(r.reached());
@@ -557,7 +557,7 @@ TEST_F(ClientTest, funcCall) {
     dummy_s->send(message::CallResult{{}, 2, 0, false, ValAdaptor("b")});
     wcli_->loopSyncFor(std::chrono::milliseconds(WEBCFACE_TEST_TIMEOUT));
     ASSERT_TRUE(r.finished());
-    EXPECT_EQ(static_cast<std::string>(r.response()), "b");
+    EXPECT_EQ(static_cast<std::string_view>(r.response()), "b");
 }
 TEST_F(ClientTest, funcResponse) {
     dummy_s = std::make_shared<DummyServer>(false);
@@ -614,7 +614,7 @@ TEST_F(ClientTest, funcResponse) {
         EXPECT_EQ(obj.caller_member_id, 100u);
         EXPECT_EQ(obj.is_error, true);
         // 関数の中でthrowされた内容
-        EXPECT_EQ(static_cast<std::string>(obj.result), "a==0");
+        EXPECT_EQ(static_cast<std::string_view>(obj.result), "a==0");
     });
     dummy_s->recvClear();
 

--- a/tests/data_test.cc
+++ b/tests/data_test.cc
@@ -206,9 +206,8 @@ TEST_F(DataTest, textSet) {
     data_->text_change_event.lock().get()[self_name]["b"_ss] =
         std::make_shared<std::function<void(Variant)>>(callback<Variant>());
     text(self_name, "b").set("c");
-    EXPECT_EQ(
-        static_cast<std::string>(*data_->text_store.getRecv(self_name, "b"_ss)),
-        "c");
+    EXPECT_EQ(data_->text_store.getRecv(self_name, "b"_ss)->asStringView(),
+              "c");
     EXPECT_EQ(callback_called, 1);
     EXPECT_THROW(text("a", "b").set("c"), std::invalid_argument);
 }
@@ -216,9 +215,8 @@ TEST_F(DataTest, textSetW) {
     data_->text_change_event.lock().get()[self_name]["b"_ss] =
         std::make_shared<std::function<void(Variant)>>(callback<Variant>());
     text(self_name, "b").set(L"c");
-    EXPECT_EQ(
-        static_cast<std::string>(*data_->text_store.getRecv(self_name, "b"_ss)),
-        "c");
+    EXPECT_EQ(data_->text_store.getRecv(self_name, "b"_ss)->asStringView(),
+              "c");
     EXPECT_EQ(callback_called, 1);
     EXPECT_THROW(text("a", "b").set(L"c"), std::invalid_argument);
 }

--- a/tests/data_test.cc
+++ b/tests/data_test.cc
@@ -19,20 +19,20 @@ class DataTest : public ::testing::Test {
     }
     SharedString self_name = "test"_ss;
     std::shared_ptr<internal::ClientData> data_;
-    FieldBase fieldBase(const SharedString &member,
-                        std::string_view name) const {
-        return FieldBase{member, SharedString::fromU8String(name)};
+    FieldBase fieldBase(const SharedString &member, std::string name) const {
+        return FieldBase{member, SharedString::fromU8String(std::move(name))};
     }
-    FieldBase fieldBase(std::string_view member, std::string_view name) const {
-        return FieldBase{SharedString::fromU8String(member),
-                         SharedString::fromU8String(name)};
+    FieldBase fieldBase(std::string member, std::string name) const {
+        return FieldBase{SharedString::fromU8String(std::move(member)),
+                         SharedString::fromU8String(std::move(name))};
     }
-    Field field(const SharedString &member, std::string_view name = "") const {
-        return Field{data_, member, SharedString::fromU8String(name)};
+    Field field(const SharedString &member, std::string name = "") const {
+        return Field{data_, member,
+                     SharedString::fromU8String(std::move(name))};
     }
-    Field field(std::string_view member, std::string_view name = "") const {
-        return Field{data_, SharedString::fromU8String(member),
-                     SharedString::fromU8String(name)};
+    Field field(std::string member, std::string name = "") const {
+        return Field{data_, SharedString::fromU8String(std::move(member)),
+                     SharedString::fromU8String(std::move(name))};
     }
     template <typename T1, typename T2>
     Value value(const T1 &member, const T2 &name) {
@@ -49,9 +49,9 @@ class DataTest : public ::testing::Test {
     Log log(const SharedString &member, const SharedString &name) {
         return Log{Field{data_, member, name}};
     }
-    Log log(std::string_view member, std::string_view name) {
-        return Log{Field{data_, SharedString::fromU8String(member),
-                         SharedString::fromU8String(name)}};
+    Log log(std::string member, std::string name) {
+        return Log{Field{data_, SharedString::fromU8String(std::move(member)),
+                         SharedString::fromU8String(std::move(name))}};
     }
     int callback_called;
     template <typename V>
@@ -84,23 +84,27 @@ TEST_F(DataTest, field) {
 }
 TEST_F(DataTest, eventTarget) {
     value("a", "b").onChange(callback<Value>());
-    data_->value_change_event.lock().get()["a"_ss]["b"_ss]->operator()(field("a", "b"));
+    data_->value_change_event.lock().get()["a"_ss]["b"_ss]->operator()(
+        field("a", "b"));
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
     value("a", "b").onChange(nullptr);
     EXPECT_FALSE(*data_->value_change_event.lock().get()["a"_ss]["b"_ss]);
     value("a", "b").onChange(callbackVoid());
-    data_->value_change_event.lock().get()["a"_ss]["b"_ss]->operator()(field("a", "b"));
+    data_->value_change_event.lock().get()["a"_ss]["b"_ss]->operator()(
+        field("a", "b"));
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
 
     text("a", "b").onChange(callback<Text>());
-    data_->text_change_event.lock().get()["a"_ss]["b"_ss]->operator()(field("a", "b"));
+    data_->text_change_event.lock().get()["a"_ss]["b"_ss]->operator()(
+        field("a", "b"));
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
 
     log("a", "b").onChange(callback<Log>());
-    data_->log_append_event.lock().get()["a"_ss]["b"_ss]->operator()(field("a"));
+    data_->log_append_event.lock().get()["a"_ss]["b"_ss]->operator()(
+        field("a"));
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
 }
@@ -202,9 +206,9 @@ TEST_F(DataTest, textSet) {
     data_->text_change_event.lock().get()[self_name]["b"_ss] =
         std::make_shared<std::function<void(Variant)>>(callback<Variant>());
     text(self_name, "b").set("c");
-    EXPECT_EQ(static_cast<std::string>(
-                  **data_->text_store.getRecv(self_name, "b"_ss)),
-              "c");
+    EXPECT_EQ(
+        static_cast<std::string>(*data_->text_store.getRecv(self_name, "b"_ss)),
+        "c");
     EXPECT_EQ(callback_called, 1);
     EXPECT_THROW(text("a", "b").set("c"), std::invalid_argument);
 }
@@ -212,9 +216,9 @@ TEST_F(DataTest, textSetW) {
     data_->text_change_event.lock().get()[self_name]["b"_ss] =
         std::make_shared<std::function<void(Variant)>>(callback<Variant>());
     text(self_name, "b").set(L"c");
-    EXPECT_EQ(static_cast<std::string>(
-                  **data_->text_store.getRecv(self_name, "b"_ss)),
-              "c");
+    EXPECT_EQ(
+        static_cast<std::string>(*data_->text_store.getRecv(self_name, "b"_ss)),
+        "c");
     EXPECT_EQ(callback_called, 1);
     EXPECT_THROW(text("a", "b").set(L"c"), std::invalid_argument);
 }
@@ -244,15 +248,14 @@ TEST_F(DataTest, valueGet) {
     EXPECT_EQ(data_->value_store.transferReq().at("a"_ss).at("d"_ss), 3u);
 }
 TEST_F(DataTest, textGet) {
-    data_->text_store.setRecv("a"_ss, "b"_ss,
-                              std::make_shared<ValAdaptor>("hoge"));
+    data_->text_store.setRecv("a"_ss, "b"_ss, ValAdaptor("hoge"));
     ASSERT_NE(text("a", "b").tryGet(), std::nullopt);
     EXPECT_EQ(text("a", "b").tryGet().value(), "hoge");
     EXPECT_EQ(text("a", "b").tryGetW().value(), L"hoge");
     EXPECT_EQ(variant("a", "b").tryGet().value(), ValAdaptor("hoge"));
     EXPECT_EQ(text("a", "b").get(), "hoge");
     EXPECT_EQ(text("a", "b").getW(), L"hoge");
-    EXPECT_EQ(variant("a", "b").get().asStringRef(), "hoge");
+    EXPECT_EQ(variant("a", "b").get().asStringView(), "hoge");
     EXPECT_EQ(text("a", "c").tryGet(), std::nullopt);
     EXPECT_EQ(text("a", "c").tryGetW(), std::nullopt);
     EXPECT_EQ(variant("a", "c").tryGet(), std::nullopt);

--- a/tests/encoding_test.cc
+++ b/tests/encoding_test.cc
@@ -9,30 +9,28 @@ TEST(EncodingTest, usingUTF8) {
     EXPECT_FALSE(usingUTF8());
 }
 TEST(EncodingTest, encode) {
-    std::string_view s = "Aあ";
-    std::wstring_view w = L"Aあ";
-    std::string_view u = "Aあ";
-    std::string us(u.cbegin(), u.cend());
+    std::string s = "Aあ";
+    std::wstring w = L"Aあ";
+    std::string u = "Aあ";
     usingUTF8(true);
-    EXPECT_EQ(SharedString::encode(us).u8String(), u);
-    EXPECT_EQ(SharedString::encode(w).u8String(), u);
+    EXPECT_EQ(SharedString::encode(u).u8StringView(), u);
+    EXPECT_EQ(SharedString::encode(w).u8StringView(), u);
     usingUTF8(false);
 #if WEBCFACE_SYSTEM_WCHAR_WINDOWS
     // webcfaceはutf8エンコーディングでビルドしてるのでsはANSIではない
-    EXPECT_NE(SharedString::encode(s).u8String(), u);
+    EXPECT_NE(SharedString::encode(s).u8StringView(), u);
 #else
     // linux, macではutf8として扱われる
-    EXPECT_EQ(SharedString::encode(s).u8String(), u);
+    EXPECT_EQ(SharedString::encode(s).u8StringView(), u);
 #endif
-    EXPECT_EQ(SharedString::encode(w).u8String(), u);
+    EXPECT_EQ(SharedString::encode(w).u8StringView(), u);
 }
 TEST(EncodingTest, decode) {
-    std::string_view s = "Aあ";
-    std::wstring_view w = L"Aあ";
-    std::string_view u = "Aあ";
-    std::string us(u.cbegin(), u.cend());
+    std::string s = "Aあ";
+    std::wstring w = L"Aあ";
+    std::string u = "Aあ";
     usingUTF8(true);
-    EXPECT_EQ(SharedString::fromU8String(u).decode(), us);
+    EXPECT_EQ(SharedString::fromU8String(u).decode(), u);
     EXPECT_EQ(SharedString::fromU8String(u).decodeW(), w);
     usingUTF8(false);
 #if WEBCFACE_SYSTEM_WCHAR_WINDOWS

--- a/tests/func_listener_test.cc
+++ b/tests/func_listener_test.cc
@@ -102,7 +102,7 @@ TEST_F(FuncListenerTest, funcRun) {
     ASSERT_NE(h, std::nullopt);
     EXPECT_EQ(static_cast<int>(h->args()[0]), 123);
     EXPECT_EQ(static_cast<double>(h->args()[1]), 123.45);
-    EXPECT_EQ(static_cast<std::string>(h->args()[2]), "a");
+    EXPECT_EQ(static_cast<std::string_view>(h->args()[2]), "a");
     EXPECT_TRUE(static_cast<bool>(h->args()[3]));
     h->respond(123.45);
     EXPECT_TRUE(ret_a.finished());

--- a/tests/func_listener_test.cc
+++ b/tests/func_listener_test.cc
@@ -17,19 +17,19 @@ class FuncListenerTest : public ::testing::Test {
     SharedString self_name = "test"_ss;
     std::shared_ptr<internal::ClientData> data_;
     FieldBase fieldBase(const SharedString &member,
-                        std::string_view name) const {
-        return FieldBase{member, SharedString::fromU8String(name)};
+                        std::string name) const {
+        return FieldBase{member, SharedString::fromU8String(std::move(name))};
     }
-    FieldBase fieldBase(std::string_view member, std::string_view name) const {
-        return FieldBase{SharedString::fromU8String(member),
-                         SharedString::fromU8String(name)};
+    FieldBase fieldBase(std::string member, std::string name) const {
+        return FieldBase{SharedString::fromU8String(std::move(member)),
+                         SharedString::fromU8String(std::move(name))};
     }
-    Field field(const SharedString &member, std::string_view name = "") const {
-        return Field{data_, member, SharedString::fromU8String(name)};
+    Field field(const SharedString &member, std::string name = "") const {
+        return Field{data_, member, SharedString::fromU8String(std::move(name))};
     }
-    Field field(std::string_view member, std::string_view name = "") const {
-        return Field{data_, SharedString::fromU8String(member),
-                     SharedString::fromU8String(name)};
+    Field field(std::string member, std::string name = "") const {
+        return Field{data_, SharedString::fromU8String(std::move(member)),
+                     SharedString::fromU8String(std::move(name))};
     }
     template <typename T1, typename T2>
     Func func(const T1 &member, const T2 &name) {

--- a/tests/func_test.cc
+++ b/tests/func_test.cc
@@ -45,9 +45,9 @@ TEST_F(FuncTest, valAdaptor) {
     EXPECT_EQ(static_cast<bool>(ValAdaptor(0)), false);
     EXPECT_EQ(static_cast<bool>(ValAdaptor(1)), true);
     EXPECT_EQ(static_cast<bool>(ValAdaptor(2)), true);
-    EXPECT_EQ(static_cast<std::string>(ValAdaptor(10)), "10");
+    EXPECT_EQ(static_cast<std::string_view>(ValAdaptor(10)), "10");
     EXPECT_STREQ(static_cast<const char *>(ValAdaptor(10)), "10");
-    EXPECT_EQ(static_cast<std::wstring>(ValAdaptor(10)), L"10");
+    EXPECT_EQ(static_cast<std::wstring_view>(ValAdaptor(10)), L"10");
     EXPECT_STREQ(static_cast<const wchar_t *>(ValAdaptor(10)), L"10");
 
     EXPECT_FALSE(ValAdaptor(1.5).empty());
@@ -56,9 +56,9 @@ TEST_F(FuncTest, valAdaptor) {
     EXPECT_EQ(static_cast<bool>(ValAdaptor(0.0)), false);
     EXPECT_EQ(static_cast<bool>(ValAdaptor(1.0)), true);
     EXPECT_EQ(static_cast<bool>(ValAdaptor(1.5)), true);
-    EXPECT_EQ(static_cast<std::string>(ValAdaptor(1.5)), "1.500000");
+    EXPECT_EQ(static_cast<std::string_view>(ValAdaptor(1.5)), "1.500000");
     EXPECT_STREQ(static_cast<const char *>(ValAdaptor(1.5)), "1.500000");
-    EXPECT_EQ(static_cast<std::wstring>(ValAdaptor(1.5)), L"1.500000");
+    EXPECT_EQ(static_cast<std::wstring_view>(ValAdaptor(1.5)), L"1.500000");
     EXPECT_STREQ(static_cast<const wchar_t *>(ValAdaptor(1.5)), L"1.500000");
 
     EXPECT_FALSE(ValAdaptor(true).empty());
@@ -68,9 +68,9 @@ TEST_F(FuncTest, valAdaptor) {
     EXPECT_EQ(static_cast<double>(ValAdaptor(false)), 0.0);
     EXPECT_EQ(static_cast<bool>(ValAdaptor(true)), true);
     EXPECT_EQ(static_cast<bool>(ValAdaptor(false)), false);
-    EXPECT_EQ(static_cast<std::string>(ValAdaptor(true)), "1");
+    EXPECT_EQ(static_cast<std::string_view>(ValAdaptor(true)), "1");
     EXPECT_STREQ(static_cast<const char *>(ValAdaptor(true)), "1");
-    EXPECT_EQ(static_cast<std::wstring>(ValAdaptor(true)), L"1");
+    EXPECT_EQ(static_cast<std::wstring_view>(ValAdaptor(true)), L"1");
     EXPECT_STREQ(static_cast<const wchar_t *>(ValAdaptor(true)), L"1");
 
     EXPECT_FALSE(ValAdaptor("1.5").empty());
@@ -82,9 +82,9 @@ TEST_F(FuncTest, valAdaptor) {
     EXPECT_EQ(static_cast<bool>(ValAdaptor("1.0")), true);
     EXPECT_EQ(static_cast<bool>(ValAdaptor("1.5")), true);
     EXPECT_EQ(static_cast<bool>(ValAdaptor("hoge")), true);
-    EXPECT_EQ(static_cast<std::string>(ValAdaptor("1.5")), "1.5");
+    EXPECT_EQ(static_cast<std::string_view>(ValAdaptor("1.5")), "1.5");
     EXPECT_STREQ(static_cast<const char *>(ValAdaptor("1.5")), "1.5");
-    EXPECT_EQ(static_cast<std::wstring>(ValAdaptor("1.5")), L"1.5");
+    EXPECT_EQ(static_cast<std::wstring_view>(ValAdaptor("1.5")), L"1.5");
     EXPECT_STREQ(static_cast<const wchar_t *>(ValAdaptor("1.5")), L"1.5");
 
     EXPECT_TRUE(ValAdaptor().empty());

--- a/tests/func_test.cc
+++ b/tests/func_test.cc
@@ -18,19 +18,19 @@ class FuncTest : public ::testing::Test {
     SharedString self_name = "test"_ss;
     std::shared_ptr<internal::ClientData> data_;
     FieldBase fieldBase(const SharedString &member,
-                        std::string_view name) const {
-        return FieldBase{member, SharedString::fromU8String(name)};
+                        std::string name) const {
+        return FieldBase{member, SharedString::fromU8String(std::move(name))};
     }
-    FieldBase fieldBase(std::string_view member, std::string_view name) const {
-        return FieldBase{SharedString::fromU8String(member),
-                         SharedString::fromU8String(name)};
+    FieldBase fieldBase(std::string member, std::string name) const {
+        return FieldBase{SharedString::fromU8String(std::move(member)),
+                         SharedString::fromU8String(std::move(name))};
     }
-    Field field(const SharedString &member, std::string_view name = "") const {
-        return Field{data_, member, SharedString::fromU8String(name)};
+    Field field(const SharedString &member, std::string name = "") const {
+        return Field{data_, member, SharedString::fromU8String(std::move(name))};
     }
-    Field field(std::string_view member, std::string_view name = "") const {
-        return Field{data_, SharedString::fromU8String(member),
-                     SharedString::fromU8String(name)};
+    Field field(std::string member, std::string name = "") const {
+        return Field{data_, SharedString::fromU8String(std::move(member)),
+                     SharedString::fromU8String(std::move(name))};
     }
     template <typename T1, typename T2>
     Func func(const T1 &member, const T2 &name) {

--- a/tests/image_test.cc
+++ b/tests/image_test.cc
@@ -135,19 +135,19 @@ class ImageTest : public ::testing::Test {
     SharedString self_name = "test"_ss;
     std::shared_ptr<internal::ClientData> data_;
     FieldBase fieldBase(const SharedString &member,
-                        std::string_view name) const {
-        return FieldBase{member, SharedString::fromU8String(name)};
+                        std::string name) const {
+        return FieldBase{member, SharedString::fromU8String(std::move(name))};
     }
-    FieldBase fieldBase(std::string_view member, std::string_view name) const {
-        return FieldBase{SharedString::fromU8String(member),
-                         SharedString::fromU8String(name)};
+    FieldBase fieldBase(std::string member, std::string name) const {
+        return FieldBase{SharedString::fromU8String(std::move(member)),
+                         SharedString::fromU8String(std::move(name))};
     }
-    Field field(const SharedString &member, std::string_view name = "") const {
-        return Field{data_, member, SharedString::fromU8String(name)};
+    Field field(const SharedString &member, std::string name = "") const {
+        return Field{data_, member, SharedString::fromU8String(std::move(name))};
     }
-    Field field(std::string_view member, std::string_view name = "") const {
-        return Field{data_, SharedString::fromU8String(member),
-                     SharedString::fromU8String(name)};
+    Field field(std::string member, std::string name = "") const {
+        return Field{data_, SharedString::fromU8String(std::move(member)),
+                     SharedString::fromU8String(std::move(name))};
     }
     template <typename T1, typename T2>
     Image image(const T1 &member, const T2 &name) {

--- a/tests/logger_test.cc
+++ b/tests/logger_test.cc
@@ -30,11 +30,11 @@ TEST_F(LoggerTest, loggerBuf) {
     auto ls = data_->log_store.getRecv(self_name, "buf"_ss);
     ASSERT_EQ((*ls)->data.size(), 3u);
     EXPECT_EQ((*ls)->data[0].level_, 2);
-    EXPECT_EQ((*ls)->data[0].message_.u8String(), "a");
+    EXPECT_EQ((*ls)->data[0].message_.u8StringView(), "a");
     EXPECT_EQ((*ls)->data[1].level_, 2);
-    EXPECT_EQ((*ls)->data[1].message_.u8String(), "b");
+    EXPECT_EQ((*ls)->data[1].message_.u8StringView(), "b");
     EXPECT_EQ((*ls)->data[2].level_, 2);
-    EXPECT_EQ((*ls)->data[2].message_.u8String(), "c");
+    EXPECT_EQ((*ls)->data[2].message_.u8StringView(), "c");
     std::cerr.rdbuf(cerr_buf);
 }
 TEST_F(LoggerTest, loggerBufW) {
@@ -47,10 +47,10 @@ TEST_F(LoggerTest, loggerBufW) {
     auto ls = data_->log_store.getRecv(self_name, "buf"_ss);
     ASSERT_EQ((*ls)->data.size(), 3u);
     EXPECT_EQ((*ls)->data[0].level_, 2);
-    EXPECT_EQ((*ls)->data[0].message_.u8String(), "a");
+    EXPECT_EQ((*ls)->data[0].message_.u8StringView(), "a");
     EXPECT_EQ((*ls)->data[1].level_, 2);
-    EXPECT_EQ((*ls)->data[1].message_.u8String(), "b");
+    EXPECT_EQ((*ls)->data[1].message_.u8StringView(), "b");
     EXPECT_EQ((*ls)->data[2].level_, 2);
-    EXPECT_EQ((*ls)->data[2].message_.u8String(), "c");
+    EXPECT_EQ((*ls)->data[2].message_.u8StringView(), "c");
     std::wcerr.rdbuf(wcerr_buf);
 }

--- a/tests/member_test.cc
+++ b/tests/member_test.cc
@@ -20,19 +20,19 @@ class MemberTest : public ::testing::Test {
     SharedString self_name = "test"_ss;
     std::shared_ptr<internal::ClientData> data_;
     FieldBase fieldBase(const SharedString &member,
-                        std::string_view name) const {
-        return FieldBase{member, SharedString::fromU8String(name)};
+                        std::string name) const {
+        return FieldBase{member, SharedString::fromU8String(std::move(name))};
     }
-    FieldBase fieldBase(std::string_view member, std::string_view name) const {
-        return FieldBase{SharedString::fromU8String(member),
-                         SharedString::fromU8String(name)};
+    FieldBase fieldBase(std::string member, std::string name) const {
+        return FieldBase{SharedString::fromU8String(std::move(member)),
+                         SharedString::fromU8String(std::move(name))};
     }
-    Field field(const SharedString &member, std::string_view name = "") const {
-        return Field{data_, member, SharedString::fromU8String(name)};
+    Field field(const SharedString &member, std::string name = "") const {
+        return Field{data_, member, SharedString::fromU8String(std::move(name))};
     }
-    Field field(std::string_view member, std::string_view name = "") const {
-        return Field{data_, SharedString::fromU8String(member),
-                     SharedString::fromU8String(name)};
+    Field field(std::string member, std::string name = "") const {
+        return Field{data_, SharedString::fromU8String(std::move(member)),
+                     SharedString::fromU8String(std::move(name))};
     }
     template <typename T1>
     Member member(const T1 &member) {

--- a/tests/robot_model_test.cc
+++ b/tests/robot_model_test.cc
@@ -17,19 +17,19 @@ class RobotModelTest : public ::testing::Test {
     SharedString self_name = "test"_ss;
     std::shared_ptr<internal::ClientData> data_;
     FieldBase fieldBase(const SharedString &member,
-                        std::string_view name) const {
-        return FieldBase{member, SharedString::fromU8String(name)};
+                        std::string name) const {
+        return FieldBase{member, SharedString::fromU8String(std::move(name))};
     }
-    FieldBase fieldBase(std::string_view member, std::string_view name) const {
-        return FieldBase{SharedString::fromU8String(member),
-                         SharedString::fromU8String(name)};
+    FieldBase fieldBase(std::string member, std::string name) const {
+        return FieldBase{SharedString::fromU8String(std::move(member)),
+                         SharedString::fromU8String(std::move(name))};
     }
-    Field field(const SharedString &member, std::string_view name = "") const {
-        return Field{data_, member, SharedString::fromU8String(name)};
+    Field field(const SharedString &member, std::string name = "") const {
+        return Field{data_, member, SharedString::fromU8String(std::move(name))};
     }
-    Field field(std::string_view member, std::string_view name = "") const {
-        return Field{data_, SharedString::fromU8String(member),
-                     SharedString::fromU8String(name)};
+    Field field(std::string member, std::string name = "") const {
+        return Field{data_, SharedString::fromU8String(std::move(member)),
+                     SharedString::fromU8String(std::move(name))};
     }
     template <typename T1, typename T2>
     RobotModel model(const T1 &member, const T2 &name) {
@@ -95,7 +95,7 @@ TEST_F(RobotModelTest, sync) {
 
 TEST_F(RobotModelTest, get) {
     auto ln = std::make_shared<internal::RobotLinkData>();
-    ln->name = SharedString::fromU8String("a");
+    ln->name = SharedString::fromU8StringStatic("a");
     data_->robot_model_store.setRecv(
         "a"_ss, "b"_ss,
         std::make_shared<std::vector<std::shared_ptr<internal::RobotLinkData>>>(

--- a/tests/server_test.cc
+++ b/tests/server_test.cc
@@ -37,9 +37,9 @@ TEST_F(ServerTest, sync) {
     wait();
     dummy_c1->send(message::SyncInit{{}, ""_ss, 0, "", "", ""});
     dummy_c2->send(message::SyncInit{{}, "c2"_ss, 0, "a", "1", ""});
-    dummy_c2->send(message::Text{{}, "a"_ss, std::make_shared<ValAdaptor>("")});
+    dummy_c2->send(message::Text{{}, "a"_ss, ValAdaptor("")});
     dummy_c1->waitRecv<message::SyncInit>([&](const auto &obj) {
-        EXPECT_EQ(obj.member_name.u8String(), "c2");
+        EXPECT_EQ(obj.member_name.u8StringView(), "c2");
         EXPECT_EQ(obj.member_id, 2u);
         EXPECT_EQ(obj.lib_name, "a");
         EXPECT_EQ(obj.lib_ver, "1");
@@ -72,7 +72,7 @@ TEST_F(ServerTest, sync) {
     dummy_c3->recv<message::Entry<message::Text>>(
         [&](const auto &obj) {
             EXPECT_EQ(obj.member_id, 2u);
-            EXPECT_EQ(obj.field.u8String(), "a");
+            EXPECT_EQ(obj.field.u8StringView(), "a");
         },
         [&] { ADD_FAILURE() << "should have been received entry"; });
 
@@ -128,26 +128,26 @@ TEST_F(ServerTest, entry) {
     dummy_c2 = std::make_shared<DummyClient>();
     wait();
     dummy_c1->send(message::SyncInit{{}, "c1"_ss, 0, "", "", ""});
-    dummy_c1->send(
-        message::Value{{}, "a"_ss, MutableNumVector(1)});
-    dummy_c1->send(message::Text{{}, "a"_ss, std::make_shared<ValAdaptor>("")});
+    dummy_c1->send(message::Value{{}, "a"_ss, MutableNumVector(1)});
+    dummy_c1->send(message::Text{{}, "a"_ss, ValAdaptor("")});
     dummy_c1->send(message::RobotModel{
         "a"_ss, std::vector<std::shared_ptr<message::RobotLink>>()});
     dummy_c1->send(message::Canvas3D{
         "a"_ss,
-        std::map<std::string,
-                 std::shared_ptr<message::Canvas3DComponentData>>(),
+        std::map<std::string, std::shared_ptr<message::Canvas3DComponentData>,
+                 std::less<>>(),
         {}});
     dummy_c1->send(message::Canvas2D{
         "a"_ss,
         0,
         0,
-        std::map<std::string,
-                 std::shared_ptr<message::Canvas2DComponentData>>(),
+        std::map<std::string, std::shared_ptr<message::Canvas2DComponentData>,
+                 std::less<>>(),
         {}});
     dummy_c1->send(message::View{
         "a"_ss,
-        std::map<std::string, std::shared_ptr<message::ViewComponentData>>(),
+        std::map<std::string, std::shared_ptr<message::ViewComponentData>,
+                 std::less<>>(),
         {}});
     dummy_c1->send(message::Image{
         "a"_ss,
@@ -167,47 +167,47 @@ TEST_F(ServerTest, entry) {
     // c2が接続したタイミングでのc1のentryが全部返る
     dummy_c2->send(message::SyncInit{{}, ""_ss, 0, "", "", ""});
     dummy_c2->waitRecv<message::SyncInit>([&](const auto &obj) {
-        EXPECT_EQ(obj.member_name.u8String(), "c1");
+        EXPECT_EQ(obj.member_name.u8StringView(), "c1");
         EXPECT_EQ(obj.member_id, 1u);
     });
     dummy_c2->waitRecv<message::Entry<message::Value>>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "a");
     });
     dummy_c2->waitRecv<message::Entry<message::Text>>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "a");
     });
     dummy_c2->waitRecv<message::Entry<message::RobotModel>>(
         [&](const auto &obj) {
             EXPECT_EQ(obj.member_id, 1u);
-            EXPECT_EQ(obj.field.u8String(), "a");
+            EXPECT_EQ(obj.field.u8StringView(), "a");
         });
     dummy_c2->waitRecv<message::Entry<message::View>>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "a");
     });
     dummy_c2->waitRecv<message::Entry<message::Canvas3D>>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "a");
     });
     dummy_c2->waitRecv<message::Entry<message::Canvas2D>>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "a");
     });
     dummy_c2->waitRecv<message::Entry<message::Image>>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "a");
     });
     dummy_c2->waitRecv<message::Entry<message::Log>>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "default");
+        EXPECT_EQ(obj.field.u8StringView(), "default");
     });
     dummy_c2->waitRecv<message::LogEntryDefault>(
         [&](const auto &obj) { EXPECT_EQ(obj.member_id, 1u); });
     dummy_c2->waitRecv<message::FuncInfo>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "a");
         EXPECT_EQ(obj.return_type, ValType::none_);
         EXPECT_EQ(obj.args.size(), 0u);
         EXPECT_EQ(obj.index, 5);
@@ -215,51 +215,51 @@ TEST_F(ServerTest, entry) {
     dummy_c2->recvClear();
 
     // c1にentryを追加する
-    dummy_c1->send(
-        message::Value{{}, "b"_ss, MutableNumVector(1)});
+    dummy_c1->send(message::Value{{}, "b"_ss, MutableNumVector(1)});
     dummy_c2->waitRecv<message::Entry<message::Value>>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "b");
+        EXPECT_EQ(obj.field.u8StringView(), "b");
     });
-    dummy_c1->send(message::Text{{}, "b"_ss, std::make_shared<ValAdaptor>("")});
+    dummy_c1->send(message::Text{{}, "b"_ss, ValAdaptor("")});
     dummy_c2->waitRecv<message::Entry<message::Text>>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "b");
+        EXPECT_EQ(obj.field.u8StringView(), "b");
     });
     dummy_c1->send(message::RobotModel{
         "b"_ss, std::vector<std::shared_ptr<message::RobotLink>>()});
     dummy_c2->waitRecv<message::Entry<message::RobotModel>>(
         [&](const auto &obj) {
             EXPECT_EQ(obj.member_id, 1u);
-            EXPECT_EQ(obj.field.u8String(), "b");
+            EXPECT_EQ(obj.field.u8StringView(), "b");
         });
     dummy_c1->send(message::View{
         "b"_ss,
-        std::map<std::string, std::shared_ptr<message::ViewComponentData>>(),
+        std::map<std::string, std::shared_ptr<message::ViewComponentData>,
+                 std::less<>>(),
         {}});
     dummy_c2->waitRecv<message::Entry<message::View>>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "b");
+        EXPECT_EQ(obj.field.u8StringView(), "b");
     });
     dummy_c1->send(message::Canvas3D{
         "b"_ss,
-        std::map<std::string,
-                 std::shared_ptr<message::Canvas3DComponentData>>(),
+        std::map<std::string, std::shared_ptr<message::Canvas3DComponentData>,
+                 std::less<>>(),
         {}});
     dummy_c2->waitRecv<message::Entry<message::Canvas3D>>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "b");
+        EXPECT_EQ(obj.field.u8StringView(), "b");
     });
     dummy_c1->send(message::Canvas2D{
         "b"_ss,
         0,
         0,
-        std::map<std::string,
-                 std::shared_ptr<message::Canvas2DComponentData>>(),
+        std::map<std::string, std::shared_ptr<message::Canvas2DComponentData>,
+                 std::less<>>(),
         {}});
     dummy_c2->waitRecv<message::Entry<message::Canvas2D>>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "b");
+        EXPECT_EQ(obj.field.u8StringView(), "b");
     });
     dummy_c1->send(message::Image{
         "b"_ss,
@@ -269,12 +269,12 @@ TEST_F(ServerTest, entry) {
             .toMessage()});
     dummy_c2->waitRecv<message::Entry<message::Image>>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "b");
+        EXPECT_EQ(obj.field.u8StringView(), "b");
     });
     dummy_c1->send(message::FuncInfo{0, "b"_ss, ValType::none_, {}, 5});
     dummy_c2->waitRecv<message::FuncInfo>([&](const auto &obj) {
         EXPECT_EQ(obj.member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "b");
+        EXPECT_EQ(obj.field.u8StringView(), "b");
         EXPECT_EQ(obj.return_type, ValType::none_);
         EXPECT_EQ(obj.args.size(), 0u);
         EXPECT_EQ(obj.index, 5);
@@ -445,7 +445,7 @@ TEST_F(ServerTest, call) {
         EXPECT_EQ(obj.caller_id, 1u);
         EXPECT_EQ(obj.caller_member_id, 2u);
         EXPECT_EQ(obj.target_member_id, 1u);
-        EXPECT_EQ(obj.field.u8String(), "a");
+        EXPECT_EQ(obj.field.u8StringView(), "a");
         EXPECT_EQ(obj.args.size(), 3u);
     });
     dummy_c2->recvClear();

--- a/tests/server_test.cc
+++ b/tests/server_test.cc
@@ -463,6 +463,6 @@ TEST_F(ServerTest, call) {
         EXPECT_EQ(obj.caller_id, 1u);
         EXPECT_EQ(obj.caller_member_id, 2u);
         EXPECT_EQ(obj.is_error, false);
-        EXPECT_EQ(static_cast<std::string>(obj.result), "aaa");
+        EXPECT_EQ(static_cast<std::string_view>(obj.result), "aaa");
     });
 }

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -15,6 +15,6 @@ inline void wait() {
         std::chrono::milliseconds(WEBCFACE_TEST_TIMEOUT));
 }
 inline SharedString operator""_ss(const char *str, std::size_t len) {
-    return SharedString::fromU8String(std::string_view(str, len));
+    return SharedString::fromU8StringStatic(std::string_view(str, len));
 }
 

--- a/tests/view_test.cc
+++ b/tests/view_test.cc
@@ -191,8 +191,8 @@ TEST_F(ViewTest, viewSet) {
     // EXPECT_FALSE(view_data[9].text_ref_->field_.empty());
     EXPECT_EQ(view_data[9]->option_.size(), 3u);
     func(self_name, *view_data[9]->on_click_field).runAsync("a");
-    EXPECT_EQ(static_cast<std::string>(ref2.get()), "a");
-    // EXPECT_EQ(static_cast<std::string>(
+    EXPECT_EQ(static_cast<std::string_view>(ref2.get()), "a");
+    // EXPECT_EQ(static_cast<std::string_view>(
     //               text(self_name, view_data[9].text_ref_->field_).get()),
     //           "a");
 
@@ -206,7 +206,7 @@ TEST_F(ViewTest, viewSet) {
     // EXPECT_FALSE(view_data[10].text_ref_->field_.empty());
     func(self_name, *view_data[10]->on_click_field).runAsync("aaa");
     EXPECT_EQ(called_ref3, 1);
-    // EXPECT_EQ(static_cast<std::string>(
+    // EXPECT_EQ(static_cast<std::string_view>(
     //               text(self_name, view_data[10].text_ref_->field_).get()),
     //           "aaa");
 

--- a/tests/view_test.cc
+++ b/tests/view_test.cc
@@ -19,23 +19,23 @@ class ViewTest : public ::testing::Test {
     }
     SharedString self_name = "test"_ss;
     std::shared_ptr<internal::ClientData> data_;
-    FieldBase fieldBase(const SharedString &member,
-                        std::string_view name) const {
-        return FieldBase{member, SharedString::fromU8String(name)};
+    FieldBase fieldBase(const SharedString &member, std::string name) const {
+        return FieldBase{member, SharedString::fromU8String(std::move(name))};
     }
-    FieldBase fieldBase(std::string_view member, std::string_view name) const {
-        return FieldBase{SharedString::fromU8String(member),
-                         SharedString::fromU8String(name)};
+    FieldBase fieldBase(std::string member, std::string name) const {
+        return FieldBase{SharedString::fromU8String(std::move(member)),
+                         SharedString::fromU8String(std::move(name))};
     }
     Field field(const SharedString &member, const SharedString &name) const {
         return Field{data_, member, name};
     }
-    Field field(const SharedString &member, std::string_view name = "") const {
-        return Field{data_, member, SharedString::fromU8String(name)};
+    Field field(const SharedString &member, std::string name = "") const {
+        return Field{data_, member,
+                     SharedString::fromU8String(std::move(name))};
     }
-    Field field(std::string_view member, std::string_view name) const {
-        return Field{data_, SharedString::fromU8String(member),
-                     SharedString::fromU8String(name)};
+    Field field(std::string member, std::string name) const {
+        return Field{data_, SharedString::fromU8String(std::move(member)),
+                     SharedString::fromU8String(std::move(name))};
     }
     template <typename T1, typename T2>
     View view(const T1 &member, const T2 &name) {
@@ -65,7 +65,8 @@ TEST_F(ViewTest, field) {
 }
 TEST_F(ViewTest, eventTarget) {
     view("a", "b").onChange(callback<View>());
-    data_->view_change_event.lock().get()["a"_ss]["b"_ss]->operator()(field("a", "b"));
+    data_->view_change_event.lock().get()["a"_ss]["b"_ss]->operator()(
+        field("a", "b"));
     EXPECT_EQ(callback_called, 1);
     callback_called = 0;
 }
@@ -111,49 +112,54 @@ TEST_F(ViewTest, viewSet) {
     std::vector<std::shared_ptr<message::ViewComponentData>> view_data;
     view_data.reserve(view_data_base.components.size());
     for (const auto &id : view_data_base.data_ids) {
-        view_data.push_back(view_data_base.components.at(id.u8String()));
+        view_data.push_back(
+            view_data_base.components.find(id.u8StringView())->second);
     }
-    EXPECT_EQ(view_data_base.data_ids[0].u8String(), "..0.0");
+    EXPECT_EQ(view_data_base.data_ids[0].u8StringView(), "..0.0");
     EXPECT_EQ(view_data[0]->type, static_cast<int>(ViewComponentType::text));
-    EXPECT_EQ(view_data[0]->text.u8String(), "a");
-    EXPECT_EQ(view_data_base.data_ids[1].u8String(), "..1.0");
+    EXPECT_EQ(view_data[0]->text.u8StringView(), "a");
+    EXPECT_EQ(view_data_base.data_ids[1].u8StringView(), "..1.0");
     EXPECT_EQ(view_data[1]->type,
               static_cast<int>(ViewComponentType::new_line));
-    EXPECT_EQ(view_data_base.data_ids[2].u8String(), "..0.1");
+    EXPECT_EQ(view_data_base.data_ids[2].u8StringView(), "..0.1");
     EXPECT_EQ(view_data[2]->type, static_cast<int>(ViewComponentType::text));
-    EXPECT_EQ(view_data[2]->text.u8String(), "1");
+    EXPECT_EQ(view_data[2]->text.u8StringView(), "1");
 
-    EXPECT_EQ(view_data_base.data_ids[3].u8String(), "..0.2");
+    EXPECT_EQ(view_data_base.data_ids[3].u8StringView(), "..0.2");
     EXPECT_EQ(view_data[3]->type, static_cast<int>(ViewComponentType::text));
-    EXPECT_EQ(view_data[3]->text.u8String(), "aaa");
+    EXPECT_EQ(view_data[3]->text.u8StringView(), "aaa");
     EXPECT_EQ(view_data[3]->text_color, static_cast<int>(ViewColor::yellow));
     EXPECT_EQ(view_data[3]->bg_color, static_cast<int>(ViewColor::green));
-    EXPECT_EQ(view_data_base.data_ids[4].u8String(), "..1.1");
+    EXPECT_EQ(view_data_base.data_ids[4].u8StringView(), "..1.1");
     EXPECT_EQ(view_data[4]->type,
               static_cast<int>(ViewComponentType::new_line));
 
-    EXPECT_EQ(view_data_base.data_ids[5].u8String(), "..2.0");
+    EXPECT_EQ(view_data_base.data_ids[5].u8StringView(), "..2.0");
     EXPECT_EQ(view_data[5]->type, static_cast<int>(ViewComponentType::button));
-    EXPECT_EQ(view_data[5]->text.u8String(), "f");
-    EXPECT_EQ(view_data[5]->on_click_member->u8String(), self_name.decode());
-    EXPECT_EQ(view_data[5]->on_click_field->u8String(), "f");
+    EXPECT_EQ(view_data[5]->text.u8StringView(), "f");
+    EXPECT_EQ(view_data[5]->on_click_member->u8StringView(),
+              self_name.decode());
+    EXPECT_EQ(view_data[5]->on_click_field->u8StringView(), "f");
 
-    EXPECT_EQ(view_data_base.data_ids[6].u8String(), "..2.1");
+    EXPECT_EQ(view_data_base.data_ids[6].u8StringView(), "..2.1");
     EXPECT_EQ(view_data[6]->type, static_cast<int>(ViewComponentType::button));
-    EXPECT_EQ(view_data[6]->text.u8String(), "a");
-    EXPECT_EQ(view_data[6]->on_click_member->u8String(), self_name.decode());
+    EXPECT_EQ(view_data[6]->text.u8StringView(), "a");
+    EXPECT_EQ(view_data[6]->on_click_member->u8StringView(),
+              self_name.decode());
     EXPECT_FALSE(view_data[6]->on_click_field->empty());
 
-    EXPECT_EQ(view_data_base.data_ids[7].u8String(), "hoge");
+    EXPECT_EQ(view_data_base.data_ids[7].u8StringView(), "hoge");
     EXPECT_EQ(view_data[7]->type, static_cast<int>(ViewComponentType::button));
-    EXPECT_EQ(view_data[7]->text.u8String(), "a2");
-    EXPECT_EQ(view_data[7]->on_click_member->u8String(), self_name.decode());
+    EXPECT_EQ(view_data[7]->text.u8StringView(), "a2");
+    EXPECT_EQ(view_data[7]->on_click_member->u8StringView(),
+              self_name.decode());
     EXPECT_FALSE(view_data[7]->on_click_field->empty());
 
     EXPECT_EQ(view_data[8]->type,
               static_cast<int>(ViewComponentType::decimal_input));
-    EXPECT_EQ(view_data[8]->text.u8String(), "i");
-    EXPECT_EQ(view_data[8]->on_click_member->u8String(), self_name.decode());
+    EXPECT_EQ(view_data[8]->text.u8StringView(), "i");
+    EXPECT_EQ(view_data[8]->on_click_member->u8StringView(),
+              self_name.decode());
     EXPECT_FALSE(view_data[8]->on_click_field->empty());
     // EXPECT_EQ(view_data[8].text_ref_->member_, self_name.decode());
     // EXPECT_FALSE(view_data[8].text_ref_->field_.empty());
@@ -177,8 +183,9 @@ TEST_F(ViewTest, viewSet) {
 
     EXPECT_EQ(view_data[9]->type,
               static_cast<int>(ViewComponentType::select_input));
-    EXPECT_EQ(view_data[9]->text.u8String(), "i2");
-    EXPECT_EQ(view_data[9]->on_click_member->u8String(), self_name.decode());
+    EXPECT_EQ(view_data[9]->text.u8StringView(), "i2");
+    EXPECT_EQ(view_data[9]->on_click_member->u8StringView(),
+              self_name.decode());
     EXPECT_FALSE(view_data[9]->on_click_field->empty());
     // EXPECT_EQ(view_data[9].text_ref_->member_, self_name.decode());
     // EXPECT_FALSE(view_data[9].text_ref_->field_.empty());
@@ -191,8 +198,9 @@ TEST_F(ViewTest, viewSet) {
 
     EXPECT_EQ(view_data[10]->type,
               static_cast<int>(ViewComponentType::text_input));
-    EXPECT_EQ(view_data[10]->text.u8String(), "i3");
-    EXPECT_EQ(view_data[10]->on_click_member->u8String(), self_name.decode());
+    EXPECT_EQ(view_data[10]->text.u8StringView(), "i3");
+    EXPECT_EQ(view_data[10]->on_click_member->u8StringView(),
+              self_name.decode());
     EXPECT_FALSE(view_data[10]->on_click_field->empty());
     // EXPECT_EQ(view_data[10].text_ref_->member_, self_name.decode());
     // EXPECT_FALSE(view_data[10].text_ref_->field_.empty());
@@ -203,7 +211,7 @@ TEST_F(ViewTest, viewSet) {
     //           "aaa");
 
     EXPECT_EQ(view_data[11]->type, static_cast<int>(ViewComponentType::text));
-    EXPECT_EQ(view_data[11]->text.u8String(), "ins");
+    EXPECT_EQ(view_data[11]->text.u8StringView(), "ins");
 
     v.init();
     v.sync();


### PR DESCRIPTION
* 生の文字列リテラルに対してはstringにコピーすることなくポインタのままで管理できるようにする
  * <del>todo: 生文字列リテラルの場合はSharedStringDataのshared_ptrに入れる必要もないのではないか?</del>
    * 生文字列リテラルが使われるのは送信データのみで、encodeはStringを作成した時点で行われるのであとからencodeすることは考えなくて良くて、
    * 逆にdecodeするのは受信データのみで受信データは生文字列リテラルではない
    * あとからdecode()が何度も呼ばれる可能性に備えてshared_ptrは作るしかなく、そうするとStringViewを外に出す意味がない
  * ありうるパターン
    * fromU8String() -> string, (string later), (wstring later)
    * fromU8StringStatic() -> [sview], (string later), (wstring later)
    * encode(s) on windows -> string, string, (wstring later)
    * encodeStatic(s) on windows -> string, [sview], (wstring later)
    * encode(ws) -> string, (string later), wstring
    * encodeStatic(ws) -> string, (string later), [wsview]
  * <del>その場合、string3つを1つのshared_ptrに入れる今の実装よりもvariant\<shared_ptr\>3つのほうが良さそう? →stringをやめることもできそう?</del>
* DataStore2でTextデータとしてValAdapterをshared_ptrでラップするのをやめる
* StringInitializerクラスを追加、すべての文字列入力APIをStringInitializerに置き換え
* StringViewクラスを追加、すべての文字列出力APIをStringViewに置き換え
  * これNumVectorと同様にデータのshared_ptrを持つようにしたので、寿命の心配がない
* ValAdaptor::getStringRef(), Variant::getStringRef(), InputRef::getStringRef() で　const参照を返せないのでdeprecatedに (stringのコピーを返す仕様にして残す)
* ValAdaptorからstring_viewへの暗黙変換を可能に、ValAdaptorからstringへの変換はexplicitに
  * ただしFuncの引数をstd::stringで受け取る場合に限り例外的に変換を許可
* Variant::get() InputRef::get(), をValAdaptorの参照からコピーに変更
* `using ValAdapter = ValAdaptor;` を追加
* TODO: なぜか今までの実装より遅い... たぶん解決
* Funcのtraitチェックのエラーメッセージを改善し、問題の引数がどれかわかるようにした